### PR TITLE
feat: add prompt template registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,42 @@ Available adapters:
 Fallback strings may be plain model names, which reuse the profile provider, or
 `provider/model` strings, which switch provider and model for that attempt.
 
+## Prompt templates
+
+Prompt templates live under `packages/api/src/prompts`. Podcast Forge ships
+safe default templates for each supported model role, keyed as
+`<role>.default`, plus zod validators for the structured JSON outputs expected
+by candidate scoring, source summarization, claim extraction, research
+synthesis, script generation/revision, metadata, and cover prompts.
+
+Pipeline code can render a prompt before calling the LLM runtime:
+
+```ts
+const registry = createPromptRegistry({ store });
+const rendered = await renderPromptTemplate(registry, {
+  key: modelProfile.promptTemplateKey ?? 'script_writer.default',
+  variables: {
+    show_context: show,
+    research_packet: packet,
+    format_notes: show.format,
+  },
+});
+```
+
+`rendered.messages` and `rendered.responseFormat` are compatible with the LLM
+runtime. Missing required variables fail before any provider call.
+
+Prompt template endpoints for future settings/admin UI:
+
+- `GET /prompt-templates`
+- `GET /prompt-templates?role=script_writer`
+- `GET /prompt-templates/:key?version=1`
+- `POST /prompt-templates/render`
+
+The existing `prompt_templates` table can store show-specific or global
+overrides. Default code templates remain the fallback path so a fresh install
+can render prompts before editable DB prompts are added.
+
 ## Brave source search
 
 Brave source profiles can be searched from the API using the enabled

--- a/config/examples/the-synthetic-lens.json
+++ b/config/examples/the-synthetic-lens.json
@@ -38,6 +38,7 @@
       "model": "gemini-2.5-flash",
       "temperature": 0.2,
       "maxTokens": 1200,
+      "promptTemplate": "candidate_scorer.default",
       "budgetUsd": 0.25
     },
     "source_summarizer": {
@@ -45,6 +46,7 @@
       "model": "gemini-2.5-flash",
       "temperature": 0.1,
       "maxTokens": 3000,
+      "promptTemplate": "source_summarizer.default",
       "budgetUsd": 0.75
     },
     "claim_extractor": {
@@ -52,6 +54,7 @@
       "model": "gemini-2.5-flash",
       "temperature": 0,
       "maxTokens": 2500,
+      "promptTemplate": "claim_extractor.default",
       "budgetUsd": 0.75
     },
     "research_synthesizer": {
@@ -60,6 +63,7 @@
       "temperature": 0.3,
       "maxTokens": 8000,
       "fallbacks": ["gemini-2.5-pro"],
+      "promptTemplate": "research_synthesizer.default",
       "budgetUsd": 2.5
     },
     "script_writer": {
@@ -70,6 +74,7 @@
       "params": {
         "reasoningEffort": "high"
       },
+      "promptTemplate": "script_writer.default",
       "budgetUsd": 4
     },
     "script_editor": {
@@ -77,6 +82,7 @@
       "model": "gpt-5.3-codex",
       "temperature": 0.4,
       "maxTokens": 8000,
+      "promptTemplate": "script_editor.default",
       "budgetUsd": 2
     },
     "metadata_writer": {
@@ -84,6 +90,7 @@
       "model": "gpt-5.5",
       "temperature": 0.3,
       "maxTokens": 1500,
+      "promptTemplate": "metadata_writer.default",
       "budgetUsd": 0.5
     },
     "cover_prompt_writer": {
@@ -91,6 +98,7 @@
       "model": "gpt-5.5",
       "temperature": 0.7,
       "maxTokens": 1000,
+      "promptTemplate": "cover_prompt_writer.default",
       "budgetUsd": 1
     }
   },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,6 +62,14 @@ Each agent role is an adapter over model providers:
 
 The app should not hardcode model names in business logic. It should resolve `show.defaultModelProfile[role]` at runtime.
 
+Prompt templates are a separate registry from model profiles. Model profiles may
+point at a `promptTemplateKey`, while the prompt registry resolves a
+show-specific DB template or a global default, validates required variables, and
+returns LLM runtime messages plus structured JSON response hints. Output
+validators live with the prompt domain so downstream workers can validate model
+JSON before persisting generated scoring, research, script, metadata, or art
+prompt records.
+
 ## Source adapters
 
 V1:

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -15,6 +15,8 @@ import { registerSourceRoutes } from './sources/routes.js';
 import type { SourceStore } from './sources/store.js';
 import { registerModelRoutes } from './models/routes.js';
 import type { ModelProfileStore } from './models/store.js';
+import { registerPromptRoutes } from './prompts/routes.js';
+import type { PromptTemplateStore } from './prompts/types.js';
 import { registerResearchRoutes } from './research/routes.js';
 import type { ResearchFetch } from './research/fetch.js';
 import type { ResearchStore } from './research/store.js';
@@ -41,6 +43,7 @@ interface BuildAppOptions extends FastifyServerOptions {
     & Partial<SearchJobStore>
     & Partial<ResearchStore>
     & Partial<ModelProfileStore>
+    & Partial<PromptTemplateStore>
     & Partial<ScriptStore>
     & Partial<ProductionStore>
     & Partial<SchedulerStore>;
@@ -98,6 +101,7 @@ export function buildApp(options: BuildAppOptions = {}) {
     & Partial<SearchJobStore>
     & Partial<ResearchStore>
     & Partial<ModelProfileStore>
+    & Partial<PromptTemplateStore>
     & Partial<ScriptStore>
     & Partial<ProductionStore>
     & Partial<SchedulerStore>
@@ -179,6 +183,13 @@ export function buildApp(options: BuildAppOptions = {}) {
   });
 
   registerModelRoutes(app, {
+    getStore() {
+      resolvedSourceStore ??= createDbSourceStore();
+      return resolvedSourceStore;
+    },
+  });
+
+  registerPromptRoutes(app, {
     getStore() {
       resolvedSourceStore ??= createDbSourceStore();
       return resolvedSourceStore;

--- a/packages/api/src/prompts/defaults.ts
+++ b/packages/api/src/prompts/defaults.ts
@@ -1,0 +1,230 @@
+import { MODEL_ROLES, type ModelRole } from '../models/roles.js';
+import { PROMPT_OUTPUT_SCHEMAS } from './schemas.js';
+import type { PromptOutputSchemaName, PromptTemplate, PromptVariable } from './types.js';
+
+const baseVariables = {
+  show_context: 'Show title, audience, format, voice/cast, runtime target, and editorial constraints.',
+  source_profile: 'Source profile/query metadata that led to the candidate or packet.',
+  candidate_json: 'Serialized story candidate with title, URL, source, summary, timestamps, and raw provider metadata.',
+  story_context: 'Serialized story/candidate context for the source being summarized.',
+  source_document: 'Serialized fetched source document including id, URL, title, fetchedAt, and text content.',
+  source_summary: 'Previously generated source summary for one document.',
+  source_summaries: 'Serialized array of source summaries to synthesize.',
+  claims: 'Serialized extracted claims with source references.',
+  research_packet: 'Serialized research packet including claims, citations, warnings, and source document ids.',
+  format_notes: 'Target episode format, speaker/cast rules, runtime target, and style notes.',
+  script_draft: 'Current script draft to revise.',
+  revision_instructions: 'Human/editorial revision request and acceptance criteria.',
+  script_result: 'Generated or revised script result to summarize for publishing metadata.',
+  episode_metadata: 'Episode title, summary, show branding, and publishing metadata.',
+  script_excerpt: 'Short excerpt or synopsis to inform cover-art direction.',
+  art_direction: 'Visual style constraints, exclusions, and show-level art direction.',
+} as const;
+
+function variable(name: keyof typeof baseVariables, required = true): PromptVariable {
+  return {
+    name,
+    description: baseVariables[name],
+    required,
+  };
+}
+
+function template(
+  role: ModelRole,
+  title: string,
+  description: string,
+  inputVariables: PromptVariable[],
+  outputSchemaName: PromptOutputSchemaName,
+  body: string,
+): PromptTemplate {
+  return {
+    showId: null,
+    key: `${role}.default`,
+    role,
+    version: 1,
+    title,
+    description,
+    inputVariables,
+    outputFormat: PROMPT_OUTPUT_SCHEMAS[outputSchemaName].description,
+    outputSchemaName,
+    outputSchemaHint: PROMPT_OUTPUT_SCHEMAS[outputSchemaName].schemaHint,
+    body,
+    metadata: {
+      source: 'code-default',
+      editableVia: 'prompt_templates database rows can override or extend these defaults by key/version/show.',
+    },
+  };
+}
+
+export const DEFAULT_PROMPT_TEMPLATES: PromptTemplate[] = [
+  template(
+    'candidate_scorer',
+    'Default candidate scorer',
+    'Scores one story candidate for editorial fit, significance, novelty, and source quality.',
+    [variable('show_context'), variable('source_profile'), variable('candidate_json')],
+    'candidate_score_result',
+    [
+      'You are scoring a possible episode story for an evidence-first news podcast.',
+      'Prefer primary sources, independent corroboration, clear public impact, and stories that can be explained without speculation.',
+      'Separate what is known from what is inferred. Penalize thin sourcing, promotional claims, vague summaries, or stories that depend on one unverified source.',
+      '',
+      'Show context:',
+      '{{show_context}}',
+      '',
+      'Source profile:',
+      '{{source_profile}}',
+      '',
+      'Candidate:',
+      '{{candidate_json}}',
+    ].join('\n'),
+  ),
+  template(
+    'source_summarizer',
+    'Default source summarizer',
+    'Summarizes a fetched source document while preserving source identity and caveats.',
+    [variable('story_context'), variable('source_document')],
+    'source_summary',
+    [
+      'You are summarizing one fetched source document for later research synthesis.',
+      'Do not add facts that are not in the source. Mark the source type as primary, secondary, analysis, or unknown.',
+      'Call out missing text, paywalls, unclear attribution, or unsupported claims as warnings.',
+      '',
+      'Story context:',
+      '{{story_context}}',
+      '',
+      'Source document:',
+      '{{source_document}}',
+    ].join('\n'),
+  ),
+  template(
+    'claim_extractor',
+    'Default claim extractor',
+    'Extracts sourced claims with citation references and confidence labels.',
+    [variable('source_summary'), variable('source_document')],
+    'extracted_claims',
+    [
+      'Extract the concrete claims from this source that could matter in a podcast script.',
+      'Each claim must point back to sourceDocumentIds and citation references. Label interpretation or uncertainty instead of upgrading it to fact.',
+      'Prefer fewer, clearer claims over exhaustive paraphrase.',
+      '',
+      'Source summary:',
+      '{{source_summary}}',
+      '',
+      'Source document:',
+      '{{source_document}}',
+    ].join('\n'),
+  ),
+  template(
+    'research_synthesizer',
+    'Default research synthesizer',
+    'Synthesizes source summaries and extracted claims into a research packet draft.',
+    [variable('candidate_json'), variable('source_summaries'), variable('claims')],
+    'research_synthesis',
+    [
+      'Build an evidence-first research synthesis for an editor.',
+      'Represent source disagreement and uncertainty directly. Do not smooth conflicts away.',
+      'Identify known facts, open questions, source gaps, and any warnings that require human review before script generation.',
+      '',
+      'Candidate:',
+      '{{candidate_json}}',
+      '',
+      'Source summaries:',
+      '{{source_summaries}}',
+      '',
+      'Extracted claims:',
+      '{{claims}}',
+    ].join('\n'),
+  ),
+  template(
+    'script_writer',
+    'Default script writer',
+    'Drafts an attributed podcast script from an approved research packet.',
+    [variable('show_context'), variable('research_packet'), variable('format_notes')],
+    'script_generation_result',
+    [
+      'Write a podcast script using only the supplied research packet and show context.',
+      'Keep factual claims traceable through the citation map. Distinguish confirmed facts, source claims, analysis, and unknowns.',
+      'Avoid sensationalism, invented quotes, invented sourcing, and unsupported certainty.',
+      '',
+      'Show context:',
+      '{{show_context}}',
+      '',
+      'Research packet:',
+      '{{research_packet}}',
+      '',
+      'Format notes:',
+      '{{format_notes}}',
+    ].join('\n'),
+  ),
+  template(
+    'script_editor',
+    'Default script editor',
+    'Revises a script without weakening citation discipline or speaker constraints.',
+    [variable('script_draft'), variable('research_packet'), variable('revision_instructions')],
+    'script_revision_result',
+    [
+      'Revise the script according to the instructions while preserving the research packet boundaries.',
+      'Do not add unsourced factual claims. Keep speaker labels compatible with the show cast if provided in the packet or instructions.',
+      'Report what changed and which warnings remain unresolved.',
+      '',
+      'Script draft:',
+      '{{script_draft}}',
+      '',
+      'Research packet:',
+      '{{research_packet}}',
+      '',
+      'Revision instructions:',
+      '{{revision_instructions}}',
+    ].join('\n'),
+  ),
+  template(
+    'metadata_writer',
+    'Default metadata writer',
+    'Creates publishable episode metadata from script and research context.',
+    [variable('show_context'), variable('research_packet'), variable('script_result')],
+    'metadata_result',
+    [
+      'Create episode metadata that is accurate, concise, and not clickbait.',
+      'The title and description must not overstate certainty or include claims missing from the research packet.',
+      'Use a stable lowercase hyphenated slug.',
+      '',
+      'Show context:',
+      '{{show_context}}',
+      '',
+      'Research packet:',
+      '{{research_packet}}',
+      '',
+      'Script result:',
+      '{{script_result}}',
+    ].join('\n'),
+  ),
+  template(
+    'cover_prompt_writer',
+    'Default cover prompt writer',
+    'Creates a safe cover-art prompt and alt text for an episode.',
+    [variable('episode_metadata'), variable('script_excerpt'), variable('art_direction')],
+    'cover_prompt_result',
+    [
+      'Write a cover-art generation prompt that reflects the episode topic without misleading viewers.',
+      'Avoid depicting real people, logos, copyrighted characters, or unsupported dramatic scenes unless the provided art direction explicitly authorizes them.',
+      'Include concise alt text for accessibility.',
+      '',
+      'Episode metadata:',
+      '{{episode_metadata}}',
+      '',
+      'Script excerpt:',
+      '{{script_excerpt}}',
+      '',
+      'Art direction:',
+      '{{art_direction}}',
+    ].join('\n'),
+  ),
+];
+
+const defaultRoleSet = new Set(DEFAULT_PROMPT_TEMPLATES.map((prompt) => prompt.role));
+
+for (const role of MODEL_ROLES) {
+  if (!defaultRoleSet.has(role)) {
+    throw new Error(`Missing default prompt template for role: ${role}`);
+  }
+}

--- a/packages/api/src/prompts/index.ts
+++ b/packages/api/src/prompts/index.ts
@@ -1,0 +1,7 @@
+export * from './defaults.js';
+export * from './registry.js';
+export * from './renderer.js';
+export * from './routes.js';
+export * from './schemas.js';
+export * from './store.js';
+export * from './types.js';

--- a/packages/api/src/prompts/prompts.test.ts
+++ b/packages/api/src/prompts/prompts.test.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+import Fastify from 'fastify';
+import { ZodError } from 'zod';
+
+import { MODEL_ROLES } from '../models/roles.js';
+import { DEFAULT_PROMPT_TEMPLATES } from './defaults.js';
+import { createPromptRegistry } from './registry.js';
+import { PromptRenderError, renderPromptTemplate } from './renderer.js';
+import { registerPromptRoutes } from './routes.js';
+import {
+  candidateScoreResultSchema,
+  extractedClaimsSchema,
+} from './schemas.js';
+
+describe('prompt registry defaults', () => {
+  it('provides a default template for every core model role', async () => {
+    const registry = createPromptRegistry();
+    const templates = await registry.listTemplates();
+    const roles = new Set(templates.map((template) => template.role));
+
+    assert.equal(DEFAULT_PROMPT_TEMPLATES.length, MODEL_ROLES.length);
+    for (const role of MODEL_ROLES) {
+      assert.equal(roles.has(role), true, `missing prompt for ${role}`);
+    }
+  });
+
+  it('looks up a template by key', async () => {
+    const registry = createPromptRegistry();
+    const template = await registry.getTemplateByKey('script_writer.default');
+
+    assert.equal(template?.role, 'script_writer');
+    assert.equal(template?.outputSchemaName, 'script_generation_result');
+  });
+});
+
+describe('prompt rendering', () => {
+  it('renders variables into LLM-compatible messages and JSON response hints', async () => {
+    const registry = createPromptRegistry();
+    const rendered = await renderPromptTemplate(registry, {
+      key: 'candidate_scorer.default',
+      variables: {
+        show_context: { title: 'Example Show' },
+        source_profile: { slug: 'daily-ai' },
+        candidate_json: { title: 'A sourced story', url: 'https://example.com/story' },
+      },
+    });
+
+    assert.equal(rendered.template.key, 'candidate_scorer.default');
+    assert.equal(rendered.messages.length, 1);
+    assert.equal(rendered.messages[0].role, 'system');
+    assert.match(rendered.text, /Example Show/);
+    assert.equal(rendered.responseFormat.type, 'json');
+    assert.equal(rendered.responseFormat.schemaName, 'candidate_score_result');
+  });
+
+  it('fails clearly when a required variable is missing', async () => {
+    const registry = createPromptRegistry();
+
+    await assert.rejects(
+      () => renderPromptTemplate(registry, {
+        key: 'candidate_scorer.default',
+        variables: {
+          show_context: 'show',
+          source_profile: 'source',
+        },
+      }),
+      (error) => {
+        assert.equal(error instanceof PromptRenderError, true);
+        assert.equal((error as PromptRenderError).code, 'PROMPT_VARIABLES_MISSING');
+        assert.deepEqual((error as PromptRenderError).details.missingVariables, ['candidate_json']);
+        return true;
+      },
+    );
+  });
+});
+
+describe('prompt output schemas', () => {
+  it('validates candidate score output', () => {
+    const result = candidateScoreResultSchema.parse({
+      score: 82,
+      verdict: 'shortlist',
+      rationale: 'Well sourced and relevant.',
+      dimensions: {
+        significance: 85,
+        showFit: 90,
+        novelty: 70,
+        sourceQuality: 80,
+        urgency: 75,
+      },
+      warnings: [],
+      citations: [{ url: 'https://example.com/source' }],
+    });
+
+    assert.equal(result.verdict, 'shortlist');
+    assert.throws(() => candidateScoreResultSchema.parse({
+      score: 120,
+      verdict: 'shortlist',
+      rationale: 'Too high.',
+      dimensions: {
+        significance: 85,
+        showFit: 90,
+        novelty: 70,
+        sourceQuality: 80,
+        urgency: 75,
+      },
+    }), ZodError);
+  });
+
+  it('validates extracted claims with citations', () => {
+    const result = extractedClaimsSchema.parse({
+      claims: [{
+        id: 'claim-1',
+        text: 'The company announced a new model.',
+        claimType: 'fact',
+        confidence: 'high',
+        sourceDocumentIds: ['doc-1'],
+        citations: [{ sourceDocumentId: 'doc-1', url: 'https://example.com/post' }],
+      }],
+      warnings: [],
+    });
+
+    assert.equal(result.claims.length, 1);
+    assert.throws(() => extractedClaimsSchema.parse({
+      claims: [{
+        id: 'claim-1',
+        text: 'Unsupported claim.',
+        claimType: 'fact',
+        confidence: 'high',
+        sourceDocumentIds: [],
+        citations: [],
+      }],
+    }), ZodError);
+  });
+});
+
+describe('prompt API routes', () => {
+  const app = Fastify();
+  registerPromptRoutes(app, {
+    getStore() {
+      return undefined;
+    },
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  it('lists defaults for admin/settings UI callers', async () => {
+    const response = await app.inject({ method: 'GET', url: '/prompt-templates?role=script_writer' });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.templates.length, 1);
+    assert.equal(body.templates[0].key, 'script_writer.default');
+  });
+
+  it('renders a sample prompt through the API', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/prompt-templates/render',
+      payload: {
+        key: 'metadata_writer.default',
+        variables: {
+          show_context: 'Example show',
+          research_packet: { title: 'Packet' },
+          script_result: { title: 'Script' },
+        },
+      },
+    });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.rendered.template.key, 'metadata_writer.default');
+    assert.equal(body.rendered.responseFormat.schemaName, 'metadata_result');
+  });
+});

--- a/packages/api/src/prompts/registry.ts
+++ b/packages/api/src/prompts/registry.ts
@@ -1,0 +1,113 @@
+import type { ModelRole } from '../models/roles.js';
+import { DEFAULT_PROMPT_TEMPLATES } from './defaults.js';
+import type {
+  PromptRegistry,
+  PromptTemplate,
+  PromptTemplateListFilter,
+  PromptTemplateLookup,
+  PromptTemplateStore,
+} from './types.js';
+
+export interface PromptRegistryOptions {
+  defaults?: PromptTemplate[];
+  store?: Partial<PromptTemplateStore>;
+}
+
+function hasPromptStore(store: Partial<PromptTemplateStore> | undefined): store is PromptTemplateStore {
+  return Boolean(
+    store
+    && typeof store.listPromptTemplates === 'function'
+    && typeof store.getPromptTemplateByKey === 'function',
+  );
+}
+
+function templateId(template: PromptTemplate) {
+  return `${template.showId ?? 'global'}:${template.key}:${template.version}`;
+}
+
+function bySpecificityAndVersion(a: PromptTemplate, b: PromptTemplate) {
+  const showScore = Number(b.showId !== null) - Number(a.showId !== null);
+
+  if (showScore !== 0) {
+    return showScore;
+  }
+
+  if (b.version !== a.version) {
+    return b.version - a.version;
+  }
+
+  return a.key.localeCompare(b.key);
+}
+
+function matchesDefault(template: PromptTemplate, filter: PromptTemplateListFilter = {}) {
+  if (filter.showId && !filter.includeGlobal) {
+    return false;
+  }
+
+  if (filter.showSlug && !filter.includeGlobal) {
+    return false;
+  }
+
+  if (filter.role && template.role !== filter.role) {
+    return false;
+  }
+
+  if (filter.key && template.key !== filter.key) {
+    return false;
+  }
+
+  return true;
+}
+
+function matchingDefaults(defaults: PromptTemplate[], filter: PromptTemplateListFilter = {}) {
+  return defaults.filter((template) => matchesDefault(template, filter));
+}
+
+export function createPromptRegistry(options: PromptRegistryOptions = {}): PromptRegistry {
+  const defaults = options.defaults ?? DEFAULT_PROMPT_TEMPLATES;
+  const store = hasPromptStore(options.store) ? options.store : undefined;
+
+  return {
+    async listTemplates(filter = {}) {
+      const stored = store ? await store.listPromptTemplates(filter) : [];
+      const seen = new Set(stored.map(templateId));
+      const fallback = matchingDefaults(defaults, filter).filter((template) => !seen.has(templateId(template)));
+
+      return [...stored, ...fallback].sort(bySpecificityAndVersion);
+    },
+
+    async getTemplateByKey(key: string, lookup: PromptTemplateLookup = {}) {
+      const stored = store ? await store.getPromptTemplateByKey(key, lookup) : undefined;
+
+      if (stored) {
+        return stored;
+      }
+
+      return matchingDefaults(defaults, {
+        key,
+        showId: lookup.showId,
+        showSlug: lookup.showSlug,
+        includeGlobal: lookup.includeGlobal ?? true,
+      })
+        .filter((template) => lookup.version === undefined || template.version === lookup.version)
+        .sort(bySpecificityAndVersion)[0];
+    },
+
+    async getTemplateByRole(role: ModelRole, lookup: PromptTemplateLookup = {}) {
+      const templates = await this.listTemplates({
+        role,
+        showId: lookup.showId,
+        showSlug: lookup.showSlug,
+        includeGlobal: lookup.includeGlobal ?? true,
+      });
+
+      return templates
+        .filter((template) => lookup.version === undefined || template.version === lookup.version)
+        .sort(bySpecificityAndVersion)[0];
+    },
+  };
+}
+
+export function defaultPromptKey(role: ModelRole) {
+  return `${role}.default`;
+}

--- a/packages/api/src/prompts/renderer.ts
+++ b/packages/api/src/prompts/renderer.ts
@@ -1,0 +1,123 @@
+import { PROMPT_OUTPUT_SCHEMAS } from './schemas.js';
+import type { PromptRegistry, PromptTemplate, RenderedPrompt, RenderPromptInput } from './types.js';
+
+export type PromptRenderErrorCode =
+  | 'PROMPT_LOOKUP_REQUIRED'
+  | 'PROMPT_TEMPLATE_NOT_FOUND'
+  | 'PROMPT_VARIABLES_MISSING';
+
+export class PromptRenderError extends Error {
+  constructor(
+    public readonly code: PromptRenderErrorCode,
+    message: string,
+    public readonly details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = 'PromptRenderError';
+  }
+}
+
+function variableValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function requiredVariableNames(template: PromptTemplate) {
+  return template.inputVariables
+    .filter((variable) => variable.required)
+    .map((variable) => variable.name);
+}
+
+function missingVariables(template: PromptTemplate, variables: Record<string, unknown>) {
+  return requiredVariableNames(template).filter((name) => !(name in variables) || variables[name] === undefined || variables[name] === null);
+}
+
+function renderBody(template: PromptTemplate, variables: Record<string, unknown>) {
+  return template.body.replace(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (match, name: string) => {
+    if (!(name in variables) || variables[name] === undefined || variables[name] === null) {
+      return match;
+    }
+
+    return variableValue(variables[name]);
+  });
+}
+
+function outputInstructions(template: PromptTemplate) {
+  const lines = [
+    'Output requirements:',
+    `- ${template.outputFormat}`,
+  ];
+
+  if (template.outputSchemaName) {
+    const schema = PROMPT_OUTPUT_SCHEMAS[template.outputSchemaName];
+    lines.push(`- Return only valid JSON for schema "${schema.name}".`);
+    lines.push(`- Schema hint: ${JSON.stringify(schema.schemaHint)}`);
+  }
+
+  return lines.join('\n');
+}
+
+async function resolveTemplate(registry: PromptRegistry, input: RenderPromptInput) {
+  const lookup = {
+    showId: input.showId,
+    showSlug: input.showSlug,
+    version: input.version,
+    includeGlobal: input.includeGlobal ?? true,
+  };
+
+  if (input.key) {
+    return registry.getTemplateByKey(input.key, lookup);
+  }
+
+  if (input.role) {
+    return registry.getTemplateByRole(input.role, lookup);
+  }
+
+  throw new PromptRenderError('PROMPT_LOOKUP_REQUIRED', 'Provide a prompt template key or role.');
+}
+
+export async function renderPromptTemplate(
+  registry: PromptRegistry,
+  input: RenderPromptInput,
+): Promise<RenderedPrompt> {
+  const template = await resolveTemplate(registry, input);
+
+  if (!template) {
+    throw new PromptRenderError('PROMPT_TEMPLATE_NOT_FOUND', 'Prompt template was not found.', {
+      key: input.key,
+      role: input.role,
+      version: input.version,
+      showId: input.showId,
+      showSlug: input.showSlug,
+    });
+  }
+
+  const missing = missingVariables(template, input.variables);
+  if (missing.length > 0) {
+    throw new PromptRenderError('PROMPT_VARIABLES_MISSING', `Missing required prompt variable(s): ${missing.join(', ')}`, {
+      key: template.key,
+      version: template.version,
+      missingVariables: missing,
+    });
+  }
+
+  const text = [renderBody(template, input.variables), outputInstructions(template)].join('\n\n');
+  const responseFormat = template.outputSchemaName
+    ? {
+      type: 'json' as const,
+      schemaName: template.outputSchemaName,
+      schemaHint: template.outputSchemaHint ?? PROMPT_OUTPUT_SCHEMAS[template.outputSchemaName].schemaHint,
+    }
+    : { type: 'text' as const };
+
+  return {
+    template,
+    text,
+    messages: [{ role: 'system', content: text }],
+    responseFormat,
+    missingVariables: [],
+  };
+}

--- a/packages/api/src/prompts/routes.ts
+++ b/packages/api/src/prompts/routes.ts
@@ -1,0 +1,134 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { z, ZodError } from 'zod';
+
+import { isModelRole, MODEL_ROLES } from '../models/roles.js';
+import { createPromptRegistry } from './registry.js';
+import { PromptRenderError, renderPromptTemplate } from './renderer.js';
+import type { PromptTemplateStore } from './types.js';
+
+class ApiError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+export interface PromptRoutesOptions {
+  getStore(): Partial<PromptTemplateStore> | undefined;
+}
+
+const modelRoleSchema = z.string().refine(isModelRole, {
+  message: `Role must be one of: ${MODEL_ROLES.join(', ')}`,
+});
+
+const renderPromptSchema = z.object({
+  key: z.string().trim().min(1).optional(),
+  role: modelRoleSchema.optional(),
+  version: z.number().int().positive().optional(),
+  showId: z.string().uuid().optional(),
+  showSlug: z.string().trim().min(1).optional(),
+  variables: z.record(z.string(), z.unknown()).default({}),
+  includeGlobal: z.boolean().default(true),
+}).refine((value) => Boolean(value.key || value.role), {
+  message: 'Provide key or role.',
+  path: ['key'],
+}).refine((value) => !value.showId || !value.showSlug, {
+  message: 'Provide showId or showSlug, not both.',
+  path: ['showSlug'],
+});
+
+function sendError(reply: FastifyReply, error: unknown) {
+  if (error instanceof ZodError) {
+    return reply.code(400).send({
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      error: 'Request validation failed.',
+      errors: error.issues,
+    });
+  }
+
+  if (error instanceof PromptRenderError) {
+    const statusCode = error.code === 'PROMPT_TEMPLATE_NOT_FOUND' ? 404 : 400;
+
+    return reply.code(statusCode).send({
+      ok: false,
+      code: error.code,
+      error: error.message,
+      details: error.details,
+    });
+  }
+
+  if (error instanceof ApiError) {
+    return reply.code(error.statusCode).send({
+      ok: false,
+      code: error.code,
+      error: error.message,
+      details: error.details,
+    });
+  }
+
+  throw error;
+}
+
+export function registerPromptRoutes(app: FastifyInstance, options: PromptRoutesOptions) {
+  app.get<{ Querystring: { showId?: string; showSlug?: string; role?: string; key?: string; includeGlobal?: string } }>('/prompt-templates', async (request, reply) => {
+    try {
+      const registry = createPromptRegistry({ store: options.getStore() });
+      const role = request.query.role ? modelRoleSchema.parse(request.query.role) : undefined;
+      const includeGlobal = request.query.includeGlobal !== 'false';
+      const templates = await registry.listTemplates({
+        showId: request.query.showId,
+        showSlug: request.query.showSlug,
+        role,
+        key: request.query.key,
+        includeGlobal,
+      });
+
+      return { ok: true, templates };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.get<{ Params: { key: string }; Querystring: { showId?: string; showSlug?: string; version?: string; includeGlobal?: string } }>('/prompt-templates/:key', async (request, reply) => {
+    try {
+      const registry = createPromptRegistry({ store: options.getStore() });
+      const version = request.query.version ? Number(request.query.version) : undefined;
+
+      if (version !== undefined && (!Number.isInteger(version) || version < 1)) {
+        throw new ApiError(400, 'INVALID_PROMPT_VERSION', 'Prompt template version must be a positive integer.');
+      }
+
+      const template = await registry.getTemplateByKey(request.params.key, {
+        showId: request.query.showId,
+        showSlug: request.query.showSlug,
+        version,
+        includeGlobal: request.query.includeGlobal !== 'false',
+      });
+
+      if (!template) {
+        throw new ApiError(404, 'PROMPT_TEMPLATE_NOT_FOUND', `Prompt template not found: ${request.params.key}`);
+      }
+
+      return { ok: true, template };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.post('/prompt-templates/render', async (request, reply) => {
+    try {
+      const registry = createPromptRegistry({ store: options.getStore() });
+      const body = renderPromptSchema.parse(request.body);
+      const rendered = await renderPromptTemplate(registry, body);
+
+      return { ok: true, rendered };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+}

--- a/packages/api/src/prompts/schemas.ts
+++ b/packages/api/src/prompts/schemas.ts
@@ -1,0 +1,240 @@
+import { z } from 'zod';
+
+import type { PromptOutputSchemaDefinition, PromptOutputSchemaName } from './types.js';
+
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+
+const citationReferenceSchema = z.object({
+  sourceDocumentId: z.string().min(1).optional(),
+  url: z.string().url().optional(),
+  title: z.string().min(1).optional(),
+  quote: z.string().min(1).optional(),
+}).strict().refine((value) => Boolean(value.sourceDocumentId || value.url), {
+  message: 'Citation references must include sourceDocumentId or url.',
+});
+
+const warningSchema = z.object({
+  code: z.string().min(1),
+  severity: z.enum(['info', 'warning', 'critical']),
+  message: z.string().min(1),
+  sourceDocumentId: z.string().min(1).optional(),
+  metadata: jsonObjectSchema.optional(),
+}).strict();
+
+const scoreDimensionsSchema = z.object({
+  significance: z.number().min(0).max(100),
+  showFit: z.number().min(0).max(100),
+  novelty: z.number().min(0).max(100),
+  sourceQuality: z.number().min(0).max(100),
+  urgency: z.number().min(0).max(100),
+}).strict();
+
+export const candidateScoreResultSchema = z.object({
+  score: z.number().min(0).max(100),
+  verdict: z.enum(['ignore', 'watch', 'shortlist']),
+  rationale: z.string().min(1),
+  dimensions: scoreDimensionsSchema,
+  warnings: z.array(warningSchema).default([]),
+  citations: z.array(citationReferenceSchema).default([]),
+}).strict();
+
+export const sourceSummarySchema = z.object({
+  sourceDocumentId: z.string().min(1),
+  title: z.string().min(1),
+  url: z.string().url(),
+  summary: z.string().min(1),
+  keyFacts: z.array(z.string().min(1)).min(1),
+  notableQuotes: z.array(z.object({
+    quote: z.string().min(1),
+    context: z.string().min(1).optional(),
+  }).strict()).default([]),
+  sourceType: z.enum(['primary', 'secondary', 'analysis', 'unknown']),
+  warnings: z.array(warningSchema).default([]),
+}).strict();
+
+export const extractedClaimSchema = z.object({
+  id: z.string().min(1),
+  text: z.string().min(1),
+  claimType: z.enum(['fact', 'quote', 'interpretation', 'uncertain']),
+  confidence: z.enum(['low', 'medium', 'high']),
+  sourceDocumentIds: z.array(z.string().min(1)).min(1),
+  citations: z.array(citationReferenceSchema).min(1),
+  caveat: z.string().min(1).optional(),
+}).strict();
+
+export const extractedClaimsSchema = z.object({
+  claims: z.array(extractedClaimSchema),
+  warnings: z.array(warningSchema).default([]),
+}).strict();
+
+export const researchSynthesisSchema = z.object({
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  knownFacts: z.array(z.string().min(1)),
+  openQuestions: z.array(z.string().min(1)),
+  sourceDocumentIds: z.array(z.string().min(1)),
+  claims: z.array(extractedClaimSchema),
+  warnings: z.array(warningSchema).default([]),
+  editorialAngle: z.string().min(1).optional(),
+}).strict();
+
+export const scriptGenerationResultSchema = z.object({
+  title: z.string().min(1),
+  format: z.string().min(1),
+  body: z.string().min(1),
+  speakers: z.array(z.string().min(1)).min(1),
+  citationMap: z.array(z.object({
+    line: z.string().min(1),
+    claimId: z.string().min(1).optional(),
+    sourceDocumentIds: z.array(z.string().min(1)).default([]),
+  }).strict()).default([]),
+  warnings: z.array(warningSchema).default([]),
+}).strict();
+
+export const scriptRevisionResultSchema = z.object({
+  title: z.string().min(1),
+  body: z.string().min(1),
+  changeSummary: z.string().min(1),
+  speakers: z.array(z.string().min(1)).min(1),
+  resolvedWarnings: z.array(z.string().min(1)).default([]),
+  remainingWarnings: z.array(warningSchema).default([]),
+}).strict();
+
+export const metadataResultSchema = z.object({
+  title: z.string().min(1),
+  subtitle: z.string().min(1).optional(),
+  description: z.string().min(1),
+  summary: z.string().min(1),
+  tags: z.array(z.string().min(1)).default([]),
+  slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+}).strict();
+
+export const coverPromptResultSchema = z.object({
+  prompt: z.string().min(1),
+  negativePrompt: z.string().min(1).optional(),
+  altText: z.string().min(1),
+  safetyNotes: z.array(z.string().min(1)).default([]),
+}).strict();
+
+export type CandidateScoreResult = z.infer<typeof candidateScoreResultSchema>;
+export type SourceSummaryResult = z.infer<typeof sourceSummarySchema>;
+export type ExtractedClaimsResult = z.infer<typeof extractedClaimsSchema>;
+export type ResearchSynthesisResult = z.infer<typeof researchSynthesisSchema>;
+export type ScriptGenerationResult = z.infer<typeof scriptGenerationResultSchema>;
+export type ScriptRevisionResult = z.infer<typeof scriptRevisionResultSchema>;
+export type MetadataResult = z.infer<typeof metadataResultSchema>;
+export type CoverPromptResult = z.infer<typeof coverPromptResultSchema>;
+
+function jsonSchemaHint(name: PromptOutputSchemaName, properties: Record<string, unknown>, required: string[]) {
+  return {
+    type: 'object',
+    title: name,
+    additionalProperties: false,
+    required,
+    properties,
+  };
+}
+
+export const PROMPT_OUTPUT_SCHEMAS: Record<PromptOutputSchemaName, PromptOutputSchemaDefinition> = {
+  candidate_score_result: {
+    name: 'candidate_score_result',
+    description: 'Scores one story candidate for editorial fit and source quality.',
+    schemaHint: jsonSchemaHint('candidate_score_result', {
+      score: { type: 'number', minimum: 0, maximum: 100 },
+      verdict: { enum: ['ignore', 'watch', 'shortlist'] },
+      rationale: { type: 'string' },
+      dimensions: { type: 'object' },
+      warnings: { type: 'array' },
+      citations: { type: 'array' },
+    }, ['score', 'verdict', 'rationale', 'dimensions']),
+    validate: candidateScoreResultSchema.parse,
+  },
+  source_summary: {
+    name: 'source_summary',
+    description: 'Summarizes one fetched source document with provenance.',
+    schemaHint: jsonSchemaHint('source_summary', {
+      sourceDocumentId: { type: 'string' },
+      title: { type: 'string' },
+      url: { type: 'string' },
+      summary: { type: 'string' },
+      keyFacts: { type: 'array', items: { type: 'string' } },
+      sourceType: { enum: ['primary', 'secondary', 'analysis', 'unknown'] },
+      warnings: { type: 'array' },
+    }, ['sourceDocumentId', 'title', 'url', 'summary', 'keyFacts', 'sourceType']),
+    validate: sourceSummarySchema.parse,
+  },
+  extracted_claims: {
+    name: 'extracted_claims',
+    description: 'Extracts factual claims and citation references from sources.',
+    schemaHint: jsonSchemaHint('extracted_claims', {
+      claims: { type: 'array' },
+      warnings: { type: 'array' },
+    }, ['claims']),
+    validate: extractedClaimsSchema.parse,
+  },
+  research_synthesis: {
+    name: 'research_synthesis',
+    description: 'Synthesizes claims, source coverage, warnings, and open questions.',
+    schemaHint: jsonSchemaHint('research_synthesis', {
+      title: { type: 'string' },
+      summary: { type: 'string' },
+      knownFacts: { type: 'array' },
+      openQuestions: { type: 'array' },
+      sourceDocumentIds: { type: 'array' },
+      claims: { type: 'array' },
+      warnings: { type: 'array' },
+      editorialAngle: { type: 'string' },
+    }, ['title', 'summary', 'knownFacts', 'openQuestions', 'sourceDocumentIds', 'claims']),
+    validate: researchSynthesisSchema.parse,
+  },
+  script_generation_result: {
+    name: 'script_generation_result',
+    description: 'Drafts an attributed episode script from a research packet.',
+    schemaHint: jsonSchemaHint('script_generation_result', {
+      title: { type: 'string' },
+      format: { type: 'string' },
+      body: { type: 'string' },
+      speakers: { type: 'array' },
+      citationMap: { type: 'array' },
+      warnings: { type: 'array' },
+    }, ['title', 'format', 'body', 'speakers']),
+    validate: scriptGenerationResultSchema.parse,
+  },
+  script_revision_result: {
+    name: 'script_revision_result',
+    description: 'Revises a script and records resolved or remaining issues.',
+    schemaHint: jsonSchemaHint('script_revision_result', {
+      title: { type: 'string' },
+      body: { type: 'string' },
+      changeSummary: { type: 'string' },
+      speakers: { type: 'array' },
+      resolvedWarnings: { type: 'array' },
+      remainingWarnings: { type: 'array' },
+    }, ['title', 'body', 'changeSummary', 'speakers']),
+    validate: scriptRevisionResultSchema.parse,
+  },
+  metadata_result: {
+    name: 'metadata_result',
+    description: 'Creates publishable title, description, summary, tags, and slug.',
+    schemaHint: jsonSchemaHint('metadata_result', {
+      title: { type: 'string' },
+      subtitle: { type: 'string' },
+      description: { type: 'string' },
+      summary: { type: 'string' },
+      tags: { type: 'array' },
+      slug: { type: 'string' },
+    }, ['title', 'description', 'summary', 'slug']),
+    validate: metadataResultSchema.parse,
+  },
+  cover_prompt_result: {
+    name: 'cover_prompt_result',
+    description: 'Creates a safe visual prompt and alt text for cover art generation.',
+    schemaHint: jsonSchemaHint('cover_prompt_result', {
+      prompt: { type: 'string' },
+      negativePrompt: { type: 'string' },
+      altText: { type: 'string' },
+      safetyNotes: { type: 'array' },
+    }, ['prompt', 'altText']),
+    validate: coverPromptResultSchema.parse,
+  },
+};

--- a/packages/api/src/prompts/store.ts
+++ b/packages/api/src/prompts/store.ts
@@ -1,0 +1,89 @@
+import type { PromptOutputSchemaName, PromptTemplate, PromptVariable } from './types.js';
+import { PROMPT_OUTPUT_SCHEMAS } from './schemas.js';
+import { isModelRole } from '../models/roles.js';
+
+function asJsonObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function asVariables(value: unknown): PromptVariable[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is PromptVariable => {
+    return Boolean(
+      item
+      && typeof item === 'object'
+      && !Array.isArray(item)
+      && 'name' in item
+      && typeof item.name === 'string'
+      && 'required' in item
+      && typeof item.required === 'boolean',
+    );
+  });
+}
+
+function asSchemaName(value: unknown): PromptOutputSchemaName | null {
+  return typeof value === 'string' && value in PROMPT_OUTPUT_SCHEMAS
+    ? value as PromptOutputSchemaName
+    : null;
+}
+
+export function promptTemplateFromDbRow(row: {
+  id: string;
+  showId: string | null;
+  key: string;
+  version: number;
+  role: string | null;
+  title: string | null;
+  body: string;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}): PromptTemplate {
+  if (!row.role || !isModelRole(row.role)) {
+    throw new Error(`Unknown prompt template role in database: ${row.role ?? '(none)'}`);
+  }
+
+  const metadata = asJsonObject(row.metadata);
+  const outputSchemaName = asSchemaName(metadata.outputSchemaName);
+  const outputSchemaHint = asJsonObject(metadata.outputSchemaHint);
+
+  return {
+    id: row.id,
+    showId: row.showId,
+    key: row.key,
+    role: row.role,
+    version: row.version,
+    title: row.title ?? row.key,
+    description: typeof metadata.description === 'string' ? metadata.description : '',
+    inputVariables: asVariables(metadata.inputVariables),
+    outputFormat: typeof metadata.outputFormat === 'string'
+      ? metadata.outputFormat
+      : outputSchemaName
+        ? PROMPT_OUTPUT_SCHEMAS[outputSchemaName].description
+        : 'Plain text output.',
+    outputSchemaName,
+    outputSchemaHint: Object.keys(outputSchemaHint).length > 0
+      ? outputSchemaHint
+      : outputSchemaName
+        ? PROMPT_OUTPUT_SCHEMAS[outputSchemaName].schemaHint
+        : null,
+    body: row.body,
+    metadata,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function promptTemplateMetadata(template: PromptTemplate): Record<string, unknown> {
+  return {
+    ...template.metadata,
+    description: template.description,
+    inputVariables: template.inputVariables,
+    outputFormat: template.outputFormat,
+    outputSchemaName: template.outputSchemaName,
+    outputSchemaHint: template.outputSchemaHint,
+  };
+}

--- a/packages/api/src/prompts/types.ts
+++ b/packages/api/src/prompts/types.ts
@@ -1,0 +1,87 @@
+import type { LlmMessage, LlmResponseFormat } from '../llm/types.js';
+import type { ModelRole } from '../models/roles.js';
+
+export interface PromptVariable {
+  name: string;
+  description?: string;
+  required: boolean;
+}
+
+export interface PromptTemplate {
+  id?: string;
+  showId: string | null;
+  key: string;
+  role: ModelRole;
+  version: number;
+  title: string;
+  description: string;
+  inputVariables: PromptVariable[];
+  outputFormat: string;
+  outputSchemaName: PromptOutputSchemaName | null;
+  outputSchemaHint: Record<string, unknown> | null;
+  body: string;
+  metadata: Record<string, unknown>;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface PromptTemplateListFilter {
+  showId?: string;
+  showSlug?: string;
+  role?: ModelRole;
+  key?: string;
+  includeGlobal?: boolean;
+}
+
+export interface PromptTemplateLookup {
+  showId?: string;
+  showSlug?: string;
+  version?: number;
+  includeGlobal?: boolean;
+}
+
+export interface PromptTemplateStore {
+  listPromptTemplates(filter?: PromptTemplateListFilter): Promise<PromptTemplate[]>;
+  getPromptTemplateByKey(key: string, lookup?: PromptTemplateLookup): Promise<PromptTemplate | undefined>;
+}
+
+export interface PromptRegistry {
+  listTemplates(filter?: PromptTemplateListFilter): Promise<PromptTemplate[]>;
+  getTemplateByKey(key: string, lookup?: PromptTemplateLookup): Promise<PromptTemplate | undefined>;
+  getTemplateByRole(role: ModelRole, lookup?: PromptTemplateLookup): Promise<PromptTemplate | undefined>;
+}
+
+export type PromptOutputSchemaName =
+  | 'candidate_score_result'
+  | 'source_summary'
+  | 'extracted_claims'
+  | 'research_synthesis'
+  | 'script_generation_result'
+  | 'script_revision_result'
+  | 'metadata_result'
+  | 'cover_prompt_result';
+
+export interface PromptOutputSchemaDefinition<T = unknown> {
+  name: PromptOutputSchemaName;
+  description: string;
+  schemaHint: Record<string, unknown>;
+  validate(value: unknown): T;
+}
+
+export interface RenderPromptInput {
+  key?: string;
+  role?: ModelRole;
+  version?: number;
+  showId?: string;
+  showSlug?: string;
+  variables: Record<string, unknown>;
+  includeGlobal?: boolean;
+}
+
+export interface RenderedPrompt {
+  template: PromptTemplate;
+  text: string;
+  messages: LlmMessage[];
+  responseFormat: LlmResponseFormat;
+  missingVariables: string[];
+}

--- a/packages/api/src/shows/routes.ts
+++ b/packages/api/src/shows/routes.ts
@@ -3,6 +3,7 @@ import { z, ZodError } from 'zod';
 
 import { MODEL_ROLES, isModelRole, type ModelRole } from '../models/roles.js';
 import type { CreateModelProfileInput, ModelProfileRecord, ModelProfileStore } from '../models/store.js';
+import { defaultPromptKey } from '../prompts/registry.js';
 import type { CreateFeedInput, FeedRecord, ProductionStore, UpdateFeedInput } from '../production/store.js';
 import type {
   CreateShowInput,
@@ -316,7 +317,7 @@ function modelProfileInputs(showId: string, defaults: Record<ModelRole, z.infer<
       maxTokens: input.maxTokens ?? null,
       budgetUsd: input.budgetUsd ?? null,
       fallbacks: input.fallbacks,
-      promptTemplateKey: input.promptTemplateKey ?? null,
+      promptTemplateKey: input.promptTemplateKey ?? defaultPromptKey(role),
       config: {
         ...input.config,
         params: input.params,

--- a/packages/api/src/sources/db-store.ts
+++ b/packages/api/src/sources/db-store.ts
@@ -7,6 +7,7 @@ import {
   feeds,
   jobs,
   modelProfiles,
+  promptTemplates,
   publishEvents,
   researchPackets,
   scriptRevisions,
@@ -56,6 +57,8 @@ import type {
   ModelProfileStore,
   UpdateModelProfileInput,
 } from '../models/store.js';
+import { promptTemplateFromDbRow } from '../prompts/store.js';
+import type { PromptTemplateStore } from '../prompts/types.js';
 import type {
   CreateEpisodeAssetInput,
   CreateFeedInput,
@@ -470,7 +473,7 @@ function slugify(value: string) {
   return slug || 'episode';
 }
 
-export function createDbSourceStore(connectionString = process.env.DATABASE_URL): SourceStore & SearchJobStore & ResearchStore & ModelProfileStore & ScriptStore & ProductionStore & SchedulerStore {
+export function createDbSourceStore(connectionString = process.env.DATABASE_URL): SourceStore & SearchJobStore & ResearchStore & ModelProfileStore & PromptTemplateStore & ScriptStore & ProductionStore & SchedulerStore {
   const { db, pool } = createDb(connectionString);
 
   return {
@@ -581,6 +584,51 @@ export function createDbSourceStore(connectionString = process.env.DATABASE_URL)
         .returning();
 
       return row ? mapModelProfile(row) : undefined;
+    },
+
+    async listPromptTemplates(filter = {}) {
+      let showId = filter.showId;
+
+      if (!showId && filter.showSlug) {
+        const [show] = await db.select().from(shows).where(eq(shows.slug, filter.showSlug)).limit(1);
+
+        if (!show) {
+          return [];
+        }
+
+        showId = show.id;
+      }
+
+      const keyWhere = filter.key ? eq(promptTemplates.key, filter.key) : undefined;
+      const roleWhere = filter.role ? eq(promptTemplates.role, filter.role) : undefined;
+      const showWhere = showId
+        ? filter.includeGlobal
+          ? or(eq(promptTemplates.showId, showId), isNull(promptTemplates.showId))
+          : eq(promptTemplates.showId, showId)
+        : undefined;
+      const where = and(keyWhere, roleWhere, showWhere);
+      const rows = where
+        ? await db.select().from(promptTemplates).where(where).orderBy(asc(promptTemplates.key), desc(promptTemplates.version), desc(promptTemplates.updatedAt))
+        : await db.select().from(promptTemplates).orderBy(asc(promptTemplates.key), desc(promptTemplates.version), desc(promptTemplates.updatedAt));
+
+      return rows.map(promptTemplateFromDbRow);
+    },
+
+    async getPromptTemplateByKey(key, lookup = {}) {
+      const templates = await this.listPromptTemplates({
+        key,
+        showId: lookup.showId,
+        showSlug: lookup.showSlug,
+        includeGlobal: lookup.includeGlobal ?? true,
+      });
+      const matching = templates
+        .filter((template) => lookup.version === undefined || template.version === lookup.version)
+        .sort((a, b) => {
+          const showScore = Number(b.showId !== null) - Number(a.showId !== null);
+          return showScore !== 0 ? showScore : b.version - a.version;
+        });
+
+      return matching[0];
     },
 
     async listSourceProfiles(filter = {}) {

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { eq } from 'drizzle-orm';
 import { createDb } from './client.js';
-import { feeds, modelProfiles, shows, sourceProfiles, sourceQueries } from './schema.js';
+import { feeds, modelProfiles, promptTemplates, shows, sourceProfiles, sourceQueries } from './schema.js';
 
 type ExampleConfig = {
   show: {
@@ -51,6 +51,134 @@ const configPath = process.argv[2] ? resolve(process.argv[2]) : defaultConfigPat
 
 const config = JSON.parse(await readFile(configPath, 'utf8')) as ExampleConfig;
 const { db, pool } = createDb();
+
+const defaultPromptTemplates = [
+  {
+    key: 'candidate_scorer.default',
+    role: 'candidate_scorer',
+    title: 'Default candidate scorer',
+    description: 'Scores one story candidate for editorial fit and source quality.',
+    inputVariables: ['show_context', 'source_profile', 'candidate_json'],
+    outputSchemaName: 'candidate_score_result',
+    body: [
+      'Score this possible episode story for an evidence-first podcast.',
+      'Prefer primary sources, independent corroboration, public impact, and clear uncertainty.',
+      'Show context: {{show_context}}',
+      'Source profile: {{source_profile}}',
+      'Candidate: {{candidate_json}}',
+    ].join('\n\n'),
+  },
+  {
+    key: 'source_summarizer.default',
+    role: 'source_summarizer',
+    title: 'Default source summarizer',
+    description: 'Summarizes one fetched source document with provenance and caveats.',
+    inputVariables: ['story_context', 'source_document'],
+    outputSchemaName: 'source_summary',
+    body: [
+      'Summarize this fetched source document without adding facts not present in the source.',
+      'Preserve source identity, source type, caveats, and fetch/readability warnings.',
+      'Story context: {{story_context}}',
+      'Source document: {{source_document}}',
+    ].join('\n\n'),
+  },
+  {
+    key: 'claim_extractor.default',
+    role: 'claim_extractor',
+    title: 'Default claim extractor',
+    description: 'Extracts sourced claims with citation references.',
+    inputVariables: ['source_summary', 'source_document'],
+    outputSchemaName: 'extracted_claims',
+    body: [
+      'Extract concrete claims that could matter in a podcast script.',
+      'Each claim must point to source document ids or URLs and preserve uncertainty labels.',
+      'Source summary: {{source_summary}}',
+      'Source document: {{source_document}}',
+    ].join('\n\n'),
+  },
+  {
+    key: 'research_synthesizer.default',
+    role: 'research_synthesizer',
+    title: 'Default research synthesizer',
+    description: 'Synthesizes source summaries and claims into a research packet draft.',
+    inputVariables: ['candidate_json', 'source_summaries', 'claims'],
+    outputSchemaName: 'research_synthesis',
+    body: [
+      'Build an evidence-first research synthesis for an editor.',
+      'Represent disagreement, known facts, open questions, source gaps, and review warnings.',
+      'Candidate: {{candidate_json}}',
+      'Source summaries: {{source_summaries}}',
+      'Claims: {{claims}}',
+    ].join('\n\n'),
+  },
+  {
+    key: 'script_writer.default',
+    role: 'script_writer',
+    title: 'Default script writer',
+    description: 'Drafts an attributed podcast script from a research packet.',
+    inputVariables: ['show_context', 'research_packet', 'format_notes'],
+    outputSchemaName: 'script_generation_result',
+    body: [
+      'Write a podcast script using only the supplied research packet and show context.',
+      'Keep factual claims traceable, distinguish facts from analysis, and avoid unsupported certainty.',
+      'Show context: {{show_context}}',
+      'Research packet: {{research_packet}}',
+      'Format notes: {{format_notes}}',
+    ].join('\n\n'),
+  },
+  {
+    key: 'script_editor.default',
+    role: 'script_editor',
+    title: 'Default script editor',
+    description: 'Revises a script while preserving citation discipline.',
+    inputVariables: ['script_draft', 'research_packet', 'revision_instructions'],
+    outputSchemaName: 'script_revision_result',
+    body: [
+      'Revise the script according to the instructions without adding unsourced claims.',
+      'Report what changed, resolved warnings, and remaining warnings.',
+      'Script draft: {{script_draft}}',
+      'Research packet: {{research_packet}}',
+      'Revision instructions: {{revision_instructions}}',
+    ].join('\n\n'),
+  },
+  {
+    key: 'metadata_writer.default',
+    role: 'metadata_writer',
+    title: 'Default metadata writer',
+    description: 'Creates accurate publishable episode metadata.',
+    inputVariables: ['show_context', 'research_packet', 'script_result'],
+    outputSchemaName: 'metadata_result',
+    body: [
+      'Create episode metadata that is accurate, concise, and not clickbait.',
+      'Do not overstate certainty or include claims absent from the research packet.',
+      'Show context: {{show_context}}',
+      'Research packet: {{research_packet}}',
+      'Script result: {{script_result}}',
+    ].join('\n\n'),
+  },
+  {
+    key: 'cover_prompt_writer.default',
+    role: 'cover_prompt_writer',
+    title: 'Default cover prompt writer',
+    description: 'Creates a safe cover-art prompt and alt text.',
+    inputVariables: ['episode_metadata', 'script_excerpt', 'art_direction'],
+    outputSchemaName: 'cover_prompt_result',
+    body: [
+      'Write a cover-art generation prompt that reflects the topic without misleading viewers.',
+      'Avoid depicting real people, logos, copyrighted characters, or unsupported dramatic scenes unless explicitly authorized.',
+      'Episode metadata: {{episode_metadata}}',
+      'Script excerpt: {{script_excerpt}}',
+      'Art direction: {{art_direction}}',
+    ].join('\n\n'),
+  },
+];
+
+function promptInputVariables(names: string[]) {
+  return names.map((name) => ({
+    name,
+    required: true,
+  }));
+}
 
 try {
   const showConfig = config.show;
@@ -128,6 +256,39 @@ try {
         fallbacks: model.fallbacks ?? [],
         promptTemplateKey: model.promptTemplate,
         config: { params: model.params ?? {} },
+        updatedAt: new Date()
+      }
+    });
+  }
+
+  for (const prompt of defaultPromptTemplates) {
+    await db.insert(promptTemplates).values({
+      showId: show.id,
+      key: prompt.key,
+      version: 1,
+      role: prompt.role,
+      title: prompt.title,
+      body: prompt.body,
+      metadata: {
+        description: prompt.description,
+        inputVariables: promptInputVariables(prompt.inputVariables),
+        outputFormat: prompt.description,
+        outputSchemaName: prompt.outputSchemaName,
+        source: 'seed-default',
+      }
+    }).onConflictDoUpdate({
+      target: [promptTemplates.showId, promptTemplates.key, promptTemplates.version],
+      set: {
+        role: prompt.role,
+        title: prompt.title,
+        body: prompt.body,
+        metadata: {
+          description: prompt.description,
+          inputVariables: promptInputVariables(prompt.inputVariables),
+          outputFormat: prompt.description,
+          outputSchemaName: prompt.outputSchemaName,
+          source: 'seed-default',
+        },
         updatedAt: new Date()
       }
     });


### PR DESCRIPTION
Closes #15\n\n## Summary\n- add a prompt template domain with default templates for all core model roles\n- add prompt rendering, structured output schemas, and lightweight prompt API routes\n- seed default templates and document how prompt selection works\n\n## Verification\n- npm run check