### PR TITLE
feat: add llm runtime adapters and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ curl -X PATCH http://localhost:3450/model-profiles/:id \
   -d '{"provider":"openai","model":"gpt-5.5","params":{"reasoningEffort":"high"}}'
 ```
 
+## LLM runtime
+
+The API package exposes an internal `packages/api/src/llm` runtime for
+role-based text and JSON model calls. Callers pass a resolved `model_profiles`
+record, prompt messages, and optional JSON validation; the runtime selects the
+configured provider/model, tries configured fallbacks, and returns normalized
+text/JSON plus invocation metadata suitable for `jobs.output.llmInvocations`
+and `jobs.logs`.
+
+Available adapters:
+
+- `fake` is deterministic and intended for tests and local development.
+- `openai` / `openai-compatible` use a Chat Completions-compatible HTTP path
+  when `OPENAI_API_KEY` is set. `OPENAI_BASE_URL` can point at another
+  compatible endpoint. Tests inject fakes and do not make live provider calls.
+
+Fallback strings may be plain model names, which reuse the profile provider, or
+`provider/model` strings, which switch provider and model for that attempt.
+
 ## Brave source search
 
 Brave source profiles can be searched from the API using the enabled

--- a/packages/api/src/llm/index.ts
+++ b/packages/api/src/llm/index.ts
@@ -1,0 +1,5 @@
+export * from './types.js';
+export * from './json.js';
+export * from './providers.js';
+export * from './runtime.js';
+export * from './job-metadata.js';

--- a/packages/api/src/llm/job-metadata.ts
+++ b/packages/api/src/llm/job-metadata.ts
@@ -1,0 +1,34 @@
+import type { LlmInvocationMetadata } from './types.js';
+
+export function llmInvocationJobLog(metadata: LlmInvocationMetadata): Record<string, unknown> {
+  return {
+    at: metadata.finishedAt,
+    level: metadata.selected ? 'info' : 'error',
+    message: metadata.selected ? 'LLM invocation completed.' : 'LLM invocation failed.',
+    llm: {
+      profileId: metadata.profile.id,
+      role: metadata.profile.role,
+      selected: metadata.selected,
+      latencyMs: metadata.latencyMs,
+      usage: metadata.usage,
+      cost: metadata.cost,
+      attemptCount: metadata.attempts.length,
+      warnings: metadata.warnings,
+    },
+  };
+}
+
+export function appendLlmInvocationToJobOutput(
+  output: Record<string, unknown>,
+  metadata: LlmInvocationMetadata,
+): Record<string, unknown> {
+  const current = Array.isArray(output.llmInvocations) ? output.llmInvocations : [];
+
+  return {
+    ...output,
+    llmInvocations: [
+      ...current,
+      metadata,
+    ],
+  };
+}

--- a/packages/api/src/llm/json.ts
+++ b/packages/api/src/llm/json.ts
@@ -1,0 +1,79 @@
+import type { LlmJsonValidator } from './types.js';
+
+export type LlmJsonParseErrorCode = 'malformed_json' | 'validation_failed';
+
+export interface LlmJsonParseFailure {
+  code: LlmJsonParseErrorCode;
+  message: string;
+  outputPreview: string;
+  details?: unknown;
+}
+
+export type LlmJsonParseResult<T> =
+  | {
+    ok: true;
+    value: T;
+    normalizedText: string;
+  }
+  | {
+    ok: false;
+    error: LlmJsonParseFailure;
+  };
+
+export function previewText(value: unknown, maxLength = 600): string {
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength)}...`;
+}
+
+export function stripJsonMarkdownFence(value: string): string {
+  const trimmed = value.trim();
+  const fence = trimmed.match(/^```(?:json|JSON)?\s*([\s\S]*?)\s*```$/);
+  return (fence?.[1] ?? trimmed).trim();
+}
+
+export function parseJsonOutput<T = unknown>(
+  text: string,
+  validate?: LlmJsonValidator<T>,
+): LlmJsonParseResult<T> {
+  const normalizedText = stripJsonMarkdownFence(text);
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(normalizedText);
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: 'malformed_json',
+        message: error instanceof Error ? error.message : 'Model output was not valid JSON.',
+        outputPreview: previewText(text),
+      },
+    };
+  }
+
+  if (!validate) {
+    return {
+      ok: true,
+      value: parsed as T,
+      normalizedText,
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      value: validate(parsed),
+      normalizedText,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: 'validation_failed',
+        message: error instanceof Error ? error.message : 'Model JSON output failed validation.',
+        outputPreview: previewText(text),
+        details: error,
+      },
+    };
+  }
+}

--- a/packages/api/src/llm/providers.ts
+++ b/packages/api/src/llm/providers.ts
@@ -1,0 +1,194 @@
+import { createHash } from 'node:crypto';
+
+import { previewText } from './json.js';
+import type {
+  LlmProviderAdapter,
+  LlmProviderRequest,
+  LlmProviderResult,
+  LlmUsage,
+} from './types.js';
+import { LlmProviderError } from './types.js';
+
+type FakeHandler = (request: LlmProviderRequest) => Promise<LlmProviderResult> | LlmProviderResult;
+
+export interface FakeLlmProviderOptions {
+  provider?: string;
+  handler?: FakeHandler;
+  failures?: Record<string, { message?: string; retryable?: boolean; code?: string }>;
+}
+
+function countTokens(value: string): number {
+  return value.split(/\s+/).filter(Boolean).length;
+}
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function usageFor(request: LlmProviderRequest, text: string): LlmUsage {
+  return {
+    inputTokens: request.messages.reduce((sum, message) => sum + countTokens(message.content), 0),
+    outputTokens: countTokens(text),
+    totalTokens: request.messages.reduce((sum, message) => sum + countTokens(message.content), 0) + countTokens(text),
+  };
+}
+
+export function createFakeLlmProvider(options: FakeLlmProviderOptions = {}): LlmProviderAdapter {
+  const provider = options.provider ?? 'fake';
+
+  return {
+    provider,
+    async generateText(request) {
+      const failure = options.failures?.[request.attempt.model] ?? options.failures?.[`${request.attempt.provider}/${request.attempt.model}`];
+
+      if (failure) {
+        throw new LlmProviderError(
+          failure.code ?? 'fake_failure',
+          failure.message ?? `Fake provider failed for ${request.attempt.model}.`,
+          failure.retryable ?? true,
+        );
+      }
+
+      if (options.handler) {
+        return options.handler(request);
+      }
+
+      const lastUserMessage = [...request.messages].reverse().find((message) => message.role === 'user')?.content ?? '';
+      const seed = `${request.attempt.role}:${request.attempt.provider}:${request.attempt.model}:${lastUserMessage}`;
+      const text = request.responseFormat.type === 'json'
+        ? JSON.stringify({
+          provider: request.attempt.provider,
+          model: request.attempt.model,
+          role: request.attempt.role,
+          digest: hash(seed),
+        })
+        : `Fake LLM response for ${request.attempt.role} using ${request.attempt.provider}/${request.attempt.model}: ${previewText(lastUserMessage, 120)}`;
+
+      return {
+        text,
+        usage: usageFor(request, text),
+        cost: { usd: 0, currency: 'USD' },
+        rawOutput: text,
+        metadata: {
+          adapter: 'fake',
+          deterministic: true,
+          digest: hash(seed),
+        },
+      };
+    },
+  };
+}
+
+export interface OpenAiCompatibleProviderOptions {
+  provider?: string;
+  apiKey?: string;
+  apiKeyEnv?: string;
+  baseUrl?: string;
+  baseUrlEnv?: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface OpenAiCompatibleUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+interface OpenAiCompatibleResponse {
+  id?: string;
+  choices?: Array<{
+    message?: {
+      content?: string | Array<{ type?: string; text?: string }>;
+    };
+  }>;
+  usage?: OpenAiCompatibleUsage;
+}
+
+function envValue(name: string | undefined): string | undefined {
+  return name ? process.env[name] : undefined;
+}
+
+function messageContent(content: string | Array<{ type?: string; text?: string }> | undefined): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content.map((item) => item.text).filter((text): text is string => Boolean(text)).join('\n');
+  }
+
+  return '';
+}
+
+export function createOpenAiCompatibleProvider(options: OpenAiCompatibleProviderOptions = {}): LlmProviderAdapter {
+  const provider = options.provider ?? 'openai';
+
+  return {
+    provider,
+    async generateText(request) {
+      const apiKey = options.apiKey ?? envValue(options.apiKeyEnv ?? 'OPENAI_API_KEY');
+
+      if (!apiKey) {
+        throw new LlmProviderError('not_configured', `${provider} provider is missing an API key.`, true);
+      }
+
+      const baseUrl = (options.baseUrl ?? envValue(options.baseUrlEnv ?? 'OPENAI_BASE_URL') ?? 'https://api.openai.com/v1').replace(/\/$/, '');
+      const fetchImpl = options.fetchImpl ?? fetch;
+      const response = await fetchImpl(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: request.attempt.model,
+          messages: request.messages,
+          temperature: request.attempt.params.temperature,
+          max_tokens: request.attempt.params.maxTokens,
+          response_format: request.responseFormat.type === 'json' ? { type: 'json_object' } : undefined,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new LlmProviderError(
+          'provider_http_error',
+          `${provider} provider returned HTTP ${response.status}.`,
+          response.status === 429 || response.status >= 500,
+          { status: response.status },
+        );
+      }
+
+      const data = await response.json() as OpenAiCompatibleResponse;
+      const text = messageContent(data.choices?.[0]?.message?.content);
+
+      if (!text) {
+        throw new LlmProviderError('empty_response', `${provider} provider returned no text.`, true);
+      }
+
+      return {
+        text,
+        usage: {
+          inputTokens: data.usage?.prompt_tokens ?? null,
+          outputTokens: data.usage?.completion_tokens ?? null,
+          totalTokens: data.usage?.total_tokens ?? null,
+        },
+        cost: { usd: null, currency: 'USD' },
+        rawOutput: data,
+        metadata: {
+          adapter: 'openai-compatible',
+          responseId: data.id,
+        },
+      };
+    },
+  };
+}
+
+export function createDefaultLlmProviders(): LlmProviderAdapter[] {
+  const openAiProvider = createOpenAiCompatibleProvider({ provider: 'openai' });
+
+  return [
+    createFakeLlmProvider(),
+    openAiProvider,
+    createOpenAiCompatibleProvider({ provider: 'openai-compatible' }),
+  ];
+}

--- a/packages/api/src/llm/runtime.test.ts
+++ b/packages/api/src/llm/runtime.test.ts
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { ResolvedModelProfile } from '../models/resolver.js';
+import { parseJsonOutput } from './json.js';
+import { appendLlmInvocationToJobOutput, llmInvocationJobLog } from './job-metadata.js';
+import { createFakeLlmProvider } from './providers.js';
+import { createLlmRuntime } from './runtime.js';
+import { LlmJsonOutputError, LlmRuntimeError } from './types.js';
+
+function profile(input: Partial<ResolvedModelProfile> = {}): ResolvedModelProfile {
+  return {
+    id: input.id ?? 'model-profile-1',
+    showId: input.showId ?? 'show-1',
+    role: input.role ?? 'script_writer',
+    provider: input.provider ?? 'fake',
+    model: input.model ?? 'fake-model',
+    params: input.params ?? { temperature: 0.2, maxTokens: 1000 },
+    fallbacks: input.fallbacks ?? [],
+    budgetUsd: input.budgetUsd ?? 1,
+    promptTemplateKey: input.promptTemplateKey ?? 'script.default',
+    version: input.version ?? '2026-04-26T00:00:00.000Z',
+  };
+}
+
+describe('LLM runtime', () => {
+  it('generates deterministic fake text with reusable invocation metadata', async () => {
+    const runtime = createLlmRuntime({
+      adapters: [createFakeLlmProvider()],
+      now: () => new Date('2026-04-26T12:00:00.000Z'),
+    });
+
+    const result = await runtime.generateText({
+      profile: profile(),
+      messages: [{ role: 'user', content: 'Write one sourced paragraph.' }],
+      requestMetadata: { jobId: 'job-1', storyCandidateId: 'candidate-1' },
+    });
+
+    assert.match(result.text, /Fake LLM response/);
+    assert.equal(result.metadata.profile.id, 'model-profile-1');
+    assert.deepEqual(result.metadata.selected, {
+      provider: 'fake',
+      model: 'fake-model',
+      fallbackIndex: null,
+    });
+    assert.equal(result.metadata.attempts.length, 1);
+    assert.equal(result.metadata.attempts[0].status, 'succeeded');
+    assert.equal(result.metadata.cost.usd, 0);
+    assert.equal(result.metadata.requestMetadata.jobId, 'job-1');
+
+    const log = llmInvocationJobLog(result.metadata);
+    assert.equal(log.level, 'info');
+    const output = appendLlmInvocationToJobOutput({ scriptId: 'script-1' }, result.metadata);
+    assert.equal((output.llmInvocations as unknown[]).length, 1);
+  });
+
+  it('tries configured fallbacks and records failed provider attempts', async () => {
+    const runtime = createLlmRuntime({
+      adapters: [
+        createFakeLlmProvider({
+          provider: 'primary',
+          failures: {
+            'primary-model': { message: 'Primary unavailable.', retryable: true },
+          },
+        }),
+        createFakeLlmProvider({ provider: 'fake' }),
+      ],
+      now: () => new Date('2026-04-26T12:00:00.000Z'),
+    });
+
+    const result = await runtime.generateText({
+      profile: profile({
+        provider: 'primary',
+        model: 'primary-model',
+        fallbacks: ['fake/fallback-model'],
+      }),
+      messages: [{ role: 'user', content: 'Fallback please.' }],
+    });
+
+    assert.equal(result.metadata.attempts.length, 2);
+    assert.equal(result.metadata.attempts[0].status, 'failed');
+    assert.equal(result.metadata.attempts[0].error?.message, 'Primary unavailable.');
+    assert.equal(result.metadata.attempts[1].status, 'succeeded');
+    assert.deepEqual(result.metadata.selected, {
+      provider: 'fake',
+      model: 'fallback-model',
+      fallbackIndex: 0,
+    });
+  });
+
+  it('surfaces final errors with attempted provider metadata', async () => {
+    const runtime = createLlmRuntime({
+      adapters: [
+        createFakeLlmProvider({
+          failures: {
+            'fake-model': { message: 'No capacity.', retryable: true },
+            'fallback-model': { message: 'Fallback unavailable.', retryable: true },
+          },
+        }),
+      ],
+      now: () => new Date('2026-04-26T12:00:00.000Z'),
+    });
+
+    await assert.rejects(
+      runtime.generateText({
+        profile: profile({ fallbacks: ['fallback-model'] }),
+        messages: [{ role: 'user', content: 'Fail clearly.' }],
+      }),
+      (error) => {
+        assert.ok(error instanceof LlmRuntimeError);
+        assert.equal(error.metadata.selected, null);
+        assert.equal(error.metadata.attempts.length, 2);
+        assert.equal(error.metadata.attempts[0].error?.message, 'No capacity.');
+        assert.equal(error.metadata.attempts[1].error?.message, 'Fallback unavailable.');
+        return true;
+      },
+    );
+  });
+
+  it('generates and validates JSON output', async () => {
+    const runtime = createLlmRuntime({
+      adapters: [
+        createFakeLlmProvider({
+          handler: () => ({
+            text: '```json\n{"score":0.82,"reason":"clear fit"}\n```',
+            rawOutput: { text: 'fenced' },
+          }),
+        }),
+      ],
+      now: () => new Date('2026-04-26T12:00:00.000Z'),
+    });
+
+    const result = await runtime.generateJson<{ score: number; reason: string }>({
+      profile: profile({ role: 'candidate_scorer' }),
+      messages: [{ role: 'user', content: 'Score this candidate.' }],
+      schemaName: 'candidate_score',
+      validate(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          throw new Error('Expected object.');
+        }
+
+        const candidate = value as { score?: unknown; reason?: unknown };
+        if (typeof candidate.score !== 'number' || typeof candidate.reason !== 'string') {
+          throw new Error('Expected score and reason.');
+        }
+
+        return { score: candidate.score, reason: candidate.reason };
+      },
+    });
+
+    assert.equal(result.value.score, 0.82);
+    assert.equal(result.metadata.responseFormat.type, 'json');
+    assert.match(result.metadata.validatedOutputPreview ?? '', /clear fit/);
+  });
+
+  it('returns structured helper errors for malformed JSON and validation failures', () => {
+    const malformed = parseJsonOutput('{not-json');
+    assert.equal(malformed.ok, false);
+    if (!malformed.ok) {
+      assert.equal(malformed.error.code, 'malformed_json');
+      assert.match(malformed.error.outputPreview, /\{not-json/);
+    }
+
+    const invalid = parseJsonOutput('{"score":"high"}', () => {
+      throw new Error('score must be numeric');
+    });
+    assert.equal(invalid.ok, false);
+    if (!invalid.ok) {
+      assert.equal(invalid.error.code, 'validation_failed');
+      assert.equal(invalid.error.message, 'score must be numeric');
+    }
+  });
+
+  it('throws JSON output errors with invocation metadata', async () => {
+    const runtime = createLlmRuntime({
+      adapters: [
+        createFakeLlmProvider({
+          handler: () => ({ text: 'not json' }),
+        }),
+      ],
+      now: () => new Date('2026-04-26T12:00:00.000Z'),
+    });
+
+    await assert.rejects(
+      runtime.generateJson({
+        profile: profile({ role: 'claim_extractor' }),
+        messages: [{ role: 'user', content: 'Extract claims.' }],
+      }),
+      (error) => {
+        assert.ok(error instanceof LlmJsonOutputError);
+        assert.equal(error.code, 'malformed_json');
+        assert.equal(error.metadata.selected?.provider, 'fake');
+        assert.equal(error.metadata.warnings[0].code, 'malformed_json');
+        return true;
+      },
+    );
+  });
+});

--- a/packages/api/src/llm/runtime.ts
+++ b/packages/api/src/llm/runtime.ts
@@ -1,0 +1,368 @@
+import { parseJsonOutput, previewText } from './json.js';
+import { createDefaultLlmProviders } from './providers.js';
+import type {
+  LlmAttemptMetadata,
+  LlmCost,
+  LlmInvocationMetadata,
+  LlmJsonRequest,
+  LlmJsonResult,
+  LlmModelAttempt,
+  LlmProviderAdapter,
+  LlmProviderResult,
+  LlmResponseFormat,
+  LlmRuntime,
+  LlmTextRequest,
+  LlmTextResult,
+  LlmUsage,
+  LlmWarning,
+} from './types.js';
+import { LlmJsonOutputError, LlmProviderError, LlmRuntimeError } from './types.js';
+
+export interface LlmRuntimeOptions {
+  adapters?: LlmProviderAdapter[];
+  now?: () => Date;
+}
+
+const emptyUsage: LlmUsage = {
+  inputTokens: null,
+  outputTokens: null,
+  totalTokens: null,
+};
+
+const emptyCost: LlmCost = {
+  usd: null,
+  currency: 'USD',
+};
+
+function mergeUsage(current: LlmUsage, next: LlmUsage): LlmUsage {
+  return {
+    inputTokens: sumNullable(current.inputTokens, next.inputTokens),
+    outputTokens: sumNullable(current.outputTokens, next.outputTokens),
+    totalTokens: sumNullable(current.totalTokens, next.totalTokens),
+  };
+}
+
+function mergeCost(current: LlmCost, next: LlmCost): LlmCost {
+  return {
+    usd: sumNullable(current.usd, next.usd),
+    currency: 'USD',
+  };
+}
+
+function sumNullable(current: number | null, next: number | null): number | null {
+  if (current === null) {
+    return next;
+  }
+
+  if (next === null) {
+    return current;
+  }
+
+  return current + next;
+}
+
+function normalizeUsage(value: LlmProviderResult['usage']): LlmUsage {
+  return {
+    inputTokens: value?.inputTokens ?? null,
+    outputTokens: value?.outputTokens ?? null,
+    totalTokens: value?.totalTokens ?? null,
+  };
+}
+
+function normalizeCost(value: LlmProviderResult['cost']): LlmCost {
+  return {
+    usd: value?.usd ?? null,
+    currency: 'USD',
+  };
+}
+
+function errorDetails(error: unknown): { code: string; message: string; retryable: boolean } {
+  if (error instanceof LlmProviderError) {
+    return {
+      code: error.code,
+      message: error.message,
+      retryable: error.retryable,
+    };
+  }
+
+  return {
+    code: 'provider_error',
+    message: error instanceof Error ? error.message : 'LLM provider failed.',
+    retryable: true,
+  };
+}
+
+function fallbackAttempt(primary: LlmModelAttempt, fallback: string, fallbackIndex: number): LlmModelAttempt {
+  const providerModel = fallback.match(/^([^/:]+)[/:](.+)$/);
+  const provider = providerModel?.[1] ?? primary.provider;
+  const model = providerModel?.[2] ?? fallback;
+
+  return {
+    ...primary,
+    provider,
+    model,
+    fallbackOf: `${primary.provider}/${primary.model}`,
+    fallbackIndex,
+  };
+}
+
+function attemptsFor(request: LlmTextRequest): LlmModelAttempt[] {
+  const primary: LlmModelAttempt = {
+    profileId: request.profile.id,
+    role: request.profile.role,
+    provider: request.profile.provider,
+    model: request.profile.model,
+    params: request.profile.params,
+    promptTemplateKey: request.profile.promptTemplateKey,
+    budgetUsd: request.profile.budgetUsd,
+  };
+
+  return [
+    primary,
+    ...request.profile.fallbacks.map((fallback, index) => fallbackAttempt(primary, fallback, index)),
+  ];
+}
+
+function providerMetadata(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function nowIso(now: () => Date): string {
+  return now().toISOString();
+}
+
+function millisSince(start: number, now: () => Date): number {
+  return Math.max(0, now().getTime() - start);
+}
+
+function baseMetadata(
+  request: LlmTextRequest,
+  responseFormat: LlmResponseFormat,
+  startedAt: string,
+  finishedAt: string,
+  latencyMs: number,
+  attempts: LlmAttemptMetadata[],
+  requestMetadata: Record<string, unknown>,
+  selected: LlmInvocationMetadata['selected'],
+  rawOutputPreview?: string,
+): LlmInvocationMetadata {
+  const usage = attempts.reduce((current, attempt) => mergeUsage(current, attempt.usage), emptyUsage);
+  const cost = attempts.reduce((current, attempt) => mergeCost(current, attempt.cost), emptyCost);
+  const warnings = attempts.flatMap((attempt) => attempt.warnings);
+
+  return {
+    profile: {
+      id: request.profile.id,
+      role: request.profile.role,
+      provider: request.profile.provider,
+      model: request.profile.model,
+      version: request.profile.version,
+      promptTemplateKey: request.profile.promptTemplateKey,
+      budgetUsd: request.profile.budgetUsd,
+      fallbackCount: request.profile.fallbacks.length,
+    },
+    selected,
+    responseFormat,
+    startedAt,
+    finishedAt,
+    latencyMs,
+    attempts,
+    warnings,
+    usage,
+    cost,
+    requestMetadata,
+    rawOutputPreview,
+  };
+}
+
+function shouldTryFallback(error: unknown, hasFallback: boolean): boolean {
+  if (!hasFallback) {
+    return false;
+  }
+
+  if (error instanceof LlmProviderError) {
+    return error.retryable || error.code === 'not_configured' || error.code === 'provider_not_registered';
+  }
+
+  return true;
+}
+
+export function createLlmRuntime(options: LlmRuntimeOptions = {}): LlmRuntime {
+  const adapters = new Map((options.adapters ?? createDefaultLlmProviders()).map((adapter) => [adapter.provider, adapter]));
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async generateText(request) {
+      const responseFormat = request.responseFormat ?? { type: 'text' };
+      const requestMetadata = request.requestMetadata ?? {};
+      const invocationStartedAt = nowIso(now);
+      const invocationStartMs = now().getTime();
+      const attemptMetadata: LlmAttemptMetadata[] = [];
+      const attempts = attemptsFor(request);
+
+      for (const [index, attempt] of attempts.entries()) {
+        const adapter = adapters.get(attempt.provider);
+        const attemptStartedAt = nowIso(now);
+        const attemptStartMs = now().getTime();
+
+        if (!adapter) {
+          const error = new LlmProviderError('provider_not_registered', `No LLM provider adapter is registered for ${attempt.provider}.`, true);
+          const attemptFinishedAt = nowIso(now);
+          attemptMetadata.push({
+            profileId: attempt.profileId,
+            role: attempt.role,
+            provider: attempt.provider,
+            model: attempt.model,
+            status: 'skipped',
+            startedAt: attemptStartedAt,
+            finishedAt: attemptFinishedAt,
+            latencyMs: millisSince(attemptStartMs, now),
+            fallbackOf: attempt.fallbackOf,
+            fallbackIndex: attempt.fallbackIndex,
+            usage: emptyUsage,
+            cost: emptyCost,
+            error: errorDetails(error),
+            warnings: [],
+            providerMetadata: {},
+          });
+
+          if (shouldTryFallback(error, index < attempts.length - 1)) {
+            continue;
+          }
+
+          break;
+        }
+
+        try {
+          const result = await adapter.generateText({
+            attempt,
+            messages: request.messages,
+            responseFormat,
+            requestMetadata,
+          });
+          const attemptFinishedAt = nowIso(now);
+          const rawOutputPreview = previewText(result.rawOutput ?? result.text);
+          const usage = normalizeUsage(result.usage);
+          const cost = normalizeCost(result.cost);
+          const warnings: LlmWarning[] = result.warnings ?? [];
+
+          attemptMetadata.push({
+            profileId: attempt.profileId,
+            role: attempt.role,
+            provider: attempt.provider,
+            model: attempt.model,
+            status: 'succeeded',
+            startedAt: attemptStartedAt,
+            finishedAt: attemptFinishedAt,
+            latencyMs: millisSince(attemptStartMs, now),
+            fallbackOf: attempt.fallbackOf,
+            fallbackIndex: attempt.fallbackIndex,
+            usage,
+            cost,
+            warnings,
+            rawOutputPreview,
+            providerMetadata: providerMetadata(result.metadata),
+          });
+
+          return {
+            text: result.text,
+            metadata: baseMetadata(
+              request,
+              responseFormat,
+              invocationStartedAt,
+              nowIso(now),
+              millisSince(invocationStartMs, now),
+              attemptMetadata,
+              requestMetadata,
+              {
+                provider: attempt.provider,
+                model: attempt.model,
+                fallbackIndex: attempt.fallbackIndex ?? null,
+              },
+              rawOutputPreview,
+            ),
+          };
+        } catch (error) {
+          const details = errorDetails(error);
+          const attemptFinishedAt = nowIso(now);
+          attemptMetadata.push({
+            profileId: attempt.profileId,
+            role: attempt.role,
+            provider: attempt.provider,
+            model: attempt.model,
+            status: 'failed',
+            startedAt: attemptStartedAt,
+            finishedAt: attemptFinishedAt,
+            latencyMs: millisSince(attemptStartMs, now),
+            fallbackOf: attempt.fallbackOf,
+            fallbackIndex: attempt.fallbackIndex,
+            usage: emptyUsage,
+            cost: emptyCost,
+            error: details,
+            warnings: [],
+            providerMetadata: error instanceof LlmProviderError ? error.metadata : {},
+          });
+
+          if (shouldTryFallback(error, index < attempts.length - 1)) {
+            continue;
+          }
+
+          break;
+        }
+      }
+
+      const metadata = baseMetadata(
+        request,
+        responseFormat,
+        invocationStartedAt,
+        nowIso(now),
+        millisSince(invocationStartMs, now),
+        attemptMetadata,
+        requestMetadata,
+        null,
+      );
+      const tried = attemptMetadata.map((attempt) => `${attempt.provider}/${attempt.model}:${attempt.status}`).join(', ');
+      throw new LlmRuntimeError(`LLM invocation failed. Attempts: ${tried}`, metadata);
+    },
+
+    async generateJson<T>(request: LlmJsonRequest<T>): Promise<LlmJsonResult<T>> {
+      const textResult = await this.generateText({
+        ...request,
+        responseFormat: {
+          type: 'json',
+          schemaName: request.schemaName,
+          schemaHint: request.schemaHint,
+        },
+      });
+      const parsed = parseJsonOutput<T>(textResult.text, request.validate);
+
+      if (!parsed.ok) {
+        const metadata: LlmInvocationMetadata = {
+          ...textResult.metadata,
+          warnings: [
+            ...textResult.metadata.warnings,
+            {
+              code: parsed.error.code,
+              message: parsed.error.message,
+              metadata: {
+                outputPreview: parsed.error.outputPreview,
+              },
+            },
+          ],
+          rawOutputPreview: parsed.error.outputPreview,
+        };
+
+        throw new LlmJsonOutputError(parsed.error.code, parsed.error.message, metadata, parsed.error.details);
+      }
+
+      return {
+        ...textResult,
+        value: parsed.value,
+        metadata: {
+          ...textResult.metadata,
+          validatedOutputPreview: previewText(parsed.value),
+        },
+      };
+    },
+  };
+}

--- a/packages/api/src/llm/types.ts
+++ b/packages/api/src/llm/types.ts
@@ -1,0 +1,180 @@
+import type { ModelRole } from '../models/roles.js';
+import type { ResolvedModelProfile } from '../models/resolver.js';
+
+export type LlmMessageRole = 'system' | 'user' | 'assistant';
+
+export interface LlmMessage {
+  role: LlmMessageRole;
+  content: string;
+}
+
+export interface LlmUsage {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  totalTokens: number | null;
+}
+
+export interface LlmCost {
+  usd: number | null;
+  currency: 'USD';
+}
+
+export interface LlmResponseFormat {
+  type: 'text' | 'json';
+  schemaName?: string;
+  schemaHint?: Record<string, unknown>;
+}
+
+export interface LlmModelAttempt {
+  profileId: string;
+  role: ModelRole;
+  provider: string;
+  model: string;
+  params: Record<string, unknown>;
+  promptTemplateKey: string | null;
+  budgetUsd: number | null;
+  fallbackOf?: string;
+  fallbackIndex?: number;
+}
+
+export interface LlmProviderRequest {
+  attempt: LlmModelAttempt;
+  messages: LlmMessage[];
+  responseFormat: LlmResponseFormat;
+  requestMetadata: Record<string, unknown>;
+}
+
+export interface LlmProviderResult {
+  text: string;
+  usage?: Partial<LlmUsage>;
+  cost?: Partial<LlmCost>;
+  rawOutput?: unknown;
+  metadata?: Record<string, unknown>;
+  warnings?: LlmWarning[];
+}
+
+export interface LlmProviderAdapter {
+  readonly provider: string;
+  generateText(request: LlmProviderRequest): Promise<LlmProviderResult>;
+}
+
+export interface LlmWarning {
+  code: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface LlmAttemptMetadata {
+  profileId: string;
+  role: ModelRole;
+  provider: string;
+  model: string;
+  status: 'succeeded' | 'failed' | 'skipped';
+  startedAt: string;
+  finishedAt: string;
+  latencyMs: number;
+  fallbackOf?: string;
+  fallbackIndex?: number;
+  usage: LlmUsage;
+  cost: LlmCost;
+  error?: {
+    code: string;
+    message: string;
+    retryable: boolean;
+  };
+  warnings: LlmWarning[];
+  rawOutputPreview?: string;
+  providerMetadata: Record<string, unknown>;
+}
+
+export interface LlmInvocationMetadata {
+  profile: {
+    id: string;
+    role: ModelRole;
+    provider: string;
+    model: string;
+    version: string;
+    promptTemplateKey: string | null;
+    budgetUsd: number | null;
+    fallbackCount: number;
+  };
+  selected: {
+    provider: string;
+    model: string;
+    fallbackIndex: number | null;
+  } | null;
+  responseFormat: LlmResponseFormat;
+  startedAt: string;
+  finishedAt: string;
+  latencyMs: number;
+  attempts: LlmAttemptMetadata[];
+  warnings: LlmWarning[];
+  usage: LlmUsage;
+  cost: LlmCost;
+  requestMetadata: Record<string, unknown>;
+  rawOutputPreview?: string;
+  validatedOutputPreview?: string;
+}
+
+export interface LlmTextRequest {
+  profile: ResolvedModelProfile;
+  messages: LlmMessage[];
+  responseFormat?: LlmResponseFormat;
+  requestMetadata?: Record<string, unknown>;
+}
+
+export interface LlmTextResult {
+  text: string;
+  metadata: LlmInvocationMetadata;
+}
+
+export type LlmJsonValidator<T> = (value: unknown) => T;
+
+export interface LlmJsonRequest<T> extends Omit<LlmTextRequest, 'responseFormat'> {
+  schemaName?: string;
+  schemaHint?: Record<string, unknown>;
+  validate?: LlmJsonValidator<T>;
+}
+
+export interface LlmJsonResult<T> extends LlmTextResult {
+  value: T;
+}
+
+export interface LlmRuntime {
+  generateText(request: LlmTextRequest): Promise<LlmTextResult>;
+  generateJson<T>(request: LlmJsonRequest<T>): Promise<LlmJsonResult<T>>;
+}
+
+export class LlmProviderError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly retryable = true,
+    public readonly metadata: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = 'LlmProviderError';
+  }
+}
+
+export class LlmRuntimeError extends Error {
+  constructor(
+    message: string,
+    public readonly metadata: LlmInvocationMetadata,
+  ) {
+    super(message);
+    this.name = 'LlmRuntimeError';
+  }
+}
+
+export class LlmJsonOutputError extends Error {
+  constructor(
+    public readonly code: 'malformed_json' | 'validation_failed',
+    message: string,
+    public readonly metadata: LlmInvocationMetadata,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'LlmJsonOutputError';
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable LLM runtime with provider adapter abstraction, fallback handling, and normalized invocation metadata
- add deterministic fake + OpenAI-compatible adapters, JSON parsing/validation helpers, and job metadata helpers for future pipeline stages
- document the runtime contract and configuration in the README

Closes #14.

## Verification
- npm run check
