### PR TITLE
feat: add LLM candidate scoring and ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ The endpoint runs a synchronous `source.search` job for now and writes new
 freshness, region/language, and simple rate-limit delay config from the source
 profile/query records where present.
 
+New candidates are scored synchronously as a pragmatic V1 pass, capped at 10
+candidates per source profile by default. Override the cap with
+`source_profiles.config.candidateScoringLimit`, `scoringLimit`, or
+`scoring.limit`. When a `candidate_scorer` model profile is configured, search
+renders the candidate scorer prompt and calls the LLM runtime for structured
+JSON scoring. If no scorer is configured, validation fails, or the scorer
+errors, ingestion still keeps the candidate and records deterministic fallback
+metadata with `metadata.scoringStatus`, `score`, `scoreBreakdown.rationale`,
+component scores, warnings, flags, and scorer/runtime metadata where available.
+
 Search/job endpoints:
 
 - `POST /source-profiles/:id/search`
@@ -215,6 +225,10 @@ Search/job endpoints:
 - `POST /story-candidates/manual`
 - `GET /jobs/:id`
 - `GET /story-candidates?showSlug=the-synthetic-lens`
+
+`GET /story-candidates` defaults to `sort=score`, returning scored candidates
+highest first with unscored candidates last. Use `sort=discovered` to show the
+newest discovered candidates first.
 
 ## Scheduled pipelines
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -29,7 +29,9 @@ import type { FeedRecord, ProductionStore } from './production/store.js';
 import { registerSearchRoutes } from './search/routes.js';
 import type { BraveFetch } from './search/brave.js';
 import type { RssFetch } from './search/rss.js';
+import type { CandidateScorer } from './search/scoring.js';
 import type { SearchJobStore } from './search/store.js';
+import type { LlmRuntime } from './llm/types.js';
 import { registerSchedulerRoutes } from './scheduler/routes.js';
 import type { SchedulerStore } from './scheduler/store.js';
 import { registerLegacyImportRoutes } from './import/routes.js';
@@ -50,6 +52,8 @@ interface BuildAppOptions extends FastifyServerOptions {
   braveApiKey?: string;
   fetchImpl?: BraveFetch;
   rssFetchImpl?: RssFetch;
+  candidateScorer?: CandidateScorer;
+  llmRuntime?: LlmRuntime;
   researchFetchImpl?: ResearchFetch;
   audioPreviewProvider?: AudioPreviewProvider;
   coverArtProvider?: CoverArtProvider;
@@ -87,6 +91,8 @@ export function buildApp(options: BuildAppOptions = {}) {
     braveApiKey,
     fetchImpl,
     rssFetchImpl,
+    candidateScorer,
+    llmRuntime,
     researchFetchImpl,
     audioPreviewProvider,
     coverArtProvider,
@@ -204,6 +210,8 @@ export function buildApp(options: BuildAppOptions = {}) {
     braveApiKey,
     fetchImpl,
     rssFetchImpl,
+    candidateScorer,
+    llmRuntime,
     sleep,
   });
 

--- a/packages/api/src/scheduler/routes.test.ts
+++ b/packages/api/src/scheduler/routes.test.ts
@@ -224,6 +224,20 @@ class FakeSchedulerStore implements SourceStore, SearchJobStore, SchedulerStore 
     return candidate;
   }
 
+  async updateStoryCandidateScoring(id: string, input: { score: number | null; scoreBreakdown: Record<string, unknown>; metadata: Record<string, unknown> }) {
+    const candidate = this.candidates.find((item) => item.id === id);
+
+    if (!candidate) {
+      return undefined;
+    }
+
+    candidate.score = input.score;
+    candidate.scoreBreakdown = input.scoreBreakdown;
+    candidate.metadata = input.metadata;
+    candidate.updatedAt = new Date();
+    return candidate;
+  }
+
   async listStoryCandidates() {
     return this.candidates;
   }

--- a/packages/api/src/search/job.ts
+++ b/packages/api/src/search/job.ts
@@ -1,6 +1,7 @@
 import { searchBraveNews, type BraveCandidate, type BraveFetch } from './brave.js';
 import { normalizeTitle, type SourceCandidate } from './candidate.js';
 import { fetchRssCandidates, type RssFetch } from './rss.js';
+import { scoreCandidateBatch, scoringLimitFromProfile, type CandidateScorer, type CandidateScoringBatchResult } from './scoring.js';
 import type { JobRecord, SearchJobStore, StoryCandidateRecord } from './store.js';
 import type { ResolvedModelProfile } from '../models/resolver.js';
 import type { SourceProfileRecord, SourceQueryRecord, SourceStore } from '../sources/store.js';
@@ -20,6 +21,7 @@ interface RunSourceSearchOptions {
   fetchImpl?: BraveFetch;
   sleep?: (ms: number) => Promise<void>;
   modelProfile?: ResolvedModelProfile;
+  candidateScorer?: CandidateScorer;
 }
 
 interface RunSourceIngestOptions {
@@ -27,6 +29,8 @@ interface RunSourceIngestOptions {
   queries: SourceQueryRecord[];
   store: SourceStore & SearchJobStore;
   fetchImpl?: RssFetch;
+  modelProfile?: ResolvedModelProfile;
+  candidateScorer?: CandidateScorer;
 }
 
 type JsonObject = Record<string, unknown>;
@@ -78,6 +82,75 @@ function log(level: 'info' | 'warn' | 'error', message: string, metadata: JsonOb
     message,
     ...metadata,
   };
+}
+
+function scoringSummary(scoring?: CandidateScoringBatchResult) {
+  return scoring ? {
+    scored: scoring.scored,
+    fallback: scoring.fallback,
+    failed: scoring.failed,
+    skipped: scoring.skipped,
+  } : undefined;
+}
+
+function pushScoringEvents(logs: Array<Record<string, unknown>>, events: Array<Record<string, unknown>>) {
+  for (const event of events) {
+    const level = event.level === 'error' ? 'error' : event.level === 'warn' ? 'warn' : 'info';
+    logs.push(log(level, typeof event.message === 'string' ? event.message : 'Candidate scoring event.', {
+      ...event,
+      level: undefined,
+      message: undefined,
+    }));
+  }
+}
+
+async function maybeScoreCandidates(options: {
+  candidates: StoryCandidateRecord[];
+  profile: SourceProfileRecord;
+  queries: SourceQueryRecord[];
+  store: SourceStore & SearchJobStore;
+  modelProfile?: ResolvedModelProfile;
+  candidateScorer?: CandidateScorer;
+  logs: Array<Record<string, unknown>>;
+}): Promise<CandidateScoringBatchResult | undefined> {
+  if (options.candidates.length === 0) {
+    return undefined;
+  }
+
+  const show = (await options.store.listShows()).find((candidate) => candidate.id === options.profile.showId);
+
+  if (!show) {
+    options.logs.push(log('warn', 'Skipped candidate scoring because show context was not found.', {
+      showId: options.profile.showId,
+    }));
+    return undefined;
+  }
+
+  try {
+    options.logs.push(log('info', 'Starting candidate scoring.', {
+      candidateCount: options.candidates.length,
+      scoringLimit: scoringLimitFromProfile(options.profile),
+      modelProfileId: options.modelProfile?.id,
+      modelProfileVersion: options.modelProfile?.version,
+    }));
+    const result = await scoreCandidateBatch({
+      candidates: options.candidates,
+      show,
+      sourceProfile: options.profile,
+      queries: options.queries,
+      store: options.store,
+      scorer: options.candidateScorer,
+      modelProfile: options.modelProfile,
+    });
+    pushScoringEvents(options.logs, result.events);
+    options.logs.push(log('info', 'Completed candidate scoring.', scoringSummary(result)));
+    return result;
+  } catch (error) {
+    options.logs.push(log('error', 'Candidate scoring stage failed; candidates remain inserted.', {
+      reason: error instanceof Error ? error.message : 'Candidate scoring stage failed.',
+    }));
+    return undefined;
+  }
 }
 
 export async function runSourceSearch(options: RunSourceSearchOptions): Promise<SourceSearchResult> {
@@ -178,9 +251,22 @@ export async function runSourceSearch(options: RunSourceSearchOptions): Promise<
       }
     }
 
+    const scoring = await maybeScoreCandidates({
+      candidates: insertedCandidates,
+      profile: options.profile,
+      queries: options.queries,
+      store: options.store,
+      modelProfile: options.modelProfile,
+      candidateScorer: options.candidateScorer,
+      logs,
+    });
+
+    const finalCandidates = scoring?.candidates ?? insertedCandidates;
+
     logs.push(log('info', 'Completed source.search job.', {
       inserted: insertedCandidates.length,
       skipped,
+      scoring: scoringSummary(scoring),
     }));
     job = await options.store.updateJob(job.id, {
       status: 'succeeded',
@@ -189,7 +275,8 @@ export async function runSourceSearch(options: RunSourceSearchOptions): Promise<
       output: {
         inserted: insertedCandidates.length,
         skipped,
-        candidateIds: insertedCandidates.map((candidate) => candidate.id),
+        candidateIds: finalCandidates.map((candidate) => candidate.id),
+        scoring: scoringSummary(scoring),
         modelProfiles,
       },
       finishedAt: new Date(),
@@ -199,7 +286,7 @@ export async function runSourceSearch(options: RunSourceSearchOptions): Promise<
       job,
       inserted: insertedCandidates.length,
       skipped,
-      candidates: insertedCandidates,
+      candidates: finalCandidates,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Source search failed.';
@@ -220,8 +307,11 @@ export async function runSourceIngest(options: RunSourceIngestOptions): Promise<
     log('info', 'Starting source.ingest job.', {
       sourceProfileId: options.profile.id,
       queryCount: options.queries.length,
+      modelProfileId: options.modelProfile?.id,
+      modelProfileVersion: options.modelProfile?.version,
     }),
   ];
+  const modelProfiles = options.modelProfile ? { candidate_scorer: options.modelProfile } : {};
   let job = await options.store.createJob({
     showId: options.profile.showId,
     type: 'source.ingest',
@@ -233,6 +323,7 @@ export async function runSourceIngest(options: RunSourceIngestOptions): Promise<
       sourceProfileSlug: options.profile.slug,
       sourceType: options.profile.type,
       queryIds: options.queries.map((query) => query.id),
+      modelProfiles,
     },
     logs,
     startedAt: new Date(),
@@ -283,9 +374,22 @@ export async function runSourceIngest(options: RunSourceIngestOptions): Promise<
       }
     }
 
+    const scoring = await maybeScoreCandidates({
+      candidates: insertedCandidates,
+      profile: options.profile,
+      queries: options.queries,
+      store: options.store,
+      modelProfile: options.modelProfile,
+      candidateScorer: options.candidateScorer,
+      logs,
+    });
+
+    const finalCandidates = scoring?.candidates ?? insertedCandidates;
+
     logs.push(log('info', 'Completed source.ingest job.', {
       inserted: insertedCandidates.length,
       skipped,
+      scoring: scoringSummary(scoring),
     }));
     job = await options.store.updateJob(job.id, {
       status: 'succeeded',
@@ -294,7 +398,9 @@ export async function runSourceIngest(options: RunSourceIngestOptions): Promise<
       output: {
         inserted: insertedCandidates.length,
         skipped,
-        candidateIds: insertedCandidates.map((candidate) => candidate.id),
+        candidateIds: finalCandidates.map((candidate) => candidate.id),
+        scoring: scoringSummary(scoring),
+        modelProfiles,
       },
       finishedAt: new Date(),
     }) ?? job;
@@ -303,7 +409,7 @@ export async function runSourceIngest(options: RunSourceIngestOptions): Promise<
       job,
       inserted: insertedCandidates.length,
       skipped,
-      candidates: insertedCandidates,
+      candidates: finalCandidates,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Source ingest failed.';

--- a/packages/api/src/search/routes.test.ts
+++ b/packages/api/src/search/routes.test.ts
@@ -1,0 +1,347 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildApp } from '../app.js';
+import type { BraveFetch } from './brave.js';
+import type { CandidateScorer, CandidateScoringRequest } from './scoring.js';
+import type {
+  CreateJobInput,
+  CreateStoryCandidateInput,
+  JobRecord,
+  SearchJobStore,
+  StoryCandidateListFilter,
+  StoryCandidateRecord,
+  UpdateJobInput,
+  UpdateStoryCandidateScoringInput,
+} from './store.js';
+import type {
+  CreateSourceProfileInput,
+  CreateSourceQueryInput,
+  ShowRecord,
+  SourceProfileRecord,
+  SourceQueryRecord,
+  SourceStore,
+  UpdateSourceProfileInput,
+  UpdateSourceQueryInput,
+} from '../sources/store.js';
+
+const show: ShowRecord = {
+  id: '11111111-1111-4111-8111-111111111111',
+  slug: 'example-show',
+  title: 'Example Show',
+  description: 'Evidence-first news analysis.',
+  setupStatus: 'active',
+  format: 'briefing',
+  defaultRuntimeMinutes: 8,
+  cast: [],
+  defaultModelProfile: {},
+  settings: {},
+  createdAt: new Date('2026-04-26T00:00:00Z'),
+  updatedAt: new Date('2026-04-26T00:00:00Z'),
+};
+
+class FakeSearchStore implements SourceStore, SearchJobStore {
+  shows = [show];
+  profiles: SourceProfileRecord[] = [{
+    id: '22222222-2222-4222-8222-222222222222',
+    showId: show.id,
+    slug: 'brave-news',
+    name: 'Brave News',
+    type: 'brave',
+    enabled: true,
+    weight: 1,
+    freshness: 'pd',
+    includeDomains: [],
+    excludeDomains: [],
+    rateLimit: {},
+    config: { count: 5 },
+    createdAt: new Date('2026-04-26T00:00:00Z'),
+    updatedAt: new Date('2026-04-26T00:00:00Z'),
+  }];
+  queries: SourceQueryRecord[] = [{
+    id: '33333333-3333-4333-8333-333333333333',
+    sourceProfileId: '22222222-2222-4222-8222-222222222222',
+    query: 'ai news',
+    enabled: true,
+    weight: 1,
+    region: 'US',
+    language: 'en',
+    freshness: 'pd',
+    includeDomains: [],
+    excludeDomains: [],
+    config: {},
+    createdAt: new Date('2026-04-26T00:00:00Z'),
+    updatedAt: new Date('2026-04-26T00:00:00Z'),
+  }];
+  jobs: JobRecord[] = [];
+  candidates: StoryCandidateRecord[] = [];
+
+  async listShows() {
+    return this.shows;
+  }
+
+  async listSourceProfiles(filter: { showSlug?: string; showId?: string } = {}) {
+    const showId = filter.showId ?? (filter.showSlug ? this.shows.find((candidate) => candidate.slug === filter.showSlug)?.id : undefined);
+    return showId ? this.profiles.filter((profile) => profile.showId === showId) : this.profiles;
+  }
+
+  async getSourceProfile(id: string) {
+    return this.profiles.find((profile) => profile.id === id);
+  }
+
+  async createSourceProfile(input: CreateSourceProfileInput) {
+    const profile = { ...input, id: `profile-${this.profiles.length + 1}`, createdAt: new Date(), updatedAt: new Date() };
+    this.profiles.push(profile);
+    return profile;
+  }
+
+  async updateSourceProfile(id: string, input: UpdateSourceProfileInput) {
+    const profile = await this.getSourceProfile(id);
+
+    if (!profile) {
+      return undefined;
+    }
+
+    Object.assign(profile, input, { updatedAt: new Date() });
+    return profile;
+  }
+
+  async listSourceQueries(profileId: string, options: { enabledOnly?: boolean } = {}) {
+    return this.queries.filter((query) => query.sourceProfileId === profileId && (!options.enabledOnly || query.enabled));
+  }
+
+  async createSourceQuery(profileId: string, input: CreateSourceQueryInput) {
+    const query = { ...input, id: `query-${this.queries.length + 1}`, sourceProfileId: profileId, createdAt: new Date(), updatedAt: new Date() };
+    this.queries.push(query);
+    return query;
+  }
+
+  async updateSourceQuery(id: string, input: UpdateSourceQueryInput) {
+    const query = this.queries.find((candidate) => candidate.id === id);
+
+    if (!query) {
+      return undefined;
+    }
+
+    Object.assign(query, input, { updatedAt: new Date() });
+    return query;
+  }
+
+  async deleteSourceQuery(id: string) {
+    const before = this.queries.length;
+    this.queries = this.queries.filter((query) => query.id !== id);
+    return this.queries.length !== before;
+  }
+
+  async createJob(input: CreateJobInput) {
+    const job: JobRecord = {
+      id: `job-${this.jobs.length + 1}`,
+      showId: input.showId,
+      episodeId: input.episodeId ?? null,
+      type: input.type,
+      status: input.status,
+      progress: input.progress,
+      attempts: input.attempts ?? 0,
+      maxAttempts: input.maxAttempts ?? 1,
+      input: input.input,
+      output: {},
+      logs: input.logs ?? [],
+      error: null,
+      lockedBy: null,
+      lockedAt: null,
+      startedAt: input.startedAt ?? null,
+      finishedAt: null,
+      createdAt: new Date('2026-04-26T00:00:00Z'),
+      updatedAt: new Date('2026-04-26T00:00:00Z'),
+    };
+    this.jobs.push(job);
+    return job;
+  }
+
+  async updateJob(id: string, input: UpdateJobInput) {
+    const job = this.jobs.find((candidate) => candidate.id === id);
+
+    if (!job) {
+      return undefined;
+    }
+
+    Object.assign(job, input, { updatedAt: new Date() });
+    return job;
+  }
+
+  async getJob(id: string) {
+    return this.jobs.find((job) => job.id === id);
+  }
+
+  async listJobs() {
+    return this.jobs;
+  }
+
+  async listStoryCandidateDedupeKeys(showId: string) {
+    return this.candidates
+      .filter((candidate) => candidate.showId === showId)
+      .map((candidate) => ({ title: candidate.title, canonicalUrl: candidate.canonicalUrl }));
+  }
+
+  async insertStoryCandidate(input: CreateStoryCandidateInput) {
+    if (this.candidates.some((candidate) => candidate.showId === input.showId && candidate.canonicalUrl === input.canonicalUrl)) {
+      return undefined;
+    }
+
+    const candidate: StoryCandidateRecord = {
+      ...input,
+      id: `candidate-${this.candidates.length + 1}`,
+      author: null,
+      discoveredAt: new Date(`2026-04-26T00:0${this.candidates.length}:00Z`),
+      score: null,
+      scoreBreakdown: {},
+      status: 'new',
+      createdAt: new Date('2026-04-26T00:00:00Z'),
+      updatedAt: new Date('2026-04-26T00:00:00Z'),
+    };
+    this.candidates.push(candidate);
+    return candidate;
+  }
+
+  async updateStoryCandidateScoring(id: string, input: UpdateStoryCandidateScoringInput) {
+    const candidate = this.candidates.find((item) => item.id === id);
+
+    if (!candidate) {
+      return undefined;
+    }
+
+    candidate.score = input.score;
+    candidate.scoreBreakdown = input.scoreBreakdown;
+    candidate.metadata = input.metadata;
+    candidate.updatedAt = new Date();
+    return candidate;
+  }
+
+  async listStoryCandidates(filter: StoryCandidateListFilter) {
+    const candidates = this.candidates.filter((candidate) => candidate.showId === filter.showId);
+    const sorted = filter.sort === 'discovered'
+      ? candidates.sort((a, b) => b.discoveredAt.getTime() - a.discoveredAt.getTime())
+      : candidates.sort((a, b) => (b.score ?? -1) - (a.score ?? -1) || b.discoveredAt.getTime() - a.discoveredAt.getTime());
+
+    return sorted.slice(0, filter.limit ?? 50);
+  }
+}
+
+function braveFetch(results: Array<Record<string, unknown>>): BraveFetch {
+  return async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return { results };
+    },
+  });
+}
+
+const deterministicScorer: CandidateScorer = {
+  async score(request: CandidateScoringRequest) {
+    if (request.candidate.title.includes('Fail')) {
+      throw new Error('Injected scorer failure.');
+    }
+
+    const highValue = request.candidate.title.includes('High');
+    const score = highValue ? 92 : 41;
+
+    return {
+      overallScore: score,
+      componentScores: {
+        significance: score,
+        showFit: score - 2,
+        novelty: score - 3,
+        sourceQuality: score - 4,
+        urgency: score - 5,
+      },
+      rationale: highValue ? 'High value for this show.' : 'Lower value for this show.',
+      warnings: highValue ? [] : [{ code: 'LOW_RELEVANCE', severity: 'info', message: 'Lower relevance.' }],
+      flags: highValue ? ['shortlist'] : ['watch'],
+      angle: highValue ? 'Explain the broader impact.' : undefined,
+      verdict: highValue ? 'shortlist' : 'watch',
+      scoringStatus: 'scored',
+      scorer: { type: 'test-fake', fallback: false },
+    };
+  },
+};
+
+describe('search routes candidate scoring', () => {
+  it('persists scoring metadata and returns score-sorted candidates by default', async () => {
+    const store = new FakeSearchStore();
+    const app = buildApp({
+      sourceStore: store,
+      braveApiKey: 'test-key',
+      candidateScorer: deterministicScorer,
+      fetchImpl: braveFetch([
+        {
+          title: 'Low value update',
+          url: 'https://example.com/low',
+          description: 'A minor update.',
+          age: '2026-04-26T00:00:00Z',
+          meta_url: { hostname: 'example.com' },
+        },
+        {
+          title: 'High value development',
+          url: 'https://example.com/high',
+          description: 'A major development with clear public impact.',
+          age: '2026-04-26T00:00:00Z',
+          meta_url: { hostname: 'example.com' },
+        },
+      ]),
+    });
+
+    try {
+      const searchResponse = await app.inject({ method: 'POST', url: '/source-profiles/22222222-2222-4222-8222-222222222222/search' });
+      const searchBody = searchResponse.json();
+
+      assert.equal(searchResponse.statusCode, 200);
+      assert.equal(searchBody.inserted, 2);
+      assert.equal(searchBody.job.output.scoring.scored, 2);
+      assert.equal(searchBody.candidates[0].metadata.scoringStatus, 'scored');
+      assert.equal(searchBody.candidates[1].scoreBreakdown.rationale, 'High value for this show.');
+
+      const listResponse = await app.inject({ method: 'GET', url: '/story-candidates?showSlug=example-show' });
+      const listBody = listResponse.json();
+
+      assert.equal(listResponse.statusCode, 200);
+      assert.equal(listBody.storyCandidates[0].title, 'High value development');
+      assert.equal(listBody.storyCandidates[0].score, 92);
+      assert.equal(listBody.storyCandidates[0].scoreBreakdown.angle, 'Explain the broader impact.');
+      assert.equal(listBody.storyCandidates[1].title, 'Low value update');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps inserted candidates and logs fallback when scoring fails', async () => {
+    const store = new FakeSearchStore();
+    const app = buildApp({
+      sourceStore: store,
+      braveApiKey: 'test-key',
+      candidateScorer: deterministicScorer,
+      fetchImpl: braveFetch([{
+        title: 'Fail scoring but keep candidate',
+        url: 'https://example.com/fail',
+        description: 'A candidate that triggers fake scorer failure.',
+        age: '2026-04-26T00:00:00Z',
+        meta_url: { hostname: 'example.com' },
+      }]),
+    });
+
+    try {
+      const response = await app.inject({ method: 'POST', url: '/source-profiles/22222222-2222-4222-8222-222222222222/search' });
+      const body = response.json();
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(body.inserted, 1);
+      assert.equal(body.job.status, 'succeeded');
+      assert.equal(body.job.output.scoring.failed, 1);
+      assert.equal(body.candidates[0].metadata.scoringStatus, 'failed');
+      assert.equal(body.candidates[0].scoreBreakdown.scorer.fallback, true);
+      assert.match(JSON.stringify(body.job.logs), /Injected scorer failure/);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/api/src/search/routes.ts
+++ b/packages/api/src/search/routes.ts
@@ -5,9 +5,14 @@ import type { BraveFetch } from './brave.js';
 import { runSourceIngest, runSourceSearch } from './job.js';
 import { submitManualCandidate } from './manual.js';
 import { resolveRssFeedRefs, type RssFetch } from './rss.js';
+import { createLlmCandidateScorer, type CandidateScorer } from './scoring.js';
 import type { SearchJobStore } from './store.js';
+import { createLlmRuntime } from '../llm/runtime.js';
+import type { LlmRuntime } from '../llm/types.js';
 import { hasModelProfileStore, resolveModelProfile } from '../models/resolver.js';
 import type { ModelProfileStore } from '../models/store.js';
+import { createPromptRegistry } from '../prompts/registry.js';
+import type { PromptTemplateStore } from '../prompts/types.js';
 import type { SourceStore } from '../sources/store.js';
 
 class ApiError extends Error {
@@ -21,10 +26,12 @@ class ApiError extends Error {
 }
 
 export interface SearchRoutesOptions {
-  getStore(): SourceStore & Partial<SearchJobStore> & Partial<ModelProfileStore>;
+  getStore(): SourceStore & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<PromptTemplateStore>;
   braveApiKey?: string;
   fetchImpl?: BraveFetch;
   rssFetchImpl?: RssFetch;
+  candidateScorer?: CandidateScorer;
+  llmRuntime?: LlmRuntime;
   sleep?: (ms: number) => Promise<void>;
 }
 
@@ -81,6 +88,7 @@ function requireSearchStore(store: SourceStore & Partial<SearchJobStore>): Sourc
     'listJobs',
     'listStoryCandidateDedupeKeys',
     'insertStoryCandidate',
+    'updateStoryCandidateScoring',
     'listStoryCandidates',
   ];
 
@@ -91,6 +99,25 @@ function requireSearchStore(store: SourceStore & Partial<SearchJobStore>): Sourc
   }
 
   return store as SourceStore & SearchJobStore;
+}
+
+function candidateScorerFor(
+  options: SearchRoutesOptions,
+  rawStore: SourceStore & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<PromptTemplateStore>,
+  modelProfile: Awaited<ReturnType<typeof resolveModelProfile>>,
+): CandidateScorer | undefined {
+  if (options.candidateScorer) {
+    return options.candidateScorer;
+  }
+
+  if (!modelProfile) {
+    return undefined;
+  }
+
+  return createLlmCandidateScorer({
+    runtime: options.llmRuntime ?? createLlmRuntime(),
+    promptRegistry: createPromptRegistry({ store: rawStore }),
+  });
 }
 
 async function resolveShowId(store: SourceStore, showId?: string, showSlug?: string): Promise<string> {
@@ -151,6 +178,7 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
       const modelProfile = hasModelProfileStore(rawStore)
         ? await resolveModelProfile(rawStore, { showId: profile.showId, role: 'candidate_scorer' })
         : undefined;
+      const candidateScorer = candidateScorerFor(options, rawStore, modelProfile);
       const result = await runSourceSearch({
         apiKey,
         profile,
@@ -159,6 +187,7 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
         fetchImpl: options.fetchImpl,
         sleep: options.sleep,
         modelProfile,
+        candidateScorer,
       });
 
       return {
@@ -175,7 +204,8 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
 
   app.post<{ Params: { id: string } }>('/source-profiles/:id/ingest', async (request, reply) => {
     try {
-      const store = requireSearchStore(options.getStore());
+      const rawStore = options.getStore();
+      const store = requireSearchStore(rawStore);
       const profile = await store.getSourceProfile(request.params.id);
 
       if (!profile) {
@@ -196,11 +226,17 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
         throw new ApiError(400, 'NO_RSS_FEEDS', `RSS profile has no enabled feed URLs: ${profile.slug}`);
       }
 
+      const modelProfile = hasModelProfileStore(rawStore)
+        ? await resolveModelProfile(rawStore, { showId: profile.showId, role: 'candidate_scorer' })
+        : undefined;
+      const candidateScorer = candidateScorerFor(options, rawStore, modelProfile);
       const result = await runSourceIngest({
         profile,
         queries,
         store,
         fetchImpl: options.rssFetchImpl,
+        modelProfile,
+        candidateScorer,
       });
 
       return {
@@ -230,13 +266,19 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
     }
   });
 
-  app.get<{ Querystring: { showId?: string; showSlug?: string; limit?: string } }>('/story-candidates', async (request, reply) => {
+  app.get<{ Querystring: { showId?: string; showSlug?: string; limit?: string; sort?: string } }>('/story-candidates', async (request, reply) => {
     try {
       const store = requireSearchStore(options.getStore());
       const showId = await resolveShowId(store, request.query.showId, request.query.showSlug);
       const parsedLimit = request.query.limit ? Number(request.query.limit) : undefined;
       const limit = parsedLimit && Number.isInteger(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
-      const candidates = await store.listStoryCandidates({ showId, limit });
+      const sort = request.query.sort ?? 'score';
+
+      if (sort !== 'score' && sort !== 'discovered') {
+        throw new ApiError(400, 'INVALID_CANDIDATE_SORT', 'Sort must be "score" or "discovered".');
+      }
+
+      const candidates = await store.listStoryCandidates({ showId, limit, sort });
 
       return { ok: true, storyCandidates: candidates };
     } catch (error) {

--- a/packages/api/src/search/scoring.test.ts
+++ b/packages/api/src/search/scoring.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createFakeLlmProvider } from '../llm/providers.js';
+import { createLlmRuntime } from '../llm/runtime.js';
+import { LlmJsonOutputError } from '../llm/types.js';
+import { createPromptRegistry } from '../prompts/registry.js';
+import type { ResolvedModelProfile } from '../models/resolver.js';
+import type { ShowRecord, SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+import type { StoryCandidateRecord } from './store.js';
+import { buildCandidateScoringInput, createLlmCandidateScorer } from './scoring.js';
+
+const now = new Date('2026-04-26T12:00:00Z');
+
+const show: ShowRecord = {
+  id: '11111111-1111-4111-8111-111111111111',
+  slug: 'example-show',
+  title: 'Example Show',
+  description: 'Evidence-first news analysis.',
+  setupStatus: 'active',
+  format: 'briefing',
+  defaultRuntimeMinutes: 8,
+  cast: [{ name: 'Host', voice: 'voice-1' }],
+  defaultModelProfile: {},
+  settings: { tone: 'measured' },
+  createdAt: now,
+  updatedAt: now,
+};
+
+const sourceProfile: SourceProfileRecord = {
+  id: '22222222-2222-4222-8222-222222222222',
+  showId: show.id,
+  slug: 'news',
+  name: 'News',
+  type: 'brave',
+  enabled: true,
+  weight: 1.2,
+  freshness: 'pd',
+  includeDomains: [],
+  excludeDomains: [],
+  rateLimit: {},
+  config: {
+    count: 5,
+    apiKey: 'do-not-include',
+    localPath: '/home/private/source-cache',
+  },
+  createdAt: now,
+  updatedAt: now,
+};
+
+const sourceQuery: SourceQueryRecord = {
+  id: '33333333-3333-4333-8333-333333333333',
+  sourceProfileId: sourceProfile.id,
+  query: 'ai policy',
+  enabled: true,
+  weight: 1,
+  region: 'US',
+  language: 'en',
+  freshness: 'pd',
+  includeDomains: [],
+  excludeDomains: [],
+  config: {},
+  createdAt: now,
+  updatedAt: now,
+};
+
+const candidate: StoryCandidateRecord = {
+  id: '44444444-4444-4444-8444-444444444444',
+  showId: show.id,
+  sourceProfileId: sourceProfile.id,
+  sourceQueryId: sourceQuery.id,
+  title: 'AI policy report released',
+  url: 'https://example.com/ai-policy',
+  canonicalUrl: 'https://example.com/ai-policy',
+  sourceName: 'Example News',
+  author: null,
+  summary: 'A detailed report describes a new policy approach with multiple public impacts.',
+  publishedAt: now,
+  discoveredAt: now,
+  score: null,
+  scoreBreakdown: {},
+  status: 'new',
+  rawPayload: {
+    provider: 'brave',
+    token: 'do-not-include',
+    nested: { credentialPath: '/home/private/credential.json' },
+  },
+  metadata: {},
+  createdAt: now,
+  updatedAt: now,
+};
+
+const modelProfile: ResolvedModelProfile = {
+  id: '55555555-5555-4555-8555-555555555555',
+  showId: show.id,
+  role: 'candidate_scorer',
+  provider: 'fake',
+  model: 'candidate-score-model',
+  params: {},
+  fallbacks: [],
+  budgetUsd: null,
+  promptTemplateKey: null,
+  version: now.toISOString(),
+};
+
+describe('candidate scoring service', () => {
+  it('constructs scoring input without secrets or local-only paths', () => {
+    const input = buildCandidateScoringInput({ candidate, show, sourceProfile, sourceQuery });
+    const serialized = JSON.stringify(input);
+
+    assert.equal(input.candidate.title, 'AI policy report released');
+    assert.equal(input.candidate.domain, 'example.com');
+    assert.doesNotMatch(serialized, /do-not-include/);
+    assert.doesNotMatch(serialized, /\/home\/private/);
+  });
+
+  it('scores with the candidate_scorer prompt schema through the LLM runtime', async () => {
+    const runtime = createLlmRuntime({
+      adapters: [createFakeLlmProvider({
+        handler: () => ({
+          text: JSON.stringify({
+            score: 87,
+            verdict: 'shortlist',
+            rationale: 'Strong public impact and timely source context.',
+            dimensions: {
+              significance: 91,
+              showFit: 84,
+              novelty: 88,
+              sourceQuality: 79,
+              urgency: 86,
+            },
+            warnings: [{ code: 'NEEDS_SECOND_SOURCE', severity: 'warning', message: 'Corroborate before scripting.' }],
+            citations: [{ url: 'https://example.com/ai-policy', title: 'AI policy report released' }],
+          }),
+        }),
+      })],
+    });
+    const scorer = createLlmCandidateScorer({ runtime, promptRegistry: createPromptRegistry() });
+    const input = buildCandidateScoringInput({ candidate, show, sourceProfile, sourceQuery });
+    const result = await scorer.score({ input, candidate, show, sourceProfile, sourceQuery, modelProfile });
+
+    assert.equal(result.scoringStatus, 'scored');
+    assert.equal(result.overallScore, 87);
+    assert.equal(result.componentScores.significance, 91);
+    assert.equal(result.warnings[0]?.code, 'NEEDS_SECOND_SOURCE');
+    assert.equal(result.scorer.type, 'llm');
+    assert.equal((result.scorer.modelProfile as { role: string }).role, 'candidate_scorer');
+  });
+
+  it('rejects invalid structured scorer output before persistence', async () => {
+    const runtime = createLlmRuntime({
+      adapters: [createFakeLlmProvider({
+        handler: () => ({
+          text: JSON.stringify({
+            score: 110,
+            verdict: 'shortlist',
+            rationale: '',
+            dimensions: {
+              significance: 91,
+              showFit: 84,
+              novelty: 88,
+              sourceQuality: 79,
+              urgency: 86,
+            },
+          }),
+        }),
+      })],
+    });
+    const scorer = createLlmCandidateScorer({ runtime, promptRegistry: createPromptRegistry() });
+    const input = buildCandidateScoringInput({ candidate, show, sourceProfile, sourceQuery });
+
+    await assert.rejects(
+      () => scorer.score({ input, candidate, show, sourceProfile, sourceQuery, modelProfile }),
+      LlmJsonOutputError,
+    );
+  });
+});

--- a/packages/api/src/search/scoring.ts
+++ b/packages/api/src/search/scoring.ts
@@ -1,0 +1,547 @@
+import { PROMPT_OUTPUT_SCHEMAS, type CandidateScoreResult } from '../prompts/schemas.js';
+import { renderPromptTemplate } from '../prompts/renderer.js';
+import type { PromptRegistry } from '../prompts/types.js';
+import type { LlmInvocationMetadata, LlmRuntime } from '../llm/types.js';
+import type { ResolvedModelProfile } from '../models/resolver.js';
+import type { ShowRecord, SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+import type { SearchJobStore, StoryCandidateRecord } from './store.js';
+
+export type CandidateScoringStatus = 'scored' | 'fallback' | 'failed' | 'skipped';
+
+export interface CandidateScoringWarning {
+  code: string;
+  severity: 'info' | 'warning' | 'critical';
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CandidateComponentScores {
+  significance: number;
+  showFit: number;
+  novelty: number;
+  sourceQuality: number;
+  urgency: number;
+}
+
+export interface CandidateScoringInput {
+  candidate: Record<string, unknown>;
+  show: Record<string, unknown>;
+  sourceProfile: Record<string, unknown> | null;
+  sourceQuery: Record<string, unknown> | null;
+}
+
+export interface CandidateScoringRequest {
+  input: CandidateScoringInput;
+  candidate: StoryCandidateRecord;
+  show: ShowRecord;
+  sourceProfile: SourceProfileRecord | null;
+  sourceQuery: SourceQueryRecord | null;
+  modelProfile?: ResolvedModelProfile;
+}
+
+export interface CandidateScoringResult {
+  overallScore: number;
+  componentScores: CandidateComponentScores;
+  rationale: string;
+  warnings: CandidateScoringWarning[];
+  flags: string[];
+  angle?: string;
+  verdict?: CandidateScoreResult['verdict'];
+  scoringStatus: CandidateScoringStatus;
+  scorer: Record<string, unknown>;
+}
+
+export interface CandidateScorer {
+  score(request: CandidateScoringRequest): Promise<CandidateScoringResult>;
+}
+
+export interface CandidateScoringBatchResult {
+  candidates: StoryCandidateRecord[];
+  scored: number;
+  fallback: number;
+  failed: number;
+  skipped: number;
+  events: Array<Record<string, unknown>>;
+}
+
+interface LlmCandidateScorerOptions {
+  runtime: LlmRuntime;
+  promptRegistry: PromptRegistry;
+}
+
+interface ScoreCandidateBatchOptions {
+  candidates: StoryCandidateRecord[];
+  show: ShowRecord;
+  sourceProfile: SourceProfileRecord | null;
+  queries: SourceQueryRecord[];
+  store: Pick<SearchJobStore, 'updateStoryCandidateScoring'>;
+  scorer?: CandidateScorer;
+  modelProfile?: ResolvedModelProfile;
+  limit?: number;
+  now?: () => Date;
+}
+
+const secretKeyPattern = /(api[_-]?key|authorization|cookie|credential|password|secret|token)/i;
+const localDataKeyPattern = /(^|_)(local|absolute)?(file|dir|directory|path)$/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (depth > 4) {
+    return '[max-depth]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, depth + 1));
+  }
+
+  if (!isRecord(value)) {
+    return value instanceof Date ? value.toISOString() : value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => !secretKeyPattern.test(key) && !localDataKeyPattern.test(key))
+      .map(([key, entry]) => [key, sanitizeValue(entry, depth + 1)]),
+  );
+}
+
+function isoDate(value: Date | null): string | null {
+  return value ? value.toISOString() : null;
+}
+
+function domainFromUrl(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function sourceQueryForCandidate(candidate: StoryCandidateRecord, queries: SourceQueryRecord[]) {
+  return queries.find((query) => query.id === candidate.sourceQueryId) ?? null;
+}
+
+export function buildCandidateScoringInput(options: {
+  candidate: StoryCandidateRecord;
+  show: ShowRecord;
+  sourceProfile: SourceProfileRecord | null;
+  sourceQuery: SourceQueryRecord | null;
+}): CandidateScoringInput {
+  const { candidate, show, sourceProfile, sourceQuery } = options;
+  const candidateDomain = domainFromUrl(candidate.canonicalUrl ?? candidate.url);
+
+  return sanitizeValue({
+    candidate: {
+      id: candidate.id,
+      title: candidate.title,
+      url: candidate.url,
+      canonicalUrl: candidate.canonicalUrl,
+      domain: candidateDomain,
+      sourceName: candidate.sourceName,
+      author: candidate.author,
+      summary: candidate.summary,
+      status: candidate.status,
+      publishedAt: isoDate(candidate.publishedAt),
+      discoveredAt: isoDate(candidate.discoveredAt),
+      existingScore: candidate.score,
+      existingScoreBreakdown: candidate.scoreBreakdown,
+      metadata: candidate.metadata,
+      rawPayload: candidate.rawPayload,
+    },
+    show: {
+      id: show.id,
+      slug: show.slug,
+      title: show.title,
+      description: show.description,
+      format: show.format,
+      defaultRuntimeMinutes: show.defaultRuntimeMinutes,
+      cast: show.cast.map((member) => ({ name: member.name, role: member.role })),
+      settings: show.settings,
+    },
+    sourceProfile: sourceProfile ? {
+      id: sourceProfile.id,
+      slug: sourceProfile.slug,
+      name: sourceProfile.name,
+      type: sourceProfile.type,
+      weight: sourceProfile.weight,
+      freshness: sourceProfile.freshness,
+      includeDomains: sourceProfile.includeDomains,
+      excludeDomains: sourceProfile.excludeDomains,
+      config: sourceProfile.config,
+    } : null,
+    sourceQuery: sourceQuery ? {
+      id: sourceQuery.id,
+      query: sourceQuery.query,
+      weight: sourceQuery.weight,
+      region: sourceQuery.region,
+      language: sourceQuery.language,
+      freshness: sourceQuery.freshness,
+      includeDomains: sourceQuery.includeDomains,
+      excludeDomains: sourceQuery.excludeDomains,
+      config: sourceQuery.config,
+    } : null,
+  }) as CandidateScoringInput;
+}
+
+function freshnessScore(candidate: StoryCandidateRecord, now: Date) {
+  if (!candidate.publishedAt) {
+    return 45;
+  }
+
+  const ageHours = Math.max(0, (now.getTime() - candidate.publishedAt.getTime()) / 3_600_000);
+
+  if (ageHours <= 12) return 90;
+  if (ageHours <= 24) return 82;
+  if (ageHours <= 72) return 68;
+  if (ageHours <= 168) return 52;
+  return 35;
+}
+
+function sourceQualityScore(candidate: StoryCandidateRecord, sourceProfile: SourceProfileRecord | null, sourceQuery: SourceQueryRecord | null) {
+  const domain = domainFromUrl(candidate.canonicalUrl ?? candidate.url);
+  const domainBoost = domain ? 8 : 0;
+  const sourceBoost = candidate.sourceName ? 7 : 0;
+  const profileWeight = Math.max(0, Math.min(2, sourceProfile?.weight ?? 1));
+  const queryWeight = Math.max(0, Math.min(2, sourceQuery?.weight ?? 1));
+
+  return clampScore(50 + domainBoost + sourceBoost + (profileWeight - 1) * 8 + (queryWeight - 1) * 5);
+}
+
+function textSignalScore(candidate: StoryCandidateRecord) {
+  const text = `${candidate.title} ${candidate.summary ?? ''}`;
+  const hasSpecifics = /\b\d{4}\b|\b\d+(?:\.\d+)?%?\b|\b(launch|release|lawsuit|filing|report|study|research|funding|acquisition|security|regulation|policy)\b/i.test(text);
+  const hasSummary = Boolean(candidate.summary && candidate.summary.length >= 80);
+
+  return clampScore(52 + (hasSpecifics ? 14 : 0) + (hasSummary ? 10 : 0));
+}
+
+export function baselineCandidateScore(
+  request: CandidateScoringRequest,
+  options: { status: CandidateScoringStatus; reason: string; now?: Date },
+): CandidateScoringResult {
+  const now = options.now ?? new Date();
+  const novelty = freshnessScore(request.candidate, now);
+  const sourceQuality = sourceQualityScore(request.candidate, request.sourceProfile, request.sourceQuery);
+  const significance = textSignalScore(request.candidate);
+  const showFit = clampScore(58 + Math.min(20, ((request.sourceProfile?.weight ?? 1) - 1) * 10 + ((request.sourceQuery?.weight ?? 1) - 1) * 6));
+  const urgency = clampScore((novelty * 0.8) + (significance * 0.2));
+  const overallScore = clampScore(
+    significance * 0.28
+    + showFit * 0.22
+    + novelty * 0.2
+    + sourceQuality * 0.18
+    + urgency * 0.12,
+  );
+
+  return {
+    overallScore,
+    componentScores: {
+      significance,
+      showFit,
+      novelty,
+      sourceQuality,
+      urgency,
+    },
+    rationale: `Baseline deterministic score used because ${options.reason}.`,
+    warnings: [{
+      code: 'BASELINE_SCORING_USED',
+      severity: options.status === 'failed' ? 'warning' : 'info',
+      message: `Candidate was scored with the deterministic fallback: ${options.reason}.`,
+    }],
+    flags: ['fallback'],
+    scoringStatus: options.status,
+    scorer: {
+      type: 'deterministic-baseline',
+      fallback: true,
+      fallbackReason: options.reason,
+      scoredAt: now.toISOString(),
+    },
+  };
+}
+
+function normalizeWarnings(warnings: CandidateScoreResult['warnings']): CandidateScoringWarning[] {
+  return warnings.map((warning) => ({
+    code: warning.code,
+    severity: warning.severity,
+    message: warning.message,
+    metadata: warning.metadata,
+  }));
+}
+
+function resultFromLlmOutput(options: {
+  output: CandidateScoreResult;
+  metadata: LlmInvocationMetadata;
+  promptTemplate: { key: string; version: number };
+}): CandidateScoringResult {
+  const warnings = normalizeWarnings(options.output.warnings);
+  const flags = warnings.map((warning) => warning.code);
+
+  if (options.output.verdict === 'ignore') {
+    flags.push('verdict_ignore');
+  }
+
+  return {
+    overallScore: clampScore(options.output.score),
+    componentScores: {
+      significance: clampScore(options.output.dimensions.significance),
+      showFit: clampScore(options.output.dimensions.showFit),
+      novelty: clampScore(options.output.dimensions.novelty),
+      sourceQuality: clampScore(options.output.dimensions.sourceQuality),
+      urgency: clampScore(options.output.dimensions.urgency),
+    },
+    rationale: options.output.rationale,
+    warnings,
+    flags,
+    verdict: options.output.verdict,
+    scoringStatus: 'scored',
+    scorer: {
+      type: 'llm',
+      fallback: false,
+      promptTemplateKey: options.promptTemplate.key,
+      promptTemplateVersion: options.promptTemplate.version,
+      modelProfile: options.metadata.profile,
+      selected: options.metadata.selected,
+      runtime: options.metadata,
+    },
+  };
+}
+
+export function createLlmCandidateScorer(options: LlmCandidateScorerOptions): CandidateScorer {
+  return {
+    async score(request) {
+      if (!request.modelProfile) {
+        throw new Error('No candidate_scorer model profile is configured for this show.');
+      }
+
+      const rendered = await renderPromptTemplate(options.promptRegistry, {
+        key: request.modelProfile.promptTemplateKey ?? undefined,
+        role: request.modelProfile.promptTemplateKey ? undefined : 'candidate_scorer',
+        showId: request.show.id,
+        variables: {
+          show_context: request.input.show,
+          source_profile: {
+            profile: request.input.sourceProfile,
+            query: request.input.sourceQuery,
+          },
+          candidate_json: request.input.candidate,
+        },
+      });
+      const schema = PROMPT_OUTPUT_SCHEMAS.candidate_score_result;
+      const result = await options.runtime.generateJson<CandidateScoreResult>({
+        profile: request.modelProfile,
+        messages: rendered.messages,
+        schemaName: rendered.responseFormat.schemaName ?? schema.name,
+        schemaHint: rendered.responseFormat.schemaHint ?? schema.schemaHint,
+        validate: (value) => schema.validate(value) as CandidateScoreResult,
+        requestMetadata: {
+          purpose: 'candidate_scoring',
+          candidateId: request.candidate.id,
+          sourceProfileId: request.sourceProfile?.id,
+          sourceQueryId: request.sourceQuery?.id,
+          promptTemplateKey: rendered.template.key,
+          promptTemplateVersion: rendered.template.version,
+        },
+      });
+
+      return resultFromLlmOutput({
+        output: result.value,
+        metadata: result.metadata,
+        promptTemplate: {
+          key: rendered.template.key,
+          version: rendered.template.version,
+        },
+      });
+    },
+  };
+}
+
+export function scoringLimitFromProfile(profile: SourceProfileRecord | null): number {
+  const config = profile?.config ?? {};
+  const scoringConfig = isRecord(config.scoring) ? config.scoring : {};
+  const raw = config.candidateScoringLimit ?? config.scoringLimit ?? scoringConfig.limit;
+  let parsed: number | undefined;
+
+  if (typeof raw === 'number') {
+    parsed = raw;
+  } else if (typeof raw === 'string') {
+    parsed = Number(raw);
+  }
+
+  if (parsed === undefined || !Number.isInteger(parsed) || parsed < 0) {
+    return 10;
+  }
+
+  return parsed;
+}
+
+function scoringBreakdown(result: CandidateScoringResult): Record<string, unknown> {
+  return {
+    overall: result.overallScore,
+    significance: result.componentScores.significance,
+    showFit: result.componentScores.showFit,
+    novelty: result.componentScores.novelty,
+    sourceQuality: result.componentScores.sourceQuality,
+    urgency: result.componentScores.urgency,
+    components: result.componentScores,
+    rationale: result.rationale,
+    warnings: result.warnings,
+    flags: result.flags,
+    angle: result.angle,
+    verdict: result.verdict,
+    scoringStatus: result.scoringStatus,
+    scorer: result.scorer,
+  };
+}
+
+function scoringMetadata(candidate: StoryCandidateRecord, result: CandidateScoringResult): Record<string, unknown> {
+  return {
+    ...candidate.metadata,
+    scoringStatus: result.scoringStatus,
+    scoring: {
+      status: result.scoringStatus,
+      overallScore: result.overallScore,
+      rationale: result.rationale,
+      warnings: result.warnings,
+      flags: result.flags,
+      angle: result.angle,
+      verdict: result.verdict,
+      scorer: result.scorer,
+    },
+  };
+}
+
+function skippedMetadata(candidate: StoryCandidateRecord, reason: string, now: Date): Record<string, unknown> {
+  return {
+    ...candidate.metadata,
+    scoringStatus: 'skipped',
+    scoring: {
+      status: 'skipped',
+      reason,
+      scoredAt: now.toISOString(),
+    },
+  };
+}
+
+export async function scoreCandidateBatch(options: ScoreCandidateBatchOptions): Promise<CandidateScoringBatchResult> {
+  const limit = options.limit ?? scoringLimitFromProfile(options.sourceProfile);
+  const now = options.now?.() ?? new Date();
+  const events: Array<Record<string, unknown>> = [];
+  const candidates: StoryCandidateRecord[] = [];
+  let scored = 0;
+  let fallback = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const [index, candidate] of options.candidates.entries()) {
+    if (index >= limit) {
+      const reason = `Scoring limit reached (${limit}).`;
+      const updated = await options.store.updateStoryCandidateScoring(candidate.id, {
+        score: null,
+        scoreBreakdown: {
+          scoringStatus: 'skipped',
+          reason,
+        },
+        metadata: skippedMetadata(candidate, reason, now),
+      });
+      skipped += 1;
+      candidates.push(updated ?? candidate);
+      events.push({
+        level: 'info',
+        message: 'Skipped candidate scoring due to configured cap.',
+        candidateId: candidate.id,
+        reason,
+      });
+      continue;
+    }
+
+    const sourceQuery = sourceQueryForCandidate(candidate, options.queries);
+    const input = buildCandidateScoringInput({
+      candidate,
+      show: options.show,
+      sourceProfile: options.sourceProfile,
+      sourceQuery,
+    });
+    const request: CandidateScoringRequest = {
+      input,
+      candidate,
+      show: options.show,
+      sourceProfile: options.sourceProfile,
+      sourceQuery,
+      modelProfile: options.modelProfile,
+    };
+
+    let result: CandidateScoringResult;
+
+    if (!options.scorer) {
+      result = baselineCandidateScore(request, {
+        status: 'fallback',
+        reason: options.modelProfile ? 'candidate scorer runtime is unavailable' : 'no candidate_scorer model profile is configured',
+        now,
+      });
+      fallback += 1;
+      events.push({
+        level: 'warn',
+        message: 'Used deterministic fallback candidate score.',
+        candidateId: candidate.id,
+        reason: result.scorer.fallbackReason,
+      });
+    } else {
+      try {
+        result = await options.scorer.score(request);
+        scored += result.scoringStatus === 'scored' ? 1 : 0;
+        fallback += result.scoringStatus === 'fallback' ? 1 : 0;
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : 'Candidate scorer failed.';
+        result = baselineCandidateScore(request, {
+          status: 'failed',
+          reason,
+          now,
+        });
+        failed += 1;
+        fallback += 1;
+        events.push({
+          level: 'error',
+          message: 'Candidate scoring failed; used deterministic fallback.',
+          candidateId: candidate.id,
+          reason,
+        });
+      }
+    }
+
+    const updated = await options.store.updateStoryCandidateScoring(candidate.id, {
+      score: result.overallScore,
+      scoreBreakdown: scoringBreakdown(result),
+      metadata: scoringMetadata(candidate, result),
+    });
+    candidates.push(updated ?? {
+      ...candidate,
+      score: result.overallScore,
+      scoreBreakdown: scoringBreakdown(result),
+      metadata: scoringMetadata(candidate, result),
+    });
+  }
+
+  return {
+    candidates,
+    scored,
+    fallback,
+    failed,
+    skipped,
+    events,
+  };
+}

--- a/packages/api/src/search/store.ts
+++ b/packages/api/src/search/store.ts
@@ -89,6 +89,13 @@ export interface CreateStoryCandidateInput extends SourceCandidate {
 export interface StoryCandidateListFilter {
   showId: string;
   limit?: number;
+  sort?: 'score' | 'discovered';
+}
+
+export interface UpdateStoryCandidateScoringInput {
+  score: number | null;
+  scoreBreakdown: Record<string, unknown>;
+  metadata: Record<string, unknown>;
 }
 
 export interface SearchJobStore {
@@ -98,5 +105,6 @@ export interface SearchJobStore {
   listJobs(filter?: JobListFilter): Promise<JobRecord[]>;
   listStoryCandidateDedupeKeys(showId: string): Promise<CandidateDedupeKey[]>;
   insertStoryCandidate(input: CreateStoryCandidateInput): Promise<StoryCandidateRecord | undefined>;
+  updateStoryCandidateScoring(id: string, input: UpdateStoryCandidateScoringInput): Promise<StoryCandidateRecord | undefined>;
   listStoryCandidates(filter: StoryCandidateListFilter): Promise<StoryCandidateRecord[]>;
 }

--- a/packages/api/src/sources/db-store.ts
+++ b/packages/api/src/sources/db-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, lte, or } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import {
   approvalEvents,
   createDb,
@@ -29,6 +29,7 @@ import type {
   StoryCandidateListFilter,
   StoryCandidateRecord,
   UpdateJobInput,
+  UpdateStoryCandidateScoringInput,
 } from '../search/store.js';
 import type {
   CreateResearchPacketInput,
@@ -936,11 +937,28 @@ export function createDbSourceStore(connectionString = process.env.DATABASE_URL)
       return row ? mapStoryCandidate(row) : undefined;
     },
 
+    async updateStoryCandidateScoring(id: string, input: UpdateStoryCandidateScoringInput) {
+      const [row] = await db.update(storyCandidates)
+        .set({
+          score: input.score === null ? null : String(input.score),
+          scoreBreakdown: input.scoreBreakdown,
+          metadata: input.metadata,
+          updatedAt: new Date(),
+        })
+        .where(eq(storyCandidates.id, id))
+        .returning();
+
+      return row ? mapStoryCandidate(row) : undefined;
+    },
+
     async listStoryCandidates(filter: StoryCandidateListFilter) {
+      const orderBy = filter.sort === 'discovered'
+        ? [desc(storyCandidates.discoveredAt)]
+        : [sql`${storyCandidates.score} desc nulls last`, desc(storyCandidates.discoveredAt)];
       const rows = await db.select()
         .from(storyCandidates)
         .where(eq(storyCandidates.showId, filter.showId))
-        .orderBy(desc(storyCandidates.discoveredAt))
+        .orderBy(...orderBy)
         .limit(filter.limit ?? 50);
 
       return rows.map(mapStoryCandidate);

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -501,6 +501,20 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
     return candidate;
   }
 
+  async updateStoryCandidateScoring(id: string, input: { score: number | null; scoreBreakdown: Record<string, unknown>; metadata: Record<string, unknown> }) {
+    const candidate = this.candidates.find((item) => item.id === id);
+
+    if (!candidate) {
+      return undefined;
+    }
+
+    candidate.score = input.score;
+    candidate.scoreBreakdown = input.scoreBreakdown;
+    candidate.metadata = input.metadata;
+    candidate.updatedAt = new Date();
+    return candidate;
+  }
+
   async listStoryCandidates(filter: StoryCandidateListFilter) {
     return this.candidates
       .filter((candidate) => candidate.showId === filter.showId)


### PR DESCRIPTION
## Summary
- Adds candidate scoring service using the `candidate_scorer` role, prompt registry, and LLM runtime.
- Persists scoring status, score breakdown, rationale/warnings, suggested angle, and scorer metadata.
- Keeps ingestion resilient with deterministic fallback scoring when scoring fails.
- Exposes score-sorted candidates by default with `sort=discovered` escape hatch.

## Verification
- `npm run check` ✅

Closes #16
