### PR TITLE
feat: build multi-candidate research packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,10 +371,13 @@ URLs, then use the `Ingest RSS` action shown for RSS profiles.
 
 ## Research packets
 
-Selected story candidates can produce deterministic research packets without an
-LLM dependency. The API fetches readable source snapshots into
-`source_documents`, then writes a `research_packets` row with summary content,
-cited claims, citations, and warning objects.
+Selected story candidates can produce evidence-first research packets. The API
+fetches readable source snapshots into `source_documents`, then writes a
+`research_packets` row with source document references, cited claims, citation
+URLs, warning objects, synthesis content, and readiness metadata. When injected
+model runtime support is available, research uses the configured
+`claim_extractor` and `research_synthesizer` roles; otherwise it falls back to
+deterministic packet content from fetched source snapshots.
 
 Build a packet from the candidate URL plus optional extra URLs:
 
@@ -384,9 +387,28 @@ curl -X POST http://localhost:3450/story-candidates/:id/research-packet \
   -d '{"extraUrls":["https://example.org/second-source"]}'
 ```
 
+Build a packet from multiple selected candidates:
+
+```sh
+curl -X POST http://localhost:3450/research-packets \
+  -H 'content-type: application/json' \
+  -d '{
+    "candidateIds":["CANDIDATE_ID_1","CANDIDATE_ID_2"],
+    "angle":"Why this cluster matters now",
+    "extraUrls":["https://example.org/primary-source"]
+  }'
+```
+
+The multi-candidate endpoint validates that all selected candidates exist,
+belong to the same show, and are not ignored. Duplicate candidate IDs and
+duplicate source URLs are recorded as warnings and skipped once. Fetch or model
+failures are persisted in packet/job warnings and never create citations unless
+there is a fetched `source_documents` row behind the claim.
+
 Read and override warnings:
 
 ```sh
+curl "http://localhost:3450/research-packets?showSlug=the-synthetic-lens"
 curl http://localhost:3450/research-packets/:id
 
 curl -X POST http://localhost:3450/research-packets/:id/override-warning \
@@ -397,8 +419,17 @@ curl -X POST http://localhost:3450/research-packets/:id/override-warning \
 Research endpoints:
 
 - `POST /story-candidates/:id/research-packet`
+- `POST /research-packets`
+- `GET /research-packets?showSlug=the-synthetic-lens`
 - `GET /research-packets/:id`
 - `POST /research-packets/:id/override-warning`
+
+Packet `status` is a readiness value: `ready`, `needs_more_sources`, or
+`blocked`. The same object is also available at `content.readiness` with reasons
+and counts such as `independentSourceCount`, `usableSourceCount`, and
+`selectedCandidateCount`. Script generation should consume packet `claims`,
+`citations`, `sourceDocumentIds`, and `warnings`, and should surface non-ready
+or warning-bearing packets for editorial review before production.
 
 ## Script generation workflow
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -19,6 +19,7 @@ import { registerPromptRoutes } from './prompts/routes.js';
 import type { PromptTemplateStore } from './prompts/types.js';
 import { registerResearchRoutes } from './research/routes.js';
 import type { ResearchFetch } from './research/fetch.js';
+import type { ResearchModelServices } from './research/models.js';
 import type { ResearchStore } from './research/store.js';
 import { registerScriptRoutes } from './scripts/routes.js';
 import type { ScriptStore } from './scripts/store.js';
@@ -54,6 +55,7 @@ interface BuildAppOptions extends FastifyServerOptions {
   rssFetchImpl?: RssFetch;
   candidateScorer?: CandidateScorer;
   llmRuntime?: LlmRuntime;
+  researchModelServices?: ResearchModelServices;
   researchFetchImpl?: ResearchFetch;
   audioPreviewProvider?: AudioPreviewProvider;
   coverArtProvider?: CoverArtProvider;
@@ -93,6 +95,7 @@ export function buildApp(options: BuildAppOptions = {}) {
     rssFetchImpl,
     candidateScorer,
     llmRuntime,
+    researchModelServices,
     researchFetchImpl,
     audioPreviewProvider,
     coverArtProvider,
@@ -221,6 +224,8 @@ export function buildApp(options: BuildAppOptions = {}) {
       return resolvedSourceStore;
     },
     fetchImpl: researchFetchImpl,
+    llmRuntime,
+    researchModelServices,
   });
 
   registerScriptRoutes(app, {

--- a/packages/api/src/research/builder.ts
+++ b/packages/api/src/research/builder.ts
@@ -8,6 +8,8 @@ import type {
 } from './store.js';
 
 const MIN_TEXT_LENGTH = 120;
+const MIN_INDEPENDENT_HOSTS = 2;
+const HIGH_STAKES_PATTERN = /\b(lawsuit|court|criminal|security|breach|vulnerability|regulation|regulator|recall|death|injury|sanction|filing|investigation)\b/i;
 
 function hostnameFor(value: string): string | null {
   try {
@@ -26,10 +28,154 @@ function sourceLabel(document: SourceDocumentRecord): string {
   return document.title || hostnameFor(document.canonicalUrl ?? document.url) || document.url;
 }
 
-export function buildResearchPacketInput(
-  candidate: StoryCandidateRecord,
-  documents: SourceDocumentRecord[],
-): CreateResearchPacketInput {
+function candidateSummary(candidates: StoryCandidateRecord[]): string {
+  return candidates
+    .map((candidate) => `${candidate.title}${candidate.summary ? `: ${candidate.summary}` : ''}`)
+    .join(' | ');
+}
+
+function synthesizedTitle(candidates: StoryCandidateRecord[], angle?: string | null): string {
+  if (angle?.trim()) {
+    return angle.trim();
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0].title;
+  }
+
+  return `${candidates[0].title} + ${candidates.length - 1} related source${candidates.length === 2 ? '' : 's'}`;
+}
+
+function uniqueWarnings(warnings: ResearchWarning[]): ResearchWarning[] {
+  const seen = new Set<string>();
+
+  return warnings.filter((warning) => {
+    const key = warning.id || `${warning.code}:${warning.sourceDocumentId ?? ''}:${warning.url ?? ''}`;
+
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function hostCounts(documents: SourceDocumentRecord[]): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const document of documents) {
+    const host = hostnameFor(document.canonicalUrl ?? document.url);
+
+    if (!host) {
+      continue;
+    }
+
+    counts.set(host, (counts.get(host) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+function normalizeClaimSupport(claim: ResearchClaim, documentsById: Map<string, SourceDocumentRecord>): ResearchClaim {
+  const sourceDocumentIds = claim.sourceDocumentIds.filter((id) => documentsById.has(id));
+  const citationUrls = sourceDocumentIds.map((id) => {
+    const document = documentsById.get(id);
+    return document?.canonicalUrl ?? document?.url ?? null;
+  }).filter((value): value is string => Boolean(value));
+  const independentHosts = new Set(citationUrls.map(hostnameFor).filter((value): value is string => Boolean(value)));
+
+  return {
+    ...claim,
+    sourceDocumentIds,
+    citationUrls: [...new Set([...claim.citationUrls.filter((url) => {
+      return citationUrls.includes(url);
+    }), ...citationUrls])],
+    highStakes: claim.highStakes ?? HIGH_STAKES_PATTERN.test(claim.text),
+    supportLevel: claim.supportLevel ?? (independentHosts.size >= MIN_INDEPENDENT_HOSTS ? 'corroborated' : 'single_source'),
+  };
+}
+
+function deterministicClaims(
+  candidates: StoryCandidateRecord[],
+  usableDocuments: SourceDocumentRecord[],
+  providedClaims: ResearchClaim[],
+): ResearchClaim[] {
+  const documentsById = new Map(usableDocuments.map((document) => [document.id, document]));
+  const claims = providedClaims
+    .map((claim) => normalizeClaimSupport(claim, documentsById))
+    .filter((claim) => claim.sourceDocumentIds.length > 0 && claim.citationUrls.length > 0);
+
+  if (claims.length === 0 && usableDocuments.length > 0) {
+    const primaryDocuments = usableDocuments.slice(0, 2);
+    claims.push({
+      id: 'claim-1',
+      text: candidates.length === 1
+        ? candidates[0].summary || `${candidates[0].title} is the selected story candidate for research.`
+        : `Selected candidates cover a related story cluster: ${candidateSummary(candidates)}`,
+      sourceDocumentIds: primaryDocuments.map((document) => document.id),
+      citationUrls: primaryDocuments.map((document) => document.canonicalUrl ?? document.url),
+      claimType: 'fact',
+      confidence: primaryDocuments.length >= MIN_INDEPENDENT_HOSTS ? 'medium' : 'low',
+      supportLevel: primaryDocuments.length >= MIN_INDEPENDENT_HOSTS ? 'corroborated' : 'single_source',
+      highStakes: candidates.some((candidate) => HIGH_STAKES_PATTERN.test(`${candidate.title} ${candidate.summary ?? ''}`)),
+    });
+  }
+
+  for (const document of usableDocuments.slice(0, 3)) {
+    claims.push({
+      id: `claim-${claims.length + 1}`,
+      text: `${sourceLabel(document)} reports: ${firstSentence(document.textContent ?? '')}`,
+      sourceDocumentIds: [document.id],
+      citationUrls: [document.canonicalUrl ?? document.url],
+      claimType: 'fact',
+      confidence: 'medium',
+      supportLevel: 'single_source',
+      highStakes: HIGH_STAKES_PATTERN.test(document.textContent ?? ''),
+    });
+  }
+
+  return claims;
+}
+
+function readinessFor(options: {
+  usableSourceCount: number;
+  independentHostCount: number;
+  warnings: ResearchWarning[];
+}) {
+  const reasons: string[] = [];
+
+  if (options.usableSourceCount === 0) {
+    reasons.push('No fetched source had enough readable text.');
+    return { status: 'blocked', reasons };
+  }
+
+  if (options.independentHostCount < MIN_INDEPENDENT_HOSTS) {
+    reasons.push(`Only ${options.independentHostCount} independent source host(s) are available.`);
+    return { status: 'needs_more_sources', reasons };
+  }
+
+  if (options.warnings.some((warning) => warning.severity === 'error')) {
+    reasons.push('At least one error-level warning requires editorial review.');
+    return { status: 'blocked', reasons };
+  }
+
+  return { status: 'ready', reasons };
+}
+
+export interface BuildResearchPacketInputOptions {
+  candidates: StoryCandidateRecord[];
+  documents: SourceDocumentRecord[];
+  angle?: string | null;
+  warnings?: ResearchWarning[];
+  claims?: ResearchClaim[];
+  synthesis?: Record<string, unknown> | null;
+  modelProfiles?: Record<string, unknown>;
+  modelInvocations?: Record<string, unknown>[];
+}
+
+export function buildResearchPacketInputFromCandidates(options: BuildResearchPacketInputOptions): CreateResearchPacketInput {
+  const { candidates, documents, angle, synthesis } = options;
   const fetchedDocuments = documents.filter((document) => document.fetchStatus === 'fetched');
   const usableDocuments = fetchedDocuments.filter((document) => (document.textContent?.length ?? 0) >= MIN_TEXT_LENGTH);
   const independentHosts = new Set(
@@ -44,7 +190,7 @@ export function buildResearchPacketInput(
     fetchedAt: document.fetchedAt.toISOString(),
     status: document.fetchStatus,
   }));
-  const warnings: ResearchWarning[] = [];
+  const warnings: ResearchWarning[] = [...(options.warnings ?? [])];
 
   for (const document of documents) {
     if (document.fetchStatus !== 'fetched') {
@@ -73,7 +219,19 @@ export function buildResearchPacketInput(
     }
   }
 
-  if (independentHosts.size < 2) {
+  for (const [host, count] of hostCounts(usableDocuments)) {
+    if (count > 1) {
+      warnings.push({
+        id: `DUPLICATE_SOURCE_HOST:${host}`,
+        code: 'DUPLICATE_SOURCE_HOST',
+        severity: 'info',
+        message: `Multiple fetched sources use the same host (${host}); check for syndicated or circular coverage.`,
+        metadata: { host, count },
+      });
+    }
+  }
+
+  if (independentHosts.size < MIN_INDEPENDENT_HOSTS) {
     warnings.push({
       id: 'INSUFFICIENT_INDEPENDENT_SOURCES',
       code: 'INSUFFICIENT_INDEPENDENT_SOURCES',
@@ -81,56 +239,87 @@ export function buildResearchPacketInput(
       message: 'Research packet needs at least two fetched sources from distinct hostnames.',
       metadata: {
         independentHostCount: independentHosts.size,
-        minimumIndependentHosts: 2,
+        minimumIndependentHosts: MIN_INDEPENDENT_HOSTS,
       },
     });
   }
 
-  const primaryCitationUrls = usableDocuments.slice(0, 2).map((document) => document.canonicalUrl ?? document.url);
-  const primarySourceIds = usableDocuments.slice(0, 2).map((document) => document.id);
-  const claims: ResearchClaim[] = [];
+  const claims = deterministicClaims(candidates, usableDocuments, options.claims ?? []);
+  const documentsById = new Map(usableDocuments.map((document) => [document.id, document]));
 
-  if (primarySourceIds.length > 0) {
-    claims.push({
-      id: 'claim-1',
-      text: candidate.summary || `${candidate.title} is the selected story candidate for research.`,
-      sourceDocumentIds: primarySourceIds,
-      citationUrls: primaryCitationUrls,
+  for (const claim of claims) {
+    if (!claim.highStakes) {
+      continue;
+    }
+
+    const hasPrimary = claim.sourceDocumentIds.some((id) => {
+      const metadata = documentsById.get(id)?.metadata ?? {};
+      return metadata.sourceType === 'primary';
     });
+
+    if (!hasPrimary) {
+      warnings.push({
+        id: `HIGH_STAKES_CLAIM_NEEDS_PRIMARY_SOURCE:${claim.id}`,
+        code: 'HIGH_STAKES_CLAIM_NEEDS_PRIMARY_SOURCE',
+        severity: 'warning',
+        message: 'A high-stakes claim does not cite a source marked as primary.',
+        metadata: {
+          claimId: claim.id,
+          sourceDocumentIds: claim.sourceDocumentIds,
+        },
+      });
+    }
   }
 
-  for (const document of usableDocuments.slice(0, 3)) {
-    claims.push({
-      id: `claim-${claims.length + 1}`,
-      text: `${sourceLabel(document)} reports: ${firstSentence(document.textContent ?? '')}`,
-      sourceDocumentIds: [document.id],
-      citationUrls: [document.canonicalUrl ?? document.url],
-    });
-  }
-
+  const finalWarnings = uniqueWarnings(warnings);
+  const readiness = readinessFor({
+    usableSourceCount: usableDocuments.length,
+    independentHostCount: independentHosts.size,
+    warnings: finalWarnings,
+  });
   const sourceSummary = usableDocuments.length > 0
     ? usableDocuments.map(sourceLabel).join('; ')
     : 'No fetched sources had enough readable text.';
-  const summary = [
-    `Research packet for "${candidate.title}".`,
-    candidate.summary ? `Candidate summary: ${candidate.summary}` : undefined,
-    `Usable sources: ${sourceSummary}`,
-  ].filter(Boolean).join(' ');
+  const summary = typeof synthesis?.summary === 'string'
+    ? synthesis.summary
+    : [
+      `Research packet for "${synthesizedTitle(candidates, angle)}".`,
+      `Candidate summary: ${candidateSummary(candidates)}`,
+      `Usable sources: ${sourceSummary}`,
+    ].filter(Boolean).join(' ');
 
   return {
-    showId: candidate.showId,
+    showId: candidates[0].showId,
     episodeCandidateId: null,
-    title: candidate.title,
-    status: warnings.length > 0 ? 'needs-review' : 'ready',
+    title: typeof synthesis?.title === 'string' ? synthesis.title : synthesizedTitle(candidates, angle),
+    status: readiness.status,
     sourceDocumentIds: documents.map((document) => document.id),
     claims,
     citations,
-    warnings,
+    warnings: finalWarnings,
     content: {
-      storyCandidateId: candidate.id,
+      candidateIds: candidates.map((candidate) => candidate.id),
+      storyCandidateId: candidates.length === 1 ? candidates[0].id : undefined,
+      angle: angle ?? null,
       summary,
+      synthesis: synthesis ?? null,
+      knownFacts: Array.isArray(synthesis?.knownFacts) ? synthesis.knownFacts : claims.map((claim) => claim.text),
+      openQuestions: Array.isArray(synthesis?.openQuestions) ? synthesis.openQuestions : finalWarnings.map((warning) => warning.message),
       independentHostCount: independentHosts.size,
+      independentSourceCount: independentHosts.size,
       usableSourceCount: usableDocuments.length,
+      fetchedSourceCount: fetchedDocuments.length,
+      selectedCandidateCount: candidates.length,
+      readiness,
+      modelProfiles: options.modelProfiles ?? {},
+      modelInvocations: options.modelInvocations ?? [],
     },
   };
+}
+
+export function buildResearchPacketInput(
+  candidate: StoryCandidateRecord,
+  documents: SourceDocumentRecord[],
+): CreateResearchPacketInput {
+  return buildResearchPacketInputFromCandidates({ candidates: [candidate], documents });
 }

--- a/packages/api/src/research/models.ts
+++ b/packages/api/src/research/models.ts
@@ -1,0 +1,269 @@
+import type { LlmInvocationMetadata, LlmRuntime } from '../llm/types.js';
+import type { ResolvedModelProfile } from '../models/resolver.js';
+import { PROMPT_OUTPUT_SCHEMAS, type ExtractedClaimsResult, type ResearchSynthesisResult } from '../prompts/schemas.js';
+import { renderPromptTemplate } from '../prompts/renderer.js';
+import type { PromptRegistry } from '../prompts/types.js';
+import type { StoryCandidateRecord } from '../search/store.js';
+import type { ResearchClaim, ResearchWarning, SourceDocumentRecord } from './store.js';
+
+export interface ResearchModelServices {
+  extractClaims(input: {
+    showId: string;
+    candidates: StoryCandidateRecord[];
+    documents: SourceDocumentRecord[];
+    modelProfile?: ResolvedModelProfile;
+  }): Promise<ResearchModelClaimResult>;
+  synthesize(input: {
+    showId: string;
+    candidates: StoryCandidateRecord[];
+    documents: SourceDocumentRecord[];
+    claims: ResearchClaim[];
+    warnings: ResearchWarning[];
+    angle?: string | null;
+    modelProfile?: ResolvedModelProfile;
+  }): Promise<ResearchModelSynthesisResult>;
+}
+
+export interface ResearchModelClaimResult {
+  claims: ResearchClaim[];
+  warnings: ResearchWarning[];
+  invocations: LlmInvocationMetadata[];
+}
+
+export interface ResearchModelSynthesisResult {
+  synthesis: Record<string, unknown> | null;
+  claims: ResearchClaim[];
+  warnings: ResearchWarning[];
+  invocations: LlmInvocationMetadata[];
+}
+
+interface CreateLlmResearchModelServicesOptions {
+  runtime: LlmRuntime;
+  promptRegistry: PromptRegistry;
+}
+
+function documentUrl(document: SourceDocumentRecord): string {
+  return document.canonicalUrl ?? document.url;
+}
+
+function sourceSummary(document: SourceDocumentRecord): Record<string, unknown> {
+  return {
+    sourceDocumentId: document.id,
+    title: document.title ?? documentUrl(document),
+    url: documentUrl(document),
+    fetchStatus: document.fetchStatus,
+    httpStatus: document.httpStatus,
+    excerpt: (document.textContent ?? '').slice(0, 4_000),
+    metadata: document.metadata,
+  };
+}
+
+function candidateContext(candidates: StoryCandidateRecord[]): Array<Record<string, unknown>> {
+  return candidates.map((candidate) => ({
+    id: candidate.id,
+    title: candidate.title,
+    url: candidate.canonicalUrl ?? candidate.url,
+    sourceName: candidate.sourceName,
+    summary: candidate.summary,
+    publishedAt: candidate.publishedAt?.toISOString() ?? null,
+    status: candidate.status,
+    score: candidate.score,
+  }));
+}
+
+function warningFromModel(input: {
+  id: string;
+  code: string;
+  message: string;
+  sourceDocumentId?: string;
+  metadata?: Record<string, unknown>;
+}): ResearchWarning {
+  return {
+    id: input.id,
+    code: input.code,
+    severity: 'warning',
+    message: input.message,
+    sourceDocumentId: input.sourceDocumentId,
+    metadata: input.metadata,
+  };
+}
+
+function warningFromPromptWarning(input: {
+  index: number;
+  stage: 'claim_extractor' | 'research_synthesizer';
+  warning: { code: string; message: string; severity: 'info' | 'warning' | 'critical'; sourceDocumentId?: string; metadata?: Record<string, unknown> };
+}): ResearchWarning {
+  return {
+    id: `MODEL_WARNING:${input.stage}:${input.index}:${input.warning.code}`,
+    code: input.warning.code,
+    severity: input.warning.severity === 'critical' ? 'error' : input.warning.severity,
+    message: input.warning.message,
+    sourceDocumentId: input.warning.sourceDocumentId,
+    metadata: {
+      ...input.warning.metadata,
+      modelStage: input.stage,
+    },
+  };
+}
+
+function normalizeClaimsFromExtraction(
+  output: ExtractedClaimsResult,
+  document: SourceDocumentRecord,
+): ResearchClaim[] {
+  return output.claims.map((claim, index) => ({
+    id: claim.id || `model-claim-${document.id}-${index + 1}`,
+    text: claim.text,
+    sourceDocumentIds: [document.id],
+    citationUrls: [documentUrl(document)],
+    claimType: claim.claimType,
+    confidence: claim.confidence,
+    supportLevel: 'single_source',
+    highStakes: false,
+    caveat: claim.caveat,
+  }));
+}
+
+function normalizeClaimsFromSynthesis(
+  output: ResearchSynthesisResult,
+  validDocumentIds: Set<string>,
+  documentsById: Map<string, SourceDocumentRecord>,
+): ResearchClaim[] {
+  return output.claims
+    .map((claim, index) => {
+      const sourceDocumentIds = claim.sourceDocumentIds.filter((id) => validDocumentIds.has(id));
+      const citationUrls = sourceDocumentIds.map((id) => documentUrl(documentsById.get(id)!));
+
+      return {
+        id: claim.id || `synthesis-claim-${index + 1}`,
+        text: claim.text,
+        sourceDocumentIds,
+        citationUrls,
+        claimType: claim.claimType,
+        confidence: claim.confidence,
+        supportLevel: sourceDocumentIds.length > 1 ? 'corroborated' : 'single_source',
+        highStakes: false,
+        caveat: claim.caveat,
+      } satisfies ResearchClaim;
+    })
+    .filter((claim) => claim.sourceDocumentIds.length > 0 && claim.citationUrls.length > 0);
+}
+
+export function createLlmResearchModelServices(options: CreateLlmResearchModelServicesOptions): ResearchModelServices {
+  return {
+    async extractClaims(input) {
+      if (!input.modelProfile) {
+        return { claims: [], warnings: [], invocations: [] };
+      }
+
+      const claims: ResearchClaim[] = [];
+      const warnings: ResearchWarning[] = [];
+      const invocations: LlmInvocationMetadata[] = [];
+      const usableDocuments = input.documents.filter((document) => document.fetchStatus === 'fetched' && (document.textContent?.trim().length ?? 0) > 0);
+
+      for (const document of usableDocuments) {
+        try {
+          const rendered = await renderPromptTemplate(options.promptRegistry, {
+            key: input.modelProfile.promptTemplateKey ?? undefined,
+            role: input.modelProfile.promptTemplateKey ? undefined : 'claim_extractor',
+            showId: input.showId,
+            variables: {
+              source_summary: sourceSummary(document),
+              source_document: sourceSummary(document),
+            },
+          });
+          const schema = PROMPT_OUTPUT_SCHEMAS.extracted_claims;
+          const result = await options.runtime.generateJson<ExtractedClaimsResult>({
+            profile: input.modelProfile,
+            messages: rendered.messages,
+            schemaName: rendered.responseFormat.schemaName ?? schema.name,
+            schemaHint: rendered.responseFormat.schemaHint ?? schema.schemaHint,
+            validate: (value) => schema.validate(value) as ExtractedClaimsResult,
+            requestMetadata: {
+              purpose: 'research_claim_extraction',
+              sourceDocumentId: document.id,
+              promptTemplateKey: rendered.template.key,
+              promptTemplateVersion: rendered.template.version,
+            },
+          });
+
+          invocations.push(result.metadata);
+          claims.push(...normalizeClaimsFromExtraction(result.value, document));
+          warnings.push(...result.value.warnings.map((warning, index) => {
+            return warningFromPromptWarning({ stage: 'claim_extractor', warning, index });
+          }));
+        } catch (error) {
+          warnings.push(warningFromModel({
+            id: `MODEL_CLAIM_EXTRACTION_FAILED:${document.id}`,
+            code: 'MODEL_CLAIM_EXTRACTION_FAILED',
+            message: error instanceof Error ? error.message : 'Claim extraction model failed.',
+            sourceDocumentId: document.id,
+          }));
+        }
+      }
+
+      return { claims, warnings, invocations };
+    },
+
+    async synthesize(input) {
+      if (!input.modelProfile) {
+        return { synthesis: null, claims: [], warnings: [], invocations: [] };
+      }
+
+      try {
+        const rendered = await renderPromptTemplate(options.promptRegistry, {
+          key: input.modelProfile.promptTemplateKey ?? undefined,
+          role: input.modelProfile.promptTemplateKey ? undefined : 'research_synthesizer',
+          showId: input.showId,
+          variables: {
+            candidate_json: {
+              candidates: candidateContext(input.candidates),
+              angle: input.angle ?? null,
+            },
+            source_summaries: input.documents.map(sourceSummary),
+            claims: input.claims,
+          },
+        });
+        const schema = PROMPT_OUTPUT_SCHEMAS.research_synthesis;
+        const result = await options.runtime.generateJson<ResearchSynthesisResult>({
+          profile: input.modelProfile,
+          messages: rendered.messages,
+          schemaName: rendered.responseFormat.schemaName ?? schema.name,
+          schemaHint: rendered.responseFormat.schemaHint ?? schema.schemaHint,
+          validate: (value) => schema.validate(value) as ResearchSynthesisResult,
+          requestMetadata: {
+            purpose: 'research_synthesis',
+            candidateIds: input.candidates.map((candidate) => candidate.id),
+            promptTemplateKey: rendered.template.key,
+            promptTemplateVersion: rendered.template.version,
+          },
+        });
+        const documentsById = new Map(input.documents.map((document) => [document.id, document]));
+        const validDocumentIds = new Set(
+          input.documents
+            .filter((document) => document.fetchStatus === 'fetched')
+            .map((document) => document.id),
+        );
+
+        return {
+          synthesis: result.value as unknown as Record<string, unknown>,
+          claims: normalizeClaimsFromSynthesis(result.value, validDocumentIds, documentsById),
+          warnings: result.value.warnings.map((warning, index) => {
+            return warningFromPromptWarning({ stage: 'research_synthesizer', warning, index });
+          }),
+          invocations: [result.metadata],
+        };
+      } catch (error) {
+        return {
+          synthesis: null,
+          claims: [],
+          warnings: [warningFromModel({
+            id: 'MODEL_RESEARCH_SYNTHESIS_FAILED',
+            code: 'MODEL_RESEARCH_SYNTHESIS_FAILED',
+            message: error instanceof Error ? error.message : 'Research synthesis model failed.',
+          })],
+          invocations: [],
+        };
+      }
+    },
+  };
+}

--- a/packages/api/src/research/routes.ts
+++ b/packages/api/src/research/routes.ts
@@ -4,11 +4,15 @@ import { z, ZodError } from 'zod';
 import { canonicalizeUrl } from '../search/candidate.js';
 import { modelProfileMap, hasModelProfileStore, resolveModelProfile } from '../models/resolver.js';
 import type { ModelProfileStore } from '../models/store.js';
+import type { LlmRuntime } from '../llm/types.js';
+import { createPromptRegistry } from '../prompts/registry.js';
+import type { PromptTemplateStore } from '../prompts/types.js';
 import type { CreateJobInput, JobRecord, SearchJobStore, UpdateJobInput } from '../search/store.js';
 import type { ResearchFetch } from './fetch.js';
 import { fetchSourceSnapshot } from './fetch.js';
-import { buildResearchPacketInput } from './builder.js';
-import type { ResearchStore } from './store.js';
+import { buildResearchPacketInputFromCandidates } from './builder.js';
+import { createLlmResearchModelServices, type ResearchModelServices } from './models.js';
+import type { ResearchStore, ResearchWarning } from './store.js';
 
 class ApiError extends Error {
   constructor(
@@ -21,12 +25,20 @@ class ApiError extends Error {
 }
 
 export interface ResearchRoutesOptions {
-  getStore(): Partial<ResearchStore> & Partial<SearchJobStore> & Partial<ModelProfileStore>;
+  getStore(): Partial<ResearchStore> & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<PromptTemplateStore>;
   fetchImpl?: ResearchFetch;
+  llmRuntime?: LlmRuntime;
+  researchModelServices?: ResearchModelServices;
 }
 
 const createPacketSchema = z.object({
   extraUrls: z.array(z.string().trim().url()).max(10).default([]),
+});
+
+const createMultiCandidatePacketSchema = z.object({
+  candidateIds: z.array(z.string().trim().min(1)).min(1).max(20),
+  extraUrls: z.array(z.string().trim().url()).max(10).default([]),
+  angle: z.string().trim().min(1).max(500).nullable().optional(),
 });
 
 const overrideWarningSchema = z.object({
@@ -66,6 +78,7 @@ function requireResearchStore(store: Partial<ResearchStore>): ResearchStore {
     'createSourceDocument',
     'createResearchPacket',
     'getResearchPacket',
+    'listResearchPackets',
     'overrideResearchWarning',
   ];
 
@@ -111,71 +124,167 @@ async function updateResearchJob(
   return store.updateJob(id, input);
 }
 
-function sourceUrlsFor(candidate: { url: string | null; canonicalUrl: string | null }, extraUrls: string[]): string[] {
-  const urls = [candidate.canonicalUrl, candidate.url, ...extraUrls].filter((value): value is string => Boolean(value));
+function sourceInputsFor(
+  candidates: Array<{ id: string; url: string | null; canonicalUrl: string | null }>,
+  extraUrls: string[],
+): { sources: Array<{ url: string; storyCandidateId: string | null }>; warnings: ResearchWarning[] } {
+  const urls = [
+    ...candidates.flatMap((candidate) => {
+      return [candidate.canonicalUrl, candidate.url]
+        .filter((value): value is string => Boolean(value))
+        .map((url) => ({ url, storyCandidateId: candidate.id }));
+    }),
+    ...extraUrls.map((url) => ({ url, storyCandidateId: null })),
+  ];
   const seen = new Set<string>();
-  const result: string[] = [];
+  const sources: Array<{ url: string; storyCandidateId: string | null }> = [];
+  const warnings: ResearchWarning[] = [];
 
-  for (const url of urls) {
-    const key = canonicalizeUrl(url);
+  for (const source of urls) {
+    const key = canonicalizeUrl(source.url);
 
     if (seen.has(key)) {
+      warnings.push({
+        id: `DUPLICATE_SOURCE_URL:${key}`,
+        code: 'DUPLICATE_SOURCE_URL',
+        severity: 'info',
+        message: `Duplicate source URL skipped: ${source.url}`,
+        url: source.url,
+        metadata: { canonicalUrl: key },
+      });
       continue;
     }
 
     seen.add(key);
-    result.push(url);
+    sources.push(source);
   }
 
-  return result;
+  return { sources, warnings };
+}
+
+function duplicatedValues(values: string[]): string[] {
+  const seen = new Set<string>();
+  const duplicated = new Set<string>();
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicated.add(value);
+    }
+
+    seen.add(value);
+  }
+
+  return [...duplicated];
+}
+
+async function selectedCandidates(
+  store: ResearchStore,
+  candidateIds: string[],
+) {
+  const duplicateIds = duplicatedValues(candidateIds);
+  const uniqueIds = [...new Set(candidateIds)];
+  const candidates = await Promise.all(uniqueIds.map(async (id) => {
+    const candidate = await store.getStoryCandidate(id);
+
+    if (!candidate) {
+      throw new ApiError(404, 'STORY_CANDIDATE_NOT_FOUND', `Story candidate not found: ${id}`);
+    }
+
+    if (candidate.status === 'ignored') {
+      throw new ApiError(400, 'STORY_CANDIDATE_IGNORED', `Ignored story candidate cannot be used for research: ${id}`);
+    }
+
+    return candidate;
+  }));
+  const showIds = new Set(candidates.map((candidate) => candidate.showId));
+
+  if (showIds.size > 1) {
+    throw new ApiError(400, 'CANDIDATE_SHOW_MISMATCH', 'All story candidates in a research packet must belong to the same show.');
+  }
+
+  const warnings = duplicateIds.map((id): ResearchWarning => ({
+    id: `DUPLICATE_CANDIDATE_ID:${id}`,
+    code: 'DUPLICATE_CANDIDATE_ID',
+    severity: 'info',
+    message: `Duplicate candidate ID was provided once and ignored on repeat: ${id}`,
+    metadata: { candidateId: id },
+  }));
+
+  return { candidates, warnings, duplicateIds, uniqueIds };
+}
+
+function researchModelsFor(options: ResearchRoutesOptions, store: Partial<PromptTemplateStore>): ResearchModelServices | undefined {
+  if (options.researchModelServices) {
+    return options.researchModelServices;
+  }
+
+  if (!options.llmRuntime) {
+    return undefined;
+  }
+
+  return createLlmResearchModelServices({
+    runtime: options.llmRuntime,
+    promptRegistry: createPromptRegistry({ store }),
+  });
+}
+
+function modelFailureWarning(code: string, message: string): ResearchWarning {
+  return {
+    id: `${code}:research.packet`,
+    code,
+    severity: 'warning',
+    message,
+  };
 }
 
 export function registerResearchRoutes(app: FastifyInstance, options: ResearchRoutesOptions) {
-  app.post<{ Params: { id: string } }>('/story-candidates/:id/research-packet', async (request, reply) => {
+  async function createPacket(
+    rawStore: Partial<ResearchStore> & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<PromptTemplateStore>,
+    input: { candidateIds: string[]; extraUrls: string[]; angle?: string | null },
+  ) {
     let job: JobRecord | undefined;
     let jobStore: Pick<SearchJobStore, 'createJob' | 'updateJob'> | undefined;
     const logs: Array<Record<string, unknown>> = [];
 
     try {
-      const rawStore = options.getStore();
       const store = requireResearchStore(rawStore);
-      const body = createPacketSchema.parse(request.body ?? {});
-      const candidate = await store.getStoryCandidate(request.params.id);
-
-      if (!candidate) {
-        throw new ApiError(404, 'STORY_CANDIDATE_NOT_FOUND', `Story candidate not found: ${request.params.id}`);
-      }
-
-      const urls = sourceUrlsFor(candidate, body.extraUrls);
+      const selection = await selectedCandidates(store, input.candidateIds);
+      const candidates = selection.candidates;
+      const showId = candidates[0].showId;
+      const sourceInput = sourceInputsFor(candidates, input.extraUrls);
+      const warnings = [...selection.warnings, ...sourceInput.warnings];
       const modelProfiles = hasModelProfileStore(rawStore)
         ? modelProfileMap(await Promise.all([
-          resolveModelProfile(rawStore, { showId: candidate.showId, role: 'source_summarizer' }),
-          resolveModelProfile(rawStore, { showId: candidate.showId, role: 'claim_extractor' }),
-          resolveModelProfile(rawStore, { showId: candidate.showId, role: 'research_synthesizer' }),
+          resolveModelProfile(rawStore, { showId, role: 'source_summarizer' }),
+          resolveModelProfile(rawStore, { showId, role: 'claim_extractor' }),
+          resolveModelProfile(rawStore, { showId, role: 'research_synthesizer' }),
         ]))
         : {};
 
-      if (urls.length === 0) {
-        throw new ApiError(400, 'SOURCE_URL_REQUIRED', 'Candidate has no URL and no extraUrls were provided.');
+      if (sourceInput.sources.length === 0) {
+        throw new ApiError(400, 'SOURCE_URL_REQUIRED', 'Selected candidates have no URLs and no extraUrls were provided.');
       }
 
       logs.push(log('info', 'Starting research.packet job.', {
-        storyCandidateId: candidate.id,
-        sourceUrlCount: urls.length,
+        candidateIds: candidates.map((candidate) => candidate.id),
+        sourceUrlCount: sourceInput.sources.length,
         modelRoles: Object.keys(modelProfiles),
       }));
 
       if (hasResearchJobStore(rawStore)) {
         jobStore = rawStore;
         job = await createResearchJob(rawStore, {
-          showId: candidate.showId,
+          showId,
           type: 'research.packet',
           status: 'running',
           progress: 0,
           attempts: 1,
           input: {
-            storyCandidateId: candidate.id,
-            extraUrls: body.extraUrls,
+            candidateIds: input.candidateIds,
+            selectedCandidateIds: candidates.map((candidate) => candidate.id),
+            duplicateCandidateIds: selection.duplicateIds,
+            extraUrls: input.extraUrls,
+            angle: input.angle ?? null,
             modelProfiles,
           },
           logs,
@@ -183,8 +292,8 @@ export function registerResearchRoutes(app: FastifyInstance, options: ResearchRo
         });
       }
 
-      const documentInputs = await Promise.all(urls.map((url) => {
-        return fetchSourceSnapshot(candidate.id, url, options.fetchImpl);
+      const documentInputs = await Promise.all(sourceInput.sources.map((source) => {
+        return fetchSourceSnapshot(source.storyCandidateId, source.url, options.fetchImpl);
       }));
       const documents = [];
 
@@ -192,18 +301,71 @@ export function registerResearchRoutes(app: FastifyInstance, options: ResearchRo
         documents.push(await store.createSourceDocument(input));
       }
 
-      const packetInput = buildResearchPacketInput(candidate, documents);
-      const packet = await store.createResearchPacket({
-        ...packetInput,
-        content: {
-          ...packetInput.content,
-          modelProfiles,
-        },
+      const modelServices = researchModelsFor(options, rawStore);
+      let extracted = { claims: [], warnings: [], invocations: [] } as Awaited<ReturnType<ResearchModelServices['extractClaims']>>;
+      let synthesized = { synthesis: null, claims: [], warnings: [], invocations: [] } as Awaited<ReturnType<ResearchModelServices['synthesize']>>;
+
+      if (modelServices) {
+        try {
+          extracted = await modelServices.extractClaims({
+            showId,
+            candidates,
+            documents,
+            modelProfile: modelProfiles.claim_extractor,
+          });
+        } catch (error) {
+          extracted = {
+            claims: [],
+            warnings: [modelFailureWarning(
+              'MODEL_CLAIM_EXTRACTION_FAILED',
+              error instanceof Error ? error.message : 'Claim extraction model failed.',
+            )],
+            invocations: [],
+          };
+        }
+
+        try {
+          synthesized = await modelServices.synthesize({
+            showId,
+            candidates,
+            documents,
+            claims: extracted.claims,
+            warnings: [...warnings, ...extracted.warnings],
+            angle: input.angle,
+            modelProfile: modelProfiles.research_synthesizer,
+          });
+        } catch (error) {
+          synthesized = {
+            synthesis: null,
+            claims: [],
+            warnings: [modelFailureWarning(
+              'MODEL_RESEARCH_SYNTHESIS_FAILED',
+              error instanceof Error ? error.message : 'Research synthesis model failed.',
+            )],
+            invocations: [],
+          };
+        }
+      }
+      const packetInput = buildResearchPacketInputFromCandidates({
+        candidates,
+        documents,
+        angle: input.angle,
+        warnings: [...warnings, ...extracted.warnings, ...synthesized.warnings],
+        claims: [...extracted.claims, ...synthesized.claims],
+        synthesis: synthesized.synthesis,
+        modelProfiles,
+        modelInvocations: [...extracted.invocations, ...synthesized.invocations].map((invocation) => {
+          return invocation as unknown as Record<string, unknown>;
+        }),
       });
+      const packet = await store.createResearchPacket(packetInput);
+      const failedDocuments = documents.filter((document) => document.fetchStatus !== 'fetched');
 
       logs.push(log('info', 'Completed research.packet job.', {
         researchPacketId: packet.id,
         sourceDocumentCount: documents.length,
+        warningCount: packet.warnings.length,
+        readinessStatus: packet.status,
       }));
       if (jobStore && job) {
         job = await updateResearchJob(jobStore, job.id, {
@@ -213,13 +375,18 @@ export function registerResearchRoutes(app: FastifyInstance, options: ResearchRo
           output: {
             researchPacketId: packet.id,
             sourceDocumentIds: documents.map((document) => document.id),
+            fetchedSourceDocumentIds: documents.filter((document) => document.fetchStatus === 'fetched').map((document) => document.id),
+            failedSourceDocumentIds: failedDocuments.map((document) => document.id),
             modelProfiles,
+            warnings: packet.warnings,
+            warningCount: packet.warnings.length,
+            readiness: packet.content.readiness,
           },
           finishedAt: new Date(),
         }) ?? job;
       }
 
-      return reply.code(201).send({ ok: true, job, researchPacket: packet, sourceDocuments: documents });
+      return { job, researchPacket: packet, sourceDocuments: documents };
     } catch (error) {
       if (jobStore && job) {
         const message = error instanceof Error ? error.message : 'Research packet generation failed.';
@@ -233,6 +400,55 @@ export function registerResearchRoutes(app: FastifyInstance, options: ResearchRo
         }) ?? job;
       }
 
+      throw error;
+    }
+  }
+
+  app.post<{ Params: { id: string } }>('/story-candidates/:id/research-packet', async (request, reply) => {
+    try {
+      const body = createPacketSchema.parse(request.body ?? {});
+      const result = await createPacket(options.getStore(), {
+        candidateIds: [request.params.id],
+        extraUrls: body.extraUrls,
+      });
+
+      return reply.code(201).send({ ok: true, ...result });
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.post('/research-packets', async (request, reply) => {
+    try {
+      const body = createMultiCandidatePacketSchema.parse(request.body ?? {});
+      const result = await createPacket(options.getStore(), {
+        candidateIds: body.candidateIds,
+        extraUrls: body.extraUrls,
+        angle: body.angle,
+      });
+
+      return reply.code(201).send({ ok: true, ...result });
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.get<{ Querystring: { showSlug?: string; limit?: string } }>('/research-packets', async (request, reply) => {
+    try {
+      const store = requireResearchStore(options.getStore());
+      const limit = request.query.limit ? Number(request.query.limit) : undefined;
+
+      if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 200)) {
+        throw new ApiError(400, 'INVALID_LIMIT', 'limit must be an integer from 1 to 200.');
+      }
+
+      const packets = await store.listResearchPackets({
+        showSlug: request.query.showSlug,
+        limit,
+      });
+
+      return { ok: true, researchPackets: packets };
+    } catch (error) {
       return sendError(reply, error);
     }
   });

--- a/packages/api/src/research/store.ts
+++ b/packages/api/src/research/store.ts
@@ -38,6 +38,11 @@ export interface ResearchClaim {
   text: string;
   sourceDocumentIds: string[];
   citationUrls: string[];
+  claimType?: 'fact' | 'quote' | 'interpretation' | 'uncertain';
+  confidence?: 'low' | 'medium' | 'high';
+  supportLevel?: 'single_source' | 'corroborated' | 'uncorroborated' | 'contradicted' | 'unknown';
+  highStakes?: boolean;
+  caveat?: string;
 }
 
 export interface ResearchCitation {
@@ -96,10 +101,17 @@ export interface OverrideResearchWarningInput {
   reason: string;
 }
 
+export interface ResearchPacketListFilter {
+  showId?: string;
+  showSlug?: string;
+  limit?: number;
+}
+
 export interface ResearchStore {
   getStoryCandidate(id: string): Promise<StoryCandidateRecord | undefined>;
   createSourceDocument(input: CreateSourceDocumentInput): Promise<SourceDocumentRecord>;
   createResearchPacket(input: CreateResearchPacketInput): Promise<ResearchPacketRecord>;
   getResearchPacket(id: string): Promise<ResearchPacketRecord | undefined>;
+  listResearchPackets(filter?: ResearchPacketListFilter): Promise<ResearchPacketRecord[]>;
   overrideResearchWarning(id: string, input: OverrideResearchWarningInput): Promise<ResearchPacketRecord | undefined>;
 }

--- a/packages/api/src/sources/db-store.ts
+++ b/packages/api/src/sources/db-store.ts
@@ -37,6 +37,7 @@ import type {
   OverrideResearchWarningInput,
   ResearchCitation,
   ResearchClaim,
+  ResearchPacketListFilter,
   ResearchPacketRecord,
   ResearchStore,
   ResearchWarning,
@@ -1005,6 +1006,31 @@ export function createDbSourceStore(connectionString = process.env.DATABASE_URL)
     async getResearchPacket(id: string) {
       const [row] = await db.select().from(researchPackets).where(eq(researchPackets.id, id)).limit(1);
       return row ? mapResearchPacket(row) : undefined;
+    },
+
+    async listResearchPackets(filter: ResearchPacketListFilter = {}) {
+      let showId = filter.showId;
+
+      if (!showId && filter.showSlug) {
+        const [show] = await db.select().from(shows).where(eq(shows.slug, filter.showSlug)).limit(1);
+
+        if (!show) {
+          return [];
+        }
+
+        showId = show.id;
+      }
+
+      const rows = showId
+        ? await db.select().from(researchPackets)
+          .where(eq(researchPackets.showId, showId))
+          .orderBy(desc(researchPackets.updatedAt))
+          .limit(filter.limit ?? 50)
+        : await db.select().from(researchPackets)
+          .orderBy(desc(researchPackets.updatedAt))
+          .limit(filter.limit ?? 50);
+
+      return rows.map(mapResearchPacket);
     },
 
     async overrideResearchWarning(id: string, input: OverrideResearchWarningInput) {

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -35,10 +35,13 @@ import type {
   CreateResearchPacketInput,
   CreateSourceDocumentInput,
   OverrideResearchWarningInput,
+  ResearchPacketListFilter,
   ResearchPacketRecord,
   ResearchStore,
+  ResearchWarning,
   SourceDocumentRecord,
 } from '../research/store.js';
+import type { ResearchModelServices } from '../research/models.js';
 import type {
   ApproveScriptRevisionInput,
   CreateScriptRevisionInput,
@@ -569,6 +572,15 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
     return this.researchPackets.find((packet) => packet.id === id);
   }
 
+  async listResearchPackets(filter: ResearchPacketListFilter = {}) {
+    const showId = filter.showId
+      ?? (filter.showSlug ? this.shows.find((show) => show.slug === filter.showSlug)?.id : undefined);
+
+    return this.researchPackets
+      .filter((packet) => !showId || packet.showId === showId)
+      .slice(0, filter.limit ?? 50);
+  }
+
   async overrideResearchWarning(id: string, input: OverrideResearchWarningInput) {
     const packet = await this.getResearchPacket(id);
 
@@ -871,12 +883,64 @@ const researchFetch: ResearchFetch = async (url) => {
     },
   };
 };
+const researchModelServices: ResearchModelServices = {
+  async extractClaims(input) {
+    if (input.documents.some((document) => document.url.includes('model-failure'))) {
+      throw new Error('Fake claim extractor failed.');
+    }
+
+    const claims = input.documents
+      .filter((document) => document.fetchStatus === 'fetched')
+      .map((document, index) => ({
+        id: `model-claim-${index + 1}`,
+        text: `${document.title ?? document.url} supports the selected story cluster.`,
+        sourceDocumentIds: [document.id],
+        citationUrls: [document.canonicalUrl ?? document.url],
+        claimType: 'fact' as const,
+        confidence: 'high' as const,
+        supportLevel: 'single_source' as const,
+        highStakes: false,
+      }));
+
+    return {
+      claims,
+      warnings: [],
+      invocations: [],
+    };
+  },
+
+  async synthesize(input) {
+    const warnings: ResearchWarning[] = input.documents.some((document) => document.url.includes('model-warning'))
+      ? [{
+        id: 'MODEL_SYNTHESIS_WARNING:test',
+        code: 'MODEL_SYNTHESIS_WARNING',
+        severity: 'warning',
+        message: 'Fake synthesizer flagged a model warning for test coverage.',
+      }]
+      : [];
+
+    return {
+      synthesis: {
+        title: input.angle ?? input.candidates[0].title,
+        summary: `Synthesis for ${input.candidates.map((candidate) => candidate.title).join(' and ')}.`,
+        knownFacts: input.claims.map((claim) => claim.text),
+        openQuestions: warnings.map((warning) => warning.message),
+        sourceDocumentIds: input.documents.map((document) => document.id),
+        editorialAngle: input.angle ?? null,
+      },
+      claims: [],
+      warnings,
+      invocations: [],
+    };
+  },
+};
 const app = buildApp({
   sourceStore: store,
   braveApiKey: 'test-brave-key',
   fetchImpl: braveFetch,
   rssFetchImpl: rssFetch,
   researchFetchImpl: researchFetch,
+  researchModelServices,
   publishStorageAdapterFactory,
   rssUpdateAdapter,
   publishUrlValidator,
@@ -1299,6 +1363,189 @@ describe('source profile routes', () => {
     assert.equal(overrideResponse.statusCode, 200);
     assert.equal(overriddenWarning.override.actor, 'editor@example.com');
     assert.match(overriddenWarning.override.reason, /two independent sources/);
+  });
+
+  it('builds a research packet from multiple candidates with model warnings and readiness metadata', async () => {
+    const firstResponse = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/manual',
+      payload: {
+        showSlug: 'the-synthetic-lens',
+        url: 'https://manual.example.com/news/multi-one',
+        title: 'Multi Candidate One',
+        summary: 'The first selected candidate has evidence.',
+      },
+    });
+    const secondResponse = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/manual',
+      payload: {
+        showSlug: 'the-synthetic-lens',
+        url: 'https://independent.example.net/news/multi-two',
+        title: 'Multi Candidate Two',
+        summary: 'The second selected candidate is part of the same story cluster.',
+      },
+    });
+    const first = firstResponse.json().candidate as StoryCandidateRecord;
+    const second = secondResponse.json().candidate as StoryCandidateRecord;
+
+    const packetResponse = await app.inject({
+      method: 'POST',
+      url: '/research-packets',
+      payload: {
+        candidateIds: [first.id, second.id, first.id],
+        angle: 'Shared AI infrastructure story',
+        extraUrls: ['https://model-warning.example.org/source'],
+      },
+    });
+    const body = packetResponse.json();
+    const packet = body.researchPacket as ResearchPacketRecord;
+
+    assert.equal(packetResponse.statusCode, 201);
+    assert.equal(packet.title, 'Shared AI infrastructure story');
+    assert.equal(packet.status, 'ready');
+    assert.deepEqual(packet.content.candidateIds, [first.id, second.id]);
+    assert.equal(packet.content.selectedCandidateCount, 2);
+    assert.equal(packet.content.independentSourceCount, 3);
+    assert.equal((packet.content.readiness as { status: string }).status, 'ready');
+    assert.equal(body.sourceDocuments.length, 3);
+    assert.ok(packet.claims.some((claim) => claim.id.startsWith('model-claim-')));
+    assert.ok(packet.claims.every((claim) => claim.sourceDocumentIds.length > 0));
+    assert.ok(packet.claims.every((claim) => claim.citationUrls.length > 0));
+    assert.ok(packet.warnings.some((warning) => warning.code === 'DUPLICATE_CANDIDATE_ID'));
+    assert.ok(packet.warnings.some((warning) => warning.code === 'MODEL_SYNTHESIS_WARNING'));
+    assert.equal(body.job.output.warningCount, packet.warnings.length);
+    assert.deepEqual(body.job.output.failedSourceDocumentIds, []);
+
+    const listResponse = await app.inject({
+      method: 'GET',
+      url: '/research-packets?showSlug=the-synthetic-lens',
+    });
+
+    assert.equal(listResponse.statusCode, 200);
+    assert.ok(listResponse.json().researchPackets.some((item: ResearchPacketRecord) => item.id === packet.id));
+  });
+
+  it('records partial fetch failures in packet and job warnings without creating fake evidence', async () => {
+    const firstResponse = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/manual',
+      payload: {
+        showSlug: 'the-synthetic-lens',
+        url: 'https://manual.example.com/news/partial-success',
+        title: 'Partial Success',
+      },
+    });
+    const secondResponse = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/manual',
+      payload: {
+        showSlug: 'the-synthetic-lens',
+        url: 'https://unavailable.example.org/news/partial-failure',
+        title: 'Partial Failure',
+      },
+    });
+    const first = firstResponse.json().candidate as StoryCandidateRecord;
+    const second = secondResponse.json().candidate as StoryCandidateRecord;
+
+    const packetResponse = await app.inject({
+      method: 'POST',
+      url: '/research-packets',
+      payload: {
+        candidateIds: [first.id, second.id],
+      },
+    });
+    const body = packetResponse.json();
+    const packet = body.researchPacket as ResearchPacketRecord;
+    const failedDocument = body.sourceDocuments.find((document: SourceDocumentRecord) => document.fetchStatus === 'failed') as SourceDocumentRecord;
+
+    assert.equal(packetResponse.statusCode, 201);
+    assert.equal(packet.status, 'needs_more_sources');
+    assert.ok(failedDocument);
+    assert.ok(packet.warnings.some((warning) => warning.code === 'SOURCE_FETCH_FAILED'));
+    assert.ok(packet.warnings.some((warning) => warning.code === 'INSUFFICIENT_INDEPENDENT_SOURCES'));
+    assert.ok(body.job.output.failedSourceDocumentIds.includes(failedDocument.id));
+    assert.ok(body.job.output.warnings.some((warning: ResearchWarning) => warning.code === 'SOURCE_FETCH_FAILED'));
+    assert.ok(packet.claims.every((claim) => !claim.sourceDocumentIds.includes(failedDocument.id)));
+    assert.ok(packet.claims.every((claim) => !claim.citationUrls.includes(failedDocument.url)));
+  });
+
+  it('records model failures as warnings without inventing citations', async () => {
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/manual',
+      payload: {
+        showSlug: 'the-synthetic-lens',
+        url: 'https://model-failure.example.com/news/research-story',
+        title: 'Model Failure Story',
+      },
+    });
+    const candidate = createResponse.json().candidate as StoryCandidateRecord;
+
+    const packetResponse = await app.inject({
+      method: 'POST',
+      url: '/research-packets',
+      payload: {
+        candidateIds: [candidate.id],
+        extraUrls: ['https://independent.example.net/model-failure-backup'],
+      },
+    });
+    const body = packetResponse.json();
+    const packet = body.researchPacket as ResearchPacketRecord;
+    const fetchedDocumentIds = new Set(
+      (body.sourceDocuments as SourceDocumentRecord[])
+        .filter((document) => document.fetchStatus === 'fetched')
+        .map((document) => document.id),
+    );
+
+    assert.equal(packetResponse.statusCode, 201);
+    assert.ok(packet.warnings.some((warning) => warning.code === 'MODEL_CLAIM_EXTRACTION_FAILED'));
+    assert.ok(body.job.output.warnings.some((warning: ResearchWarning) => warning.code === 'MODEL_CLAIM_EXTRACTION_FAILED'));
+    assert.ok(packet.claims.length > 0);
+    assert.ok(packet.claims.every((claim) => claim.sourceDocumentIds.every((id) => fetchedDocumentIds.has(id))));
+    assert.ok(packet.claims.every((claim) => claim.citationUrls.length > 0));
+  });
+
+  it('rejects multi-candidate packets spanning multiple shows', async () => {
+    store.shows.push({
+      ...store.shows[0],
+      id: '99999999-9999-4999-8999-999999999999',
+      slug: 'second-show',
+      title: 'Second Show',
+    });
+    const firstResponse = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/manual',
+      payload: {
+        showSlug: 'the-synthetic-lens',
+        url: 'https://manual.example.com/news/show-one',
+        title: 'Show One Candidate',
+      },
+    });
+    const secondResponse = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/manual',
+      payload: {
+        showSlug: 'second-show',
+        url: 'https://manual.example.com/news/show-two',
+        title: 'Show Two Candidate',
+      },
+    });
+    const first = firstResponse.json().candidate as StoryCandidateRecord;
+    const second = secondResponse.json().candidate as StoryCandidateRecord;
+
+    const packetResponse = await app.inject({
+      method: 'POST',
+      url: '/research-packets',
+      payload: {
+        candidateIds: [first.id, second.id],
+      },
+    });
+    const body = packetResponse.json();
+
+    assert.equal(packetResponse.statusCode, 400);
+    assert.equal(body.code, 'CANDIDATE_SHOW_MISMATCH');
+    assert.equal(store.researchPackets.length, 0);
   });
 
   it('warns when a packet has fewer than two independent fetched sources', async () => {


### PR DESCRIPTION
Closes #17

## Summary
- Adds multi-candidate research packet creation via POST /research-packets.
- Persists multi-candidate packet metadata, source document references, claims/citations, warnings, and readiness.
- Preserves single-candidate compatibility through the same builder path.
- Adds coverage for multi-candidate success, partial fetch failure/warnings, and cross-show candidate rejection.

## Verification
- npm run check

## Handoff
- Script generation should consume packet claims/citations/sourceDocumentIds and surface non-ready packets for editorial review before production.