### PR TITLE
docs: add editorial north star template

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -19,16 +19,13 @@ jobs:
     name: Request Copilot review
     runs-on: ubuntu-latest
     steps:
-      - name: Install current GitHub CLI
+      - name: Verify GitHub CLI is available
         run: |
           set -euo pipefail
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
-            sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
-            sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
+          if ! command -v gh > /dev/null 2>&1; then
+            echo "::error::GitHub CLI (gh) is not available on this runner."
+            exit 1
+          fi
           gh --version
 
       - name: Request Copilot as reviewer

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -19,6 +19,18 @@ jobs:
     name: Request Copilot review
     runs-on: ubuntu-latest
     steps:
+      - name: Install current GitHub CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+            sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+            sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
+          gh --version
+
       - name: Request Copilot as reviewer
         env:
           GH_TOKEN: ${{ github.token }}

--- a/NORTH_STAR.md
+++ b/NORTH_STAR.md
@@ -1,0 +1,119 @@
+# NORTH_STAR.md
+
+Podcast Forge exists to help create news and analysis podcasts that earn trust before they seek attention.
+
+This file is a template for a show's editorial north star. Each show should adapt it, but the default standard is simple:
+
+**Integrity is the paramount value.**
+
+## Core Editorial Values
+
+### 1. Unbiased by Design
+
+Unbiased does not mean having no perspective, no taste, or no judgment. It means the work is deliberately structured to avoid hidden agendas, lazy framing, and one-sided storytelling.
+
+An unbiased episode should:
+
+- Separate verified facts from interpretation.
+- Represent materially different credible viewpoints fairly.
+- Avoid partisan, tribal, brand-loyal, or hype-driven framing.
+- Disclose uncertainty instead of smoothing it over.
+- Avoid cherry-picking facts to support a preferred conclusion.
+- Make room for complexity when the facts are complex.
+- Correct prior claims when better evidence emerges.
+
+A show may have a point of view, but the audience should be able to tell where the evidence ends and where analysis begins.
+
+### 2. Thoroughly Researched
+
+Thorough research means an episode is built from enough independent evidence to support its claims, not just enough links to look credible.
+
+A thoroughly researched episode should:
+
+- Use multiple independent sources for major claims.
+- Prefer primary sources when available: filings, papers, official statements, transcripts, datasets, product docs, legal documents, direct interviews, or original reporting.
+- Treat secondary reporting as useful context, not final proof.
+- Track source provenance and publication dates.
+- Identify conflicts of interest, incentives, and missing information.
+- Distinguish confirmed facts from rumors, leaks, speculation, and opinion.
+- Include dissenting evidence or credible counterarguments when they exist.
+- Refuse to publish a strong claim if the evidence is too thin.
+
+Research is complete enough only when the story can survive a skeptical reader asking, “How do you know?”
+
+### 3. Unbiased News, Repeated Because It Matters
+
+For news programming, unbiasedness is not a cosmetic tone choice. It is a production constraint.
+
+Unbiased news should:
+
+- Not launder press releases into journalism.
+- Not confuse popularity with importance.
+- Not exaggerate certainty for drama.
+- Not hide inconvenient facts because they weaken the narrative.
+- Not use loaded language where plain language would be more accurate.
+- Not treat “both sides” as automatically equal when the evidence is not equal.
+- Not treat institutional authority as automatically correct when the evidence is weak.
+
+The goal is not neutrality theater. The goal is truth-seeking with visible discipline.
+
+## Integrity Rules
+
+1. Never knowingly publish a false claim.
+2. Never bury uncertainty that materially changes the meaning of a story.
+3. Never present speculation as fact.
+4. Never use AI-generated claims without verification.
+5. Never let speed, novelty, ideology, sponsor pressure, or entertainment value outrank accuracy.
+6. Never quote or summarize a source in a way that reverses or distorts its meaning.
+7. Never ignore a credible correction.
+
+## Minimum Research Gate
+
+Before an episode is approved for production, it should have:
+
+- At least two independent credible sources for each central factual claim.
+- Primary-source support for any high-stakes claim when primary sources are available.
+- A written list of unresolved uncertainties.
+- A clear distinction between facts, analysis, and opinion.
+- A final editorial check asking: “Would we be comfortable defending this publicly?”
+
+If the answer is no, the episode is not ready.
+
+## Tone Standard
+
+The tone should be clear, calm, curious, and rigorous.
+
+Avoid:
+
+- Hype
+- Rage bait
+- Partisan shorthand
+- Cheap dunking
+- Overconfident predictions
+- Pretending certainty where none exists
+
+Prefer:
+
+- Specificity
+- Humility
+- Evidence
+- Context
+- Proportionality
+- Intellectual honesty
+
+## Working Template for Show-Specific North Stars
+
+Each show can extend this file with:
+
+- Audience promise
+- Coverage boundaries
+- Source quality rules
+- Voice and tone notes
+- Red-line topics or claims requiring extra review
+- Correction policy
+- Sponsor/ad disclosure policy
+- Human approval requirements
+
+But every show inherits the default rule:
+
+**Integrity first. Everything else second.**

--- a/NORTH_STAR.md
+++ b/NORTH_STAR.md
@@ -1,4 +1,4 @@
-# NORTH_STAR.md
+# North Star
 
 Podcast Forge exists to help create news and analysis podcasts that earn trust before they seek attention.
 


### PR DESCRIPTION
Adds `NORTH_STAR.md`, an editorial integrity template defining unbiased, thoroughly researched news, with integrity as the paramount value.

This PR also validates the review workflow on a real PR.

## Acceptance criteria

- Add a durable editorial north-star template that future shows can adapt.
- Keep the template generic; do not hardcode TSL-only operational behavior.
- Preserve the Copilot review-request workflow without adding slow/unsafe runtime package installation.
- Address Copilot review comments before merge.
- `npm run check` passes.

## Review/verification

- Copilot reviewed the PR and comments were addressed in `2dfd4d4`.
- Local check passed after merging latest `origin/main` into the branch.
- Local automated review fallback will be rerun before merge.