### PR TITLE
feat: generate scripts from research packets

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -87,7 +87,7 @@ Open build wave:
 - #15 Prompt template registry and structured output schemas ✅ merged (#32)
 - #16 LLM candidate scoring and ranking ✅ merged (#33)
 - #17 Multi-candidate research packet builder
-- #18 LLM script generation and revision validation
+- #18 LLM script generation and revision validation ✅ implemented locally on `issue-18-script-generation`; `npm run check` passed. Commit/push may need recovery if sandbox `.git` permissions block writes.
 - #19 Real production adapters for audio, cover art, and publishing
 - #20 Guided episode pipeline UI
 - #21 Multi-select candidate clustering UI

--- a/README.md
+++ b/README.md
@@ -433,11 +433,21 @@ or warning-bearing packets for editorial review before production.
 
 ## Script generation workflow
 
-Research packets can produce deterministic editable script drafts. The
-`script.generate` job resolves the show-specific `script_writer` model profile
-and records that routing in the job input/output and initial script revision,
-but it does not call an external LLM yet. Drafts are generated from packet
-claims, citations, warnings, the show format, and the configured show cast.
+Research packets can produce LLM-backed editable script drafts. The
+`script.generate` job resolves the show-specific `script_writer` model profile,
+renders the configured prompt template, validates the structured model output,
+and records routing/runtime metadata in the job output and initial script
+revision. Tests and local development can inject the deterministic `fake` LLM
+runtime; if no runtime/profile is available, generation falls back to the
+deterministic draft builder.
+
+Generated revisions store `metadata.citationMap`, `metadata.provenance`, and
+`metadata.validation` so reviewers can see which research packet, claim IDs,
+source document IDs, citation URLs, model runtime, and warning state produced
+the draft. If a model omits citation metadata or the packet contains claims
+without usable provenance, the revision records explicit missing-provenance
+warnings. Packets with `status: "blocked"` or `content.readiness.status:
+"blocked"` are rejected before a script is persisted.
 
 Generate a script from a research packet:
 
@@ -448,8 +458,10 @@ curl -X POST http://localhost:3450/research-packets/:id/script \
 ```
 
 Human edits are saved as new immutable revisions instead of silently
-overwriting the previous body. Speaker labels such as `DAVID:` must match a
-configured cast member for the show.
+overwriting the previous body. Human edit revisions preserve the previous
+revision's citation/provenance metadata and add fresh validation metadata.
+Speaker labels such as `DAVID:` must match a configured cast member for the
+show; unknown model-generated or human-entered speaker labels are rejected.
 
 ```sh
 curl -X POST http://localhost:3450/scripts/:id/revisions \

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -233,6 +233,7 @@ export function buildApp(options: BuildAppOptions = {}) {
       resolvedSourceStore ??= createDbSourceStore();
       return resolvedSourceStore;
     },
+    llmRuntime,
   });
 
   registerProductionRoutes(app, {

--- a/packages/api/src/scripts/builder.ts
+++ b/packages/api/src/scripts/builder.ts
@@ -1,4 +1,8 @@
 import type { ResolvedModelProfile } from '../models/resolver.js';
+import type { LlmInvocationMetadata, LlmRuntime } from '../llm/types.js';
+import { PROMPT_OUTPUT_SCHEMAS, type ScriptGenerationResult } from '../prompts/schemas.js';
+import { renderPromptTemplate } from '../prompts/renderer.js';
+import type { PromptRegistry } from '../prompts/types.js';
 import type { ResearchClaim, ResearchPacketRecord } from '../research/store.js';
 import type { ShowRecord } from '../sources/store.js';
 
@@ -9,6 +13,28 @@ export interface BuiltScriptDraft {
   speakers: string[];
   metadata: Record<string, unknown>;
 }
+
+export interface ScriptGenerationRuntimeOptions {
+  runtime: LlmRuntime;
+  promptRegistry: PromptRegistry;
+}
+
+export interface ScriptProvenanceWarning {
+  code: string;
+  severity: 'info' | 'warning' | 'error';
+  message: string;
+  sourceDocumentId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+type ProvenancePacket = {
+  id: string;
+  status: string;
+  sourceDocumentIds: string[];
+  claims: Array<Pick<ResearchClaim, 'id' | 'sourceDocumentIds' | 'citationUrls'>>;
+  citations: Array<{ sourceDocumentId: string; url: string }>;
+  content: Record<string, unknown>;
+};
 
 interface SpeakerPlan {
   host: string;
@@ -47,6 +73,153 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+
+function packetReadiness(packet: Pick<ResearchPacketRecord, 'content'>): Record<string, unknown> {
+  const readiness = packet.content.readiness;
+  return readiness && typeof readiness === 'object' && !Array.isArray(readiness)
+    ? readiness as Record<string, unknown>
+    : {};
+}
+
+function claimById(packet: ResearchPacketRecord) {
+  return new Map(packet.claims.map((claim) => [claim.id, claim]));
+}
+
+function citationUrlByDocumentId(packet: ResearchPacketRecord) {
+  return new Map(packet.citations.map((citation) => [citation.sourceDocumentId, citation.url]));
+}
+
+function normalizeCitationMap(packet: ResearchPacketRecord, citationMap: ScriptGenerationResult['citationMap']) {
+  const claims = claimById(packet);
+  const urlsByDocumentId = citationUrlByDocumentId(packet);
+
+  return citationMap.map((entry) => {
+    const claim = entry.claimId ? claims.get(entry.claimId) : undefined;
+    const sourceDocumentIds = entry.sourceDocumentIds.length > 0 ? entry.sourceDocumentIds : claim?.sourceDocumentIds ?? [];
+
+    return {
+      line: entry.line,
+      claimId: entry.claimId,
+      sourceDocumentIds,
+      citationUrls: sourceDocumentIds.map((id) => urlsByDocumentId.get(id)).filter((url): url is string => Boolean(url)),
+    };
+  });
+}
+
+function promptWarningSeverity(severity: 'info' | 'warning' | 'critical'): ScriptProvenanceWarning['severity'] {
+  return severity === 'critical' ? 'error' : severity;
+}
+
+export function provenanceWarnings(
+  packet: ProvenancePacket,
+  citationMap: Array<{ claimId?: string; sourceDocumentIds: string[] }>,
+): ScriptProvenanceWarning[] {
+  const warnings: ScriptProvenanceWarning[] = [];
+  const knownSourceDocumentIds = new Set(packet.sourceDocumentIds);
+
+  if (citationMap.length === 0) {
+    warnings.push({
+      code: 'MISSING_SCRIPT_CITATION_MAP',
+      severity: 'warning',
+      message: 'The script draft did not include a citation map, so editors must verify every factual line before production.',
+      metadata: { researchPacketId: packet.id },
+    });
+  }
+
+  for (const claim of packet.claims) {
+    if (claim.sourceDocumentIds.length === 0 || claim.citationUrls.length === 0) {
+      warnings.push({
+        code: 'CLAIM_MISSING_PROVENANCE',
+        severity: 'warning',
+        message: `Research claim is missing source document or citation URL provenance: ${claim.id}`,
+        metadata: { claimId: claim.id },
+      });
+    }
+  }
+
+  for (const entry of citationMap) {
+    for (const sourceDocumentId of entry.sourceDocumentIds) {
+      if (!knownSourceDocumentIds.has(sourceDocumentId)) {
+        warnings.push({
+          code: 'UNKNOWN_SCRIPT_CITATION_SOURCE',
+          severity: 'warning',
+          message: `Script citation references a source document outside the research packet: ${sourceDocumentId}`,
+          sourceDocumentId,
+          metadata: { claimId: entry.claimId },
+        });
+      }
+    }
+  }
+
+  if (packet.status !== 'ready') {
+    warnings.push({
+      code: 'RESEARCH_PACKET_NOT_READY',
+      severity: packet.status === 'blocked' ? 'error' : 'warning',
+      message: `Research packet status is ${packet.status}; script requires editorial review before production.`,
+      metadata: {
+        researchPacketId: packet.id,
+        readiness: packetReadiness(packet),
+      },
+    });
+  }
+
+  return warnings;
+}
+
+function showContext(show: ShowRecord) {
+  return {
+    id: show.id,
+    slug: show.slug,
+    title: show.title,
+    description: show.description,
+    format: show.format,
+    defaultRuntimeMinutes: show.defaultRuntimeMinutes,
+    cast: show.cast.map((member) => ({ name: member.name, role: member.role })),
+    settings: show.settings,
+  };
+}
+
+function packetContext(packet: ResearchPacketRecord) {
+  return {
+    id: packet.id,
+    title: packet.title,
+    status: packet.status,
+    readiness: packetReadiness(packet),
+    sourceDocumentIds: packet.sourceDocumentIds,
+    claims: packet.claims,
+    citations: packet.citations,
+    warnings: packet.warnings,
+    summary: asString(packet.content.summary),
+    knownFacts: asStringArray(packet.content.knownFacts),
+    openQuestions: asStringArray(packet.content.openQuestions),
+    content: packet.content,
+  };
+}
+
+function validationMetadata(input: {
+  speakers: string[];
+  invalidSpeakers: string[];
+  provenanceWarnings: ScriptProvenanceWarning[];
+}) {
+  return {
+    speakerLabels: {
+      valid: input.invalidSpeakers.length === 0,
+      labels: input.speakers,
+      invalid: input.invalidSpeakers,
+    },
+    provenance: {
+      valid: input.provenanceWarnings.every((warning) => warning.severity !== 'error'),
+      warningCount: input.provenanceWarnings.length,
+      warnings: input.provenanceWarnings,
+    },
+    readyForAudio: input.invalidSpeakers.length === 0
+      && input.provenanceWarnings.every((warning) => warning.severity !== 'error'),
+  };
+}
+
 export function extractSpeakerLabels(body: string): string[] {
   const labels = new Set<string>();
   const matches = body.matchAll(/^([A-Za-z][A-Za-z0-9 _-]{0,63}):/gm);
@@ -61,6 +234,91 @@ export function extractSpeakerLabels(body: string): string[] {
 export function invalidSpeakerLabels(body: string, cast: ShowRecord['cast']): string[] {
   const allowed = new Set(cast.map((member) => member.name));
   return extractSpeakerLabels(body).filter((speaker) => !allowed.has(speaker));
+}
+
+export function invalidSpeakers(speakers: string[], cast: ShowRecord['cast']): string[] {
+  const allowed = new Set(cast.map((member) => member.name));
+  return speakers.filter((speaker) => !allowed.has(speaker));
+}
+
+export async function buildLlmScriptDraft(
+  show: ShowRecord,
+  packet: ResearchPacketRecord,
+  modelProfile: ResolvedModelProfile,
+  requestedFormat: string | undefined,
+  options: ScriptGenerationRuntimeOptions,
+): Promise<BuiltScriptDraft> {
+  const format = requestedFormat ?? show.format ?? 'feature-analysis';
+  const rendered = await renderPromptTemplate(options.promptRegistry, {
+    key: modelProfile.promptTemplateKey ?? undefined,
+    role: modelProfile.promptTemplateKey ? undefined : 'script_writer',
+    showId: show.id,
+    variables: {
+      show_context: showContext(show),
+      research_packet: packetContext(packet),
+      format_notes: {
+        requestedFormat: format,
+        showFormat: show.format,
+        defaultRuntimeMinutes: show.defaultRuntimeMinutes,
+      },
+    },
+  });
+  const schema = PROMPT_OUTPUT_SCHEMAS.script_generation_result;
+  const result = await options.runtime.generateJson<ScriptGenerationResult>({
+    profile: modelProfile,
+    messages: rendered.messages,
+    schemaName: rendered.responseFormat.schemaName ?? schema.name,
+    schemaHint: rendered.responseFormat.schemaHint ?? schema.schemaHint,
+    validate: (value) => schema.validate(value) as ScriptGenerationResult,
+    requestMetadata: {
+      purpose: 'script_generation',
+      researchPacketId: packet.id,
+      promptTemplateKey: rendered.template.key,
+      promptTemplateVersion: rendered.template.version,
+    },
+  });
+  const citationMap = normalizeCitationMap(packet, result.value.citationMap);
+  const promptWarnings: ScriptProvenanceWarning[] = result.value.warnings.map((warning) => ({
+    code: warning.code,
+    severity: promptWarningSeverity(warning.severity),
+    message: warning.message,
+    sourceDocumentId: warning.sourceDocumentId,
+    metadata: warning.metadata,
+  }));
+  const provenance = provenanceWarnings(packet, citationMap);
+  const speakers = result.value.speakers.length > 0 ? result.value.speakers : extractSpeakerLabels(result.value.body);
+  const invalid = [...new Set([...invalidSpeakerLabels(result.value.body, show.cast), ...invalidSpeakers(speakers, show.cast)])];
+
+  return {
+    title: result.value.title,
+    body: result.value.body,
+    format: result.value.format || format,
+    speakers,
+    metadata: {
+      template: result.value.format || format,
+      source: 'llm',
+      researchPacketId: packet.id,
+      promptTemplateKey: rendered.template.key,
+      promptTemplateVersion: rendered.template.version,
+      modelProfileId: modelProfile.id,
+      modelRole: modelProfile.role,
+      modelRuntime: result.metadata as LlmInvocationMetadata,
+      citationMap,
+      provenance: {
+        researchPacketId: packet.id,
+        sourceDocumentIds: packet.sourceDocumentIds,
+        claimIds: packet.claims.map((claim) => claim.id),
+        citationUrls: [...new Set(packet.claims.flatMap((claim) => claim.citationUrls))],
+        warnings: provenance,
+      },
+      warnings: [...promptWarnings, ...provenance],
+      validation: validationMetadata({
+        speakers,
+        invalidSpeakers: invalid,
+        provenanceWarnings: provenance,
+      }),
+    },
+  };
 }
 
 export function buildDeterministicScriptDraft(
@@ -115,6 +373,34 @@ export function buildDeterministicScriptDraft(
       researchPacketId: packet.id,
       modelProfileId: modelProfile?.id,
       modelRole: modelProfile?.role,
+      citationMap: claims.map((claim) => ({
+        line: claim.text,
+        claimId: claim.id,
+        sourceDocumentIds: claim.sourceDocumentIds,
+        citationUrls: claim.citationUrls,
+      })),
+      provenance: {
+        researchPacketId: packet.id,
+        sourceDocumentIds: packet.sourceDocumentIds,
+        claimIds: packet.claims.map((claim) => claim.id),
+        citationUrls: [...new Set(packet.claims.flatMap((claim) => claim.citationUrls))],
+        warnings: provenanceWarnings(packet, claims.map((claim) => ({
+          claimId: claim.id,
+          sourceDocumentIds: claim.sourceDocumentIds,
+        }))),
+      },
+      warnings: provenanceWarnings(packet, claims.map((claim) => ({
+        claimId: claim.id,
+        sourceDocumentIds: claim.sourceDocumentIds,
+      }))),
+      validation: validationMetadata({
+        speakers: extractSpeakerLabels(body),
+        invalidSpeakers: invalidSpeakerLabels(body, show.cast),
+        provenanceWarnings: provenanceWarnings(packet, claims.map((claim) => ({
+          claimId: claim.id,
+          sourceDocumentIds: claim.sourceDocumentIds,
+        }))),
+      }),
     },
   };
 }

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -1,12 +1,22 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { z, ZodError } from 'zod';
 
+import { LlmJsonOutputError, LlmRuntimeError, type LlmRuntime } from '../llm/types.js';
 import { hasModelProfileStore, resolveModelProfile } from '../models/resolver.js';
 import type { ModelProfileStore } from '../models/store.js';
+import { createPromptRegistry } from '../prompts/registry.js';
+import { PromptRenderError } from '../prompts/renderer.js';
+import type { PromptTemplateStore } from '../prompts/types.js';
 import type { ResearchStore } from '../research/store.js';
 import type { CreateJobInput, JobRecord, SearchJobStore, UpdateJobInput } from '../search/store.js';
 import type { SourceStore, ShowRecord } from '../sources/store.js';
-import { buildDeterministicScriptDraft, extractSpeakerLabels, invalidSpeakerLabels } from './builder.js';
+import {
+  buildDeterministicScriptDraft,
+  buildLlmScriptDraft,
+  extractSpeakerLabels,
+  invalidSpeakerLabels,
+  provenanceWarnings,
+} from './builder.js';
 import type { ScriptStore } from './store.js';
 
 class ApiError extends Error {
@@ -20,7 +30,13 @@ class ApiError extends Error {
 }
 
 export interface ScriptRoutesOptions {
-  getStore(): SourceStore & Partial<ResearchStore> & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<ScriptStore>;
+  getStore(): SourceStore
+    & Partial<ResearchStore>
+    & Partial<SearchJobStore>
+    & Partial<ModelProfileStore>
+    & Partial<PromptTemplateStore>
+    & Partial<ScriptStore>;
+  llmRuntime?: LlmRuntime;
 }
 
 const generateScriptSchema = z.object({
@@ -56,6 +72,34 @@ function sendError(reply: FastifyReply, error: unknown) {
       ok: false,
       code: error.code,
       error: error.message,
+    });
+  }
+
+  if (error instanceof LlmJsonOutputError) {
+    return reply.code(502).send({
+      ok: false,
+      code: 'MALFORMED_MODEL_OUTPUT',
+      error: error.message,
+      details: error.details,
+      metadata: error.metadata,
+    });
+  }
+
+  if (error instanceof LlmRuntimeError) {
+    return reply.code(502).send({
+      ok: false,
+      code: 'MODEL_INVOCATION_FAILED',
+      error: error.message,
+      metadata: error.metadata,
+    });
+  }
+
+  if (error instanceof PromptRenderError) {
+    return reply.code(500).send({
+      ok: false,
+      code: error.code,
+      error: error.message,
+      details: error.details,
     });
   }
 
@@ -151,8 +195,55 @@ function assertValidSpeakers(body: string, show: ShowRecord) {
   }
 }
 
+function assertPacketCanGenerate(packet: { id: string; status: string; content: Record<string, unknown> }) {
+  const readiness = packet.content.readiness;
+  const readinessStatus = readiness && typeof readiness === 'object' && !Array.isArray(readiness)
+    ? (readiness as Record<string, unknown>).status
+    : undefined;
+
+  if (packet.status === 'blocked' || readinessStatus === 'blocked') {
+    throw new ApiError(
+      409,
+      'RESEARCH_PACKET_BLOCKED',
+      `Research packet is blocked and cannot generate a script until source or warning issues are resolved: ${packet.id}`,
+    );
+  }
+}
+
 function modelProfileRecord(profile: Awaited<ReturnType<typeof resolveModelProfile>>): Record<string, unknown> {
   return profile ? { ...profile } : {};
+}
+
+function validationMetadata(body: string, show: ShowRecord, packet: { id: string; status: string; sourceDocumentIds: string[]; claims: Array<{ id: string; sourceDocumentIds: string[]; citationUrls: string[] }>; citations: Array<{ sourceDocumentId: string; url: string }>; content: Record<string, unknown> }) {
+  const speakers = extractSpeakerLabels(body);
+  const invalid = invalidSpeakerLabels(body, show.cast);
+  const provenance = provenanceWarnings(packet, []);
+
+  return {
+    speakerLabels: {
+      valid: invalid.length === 0,
+      labels: speakers,
+      invalid,
+    },
+    provenance: {
+      valid: provenance.every((warning) => warning.severity !== 'error'),
+      warningCount: provenance.length,
+      warnings: provenance,
+    },
+    readyForAudio: invalid.length === 0 && provenance.every((warning) => warning.severity !== 'error'),
+  };
+}
+
+function inheritedRevisionMetadata(previous: Record<string, unknown> | undefined, body: string, show: ShowRecord, packet: Parameters<typeof validationMetadata>[2]) {
+  return {
+    source: 'human-edit',
+    previousSource: previous?.source,
+    previousApprovedRevisionId: null,
+    citationMap: previous?.citationMap,
+    provenance: previous?.provenance,
+    inheritedProvenance: Boolean(previous?.provenance || previous?.citationMap),
+    validation: validationMetadata(body, show, packet),
+  };
 }
 
 export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutesOptions) {
@@ -203,7 +294,13 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         });
       }
 
-      const draft = buildDeterministicScriptDraft(show, packet, modelProfile, body.format);
+      assertPacketCanGenerate(packet);
+      const draft = options.llmRuntime && modelProfile
+        ? await buildLlmScriptDraft(show, packet, modelProfile, body.format, {
+          runtime: options.llmRuntime,
+          promptRegistry: createPromptRegistry({ store: rawStore }),
+        })
+        : buildDeterministicScriptDraft(show, packet, modelProfile, body.format);
       assertValidSpeakers(draft.body, show);
       const result = await scriptStore.createScriptWithRevision({
         showId: packet.showId,
@@ -238,6 +335,9 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
             revisionId: result.revision.id,
             version: result.revision.version,
             modelProfile,
+            validation: result.revision.metadata.validation,
+            provenance: result.revision.metadata.provenance,
+            citationMap: result.revision.metadata.citationMap,
           },
           finishedAt: new Date(),
         }) ?? job;
@@ -322,6 +422,15 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
       const show = await getShow(rawStore, script.showId);
       assertCast(show);
       assertValidSpeakers(body.body, show);
+      const researchStore = requireResearchStore(rawStore);
+      const packet = await researchStore.getResearchPacket(script.researchPacketId);
+
+      if (!packet) {
+        throw new ApiError(404, 'RESEARCH_PACKET_NOT_FOUND', `Research packet not found: ${script.researchPacketId}`);
+      }
+
+      const revisions = await scriptStore.listScriptRevisions(script.id);
+      const latestRevision = revisions[0];
       const result = await scriptStore.createScriptRevision(script.id, {
         title: body.title ?? script.title,
         body: body.body,
@@ -331,7 +440,7 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         changeSummary: body.changeSummary ?? 'Human edit.',
         modelProfile: {},
         metadata: {
-          source: 'human-edit',
+          ...inheritedRevisionMetadata(latestRevision?.metadata, body.body, show, packet),
           previousApprovedRevisionId: script.approvedRevisionId,
         },
       });

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -2,6 +2,9 @@ import assert from 'node:assert/strict';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import { buildApp } from '../app.js';
+import { createFakeLlmProvider } from '../llm/providers.js';
+import { createLlmRuntime } from '../llm/runtime.js';
+import type { LlmProviderRequest, LlmProviderResult } from '../llm/types.js';
 import type { ModelRole } from '../models/roles.js';
 import type {
   CreateModelProfileInput,
@@ -760,6 +763,67 @@ let requestedResearchUrls: string[] = [];
 let uploadedPublishAssets: Array<{ feedId: string; episodeId: string; assetId: string; type: string }> = [];
 let rssEntries = new Map<string, RssEpisodeEntry>();
 let validatedPublishUrls: string[] = [];
+let scriptLlmMode: 'valid' | 'malformed' | 'unknown-speaker' = 'valid';
+
+function quotedValue(content: string, key: string): string | undefined {
+  const match = content.match(new RegExp(`"${key}"\\s*:\\s*"([^"]+)"`));
+  return match?.[1];
+}
+
+function scriptWriterResult(request: LlmProviderRequest): LlmProviderResult {
+  if (request.attempt.role !== 'script_writer') {
+    const text = JSON.stringify({ ok: true });
+    return { text, rawOutput: text, metadata: { adapter: 'test-fake' } };
+  }
+
+  if (scriptLlmMode === 'malformed') {
+    return { text: 'not json', rawOutput: 'not json', metadata: { adapter: 'test-fake' } };
+  }
+
+  const content = request.messages.map((message) => message.content).join('\n');
+  const title = quotedValue(content, 'title') ?? 'Generated Story';
+  const claimId = quotedValue(content, 'id') ?? 'claim-1';
+  const sourceDocumentId = quotedValue(content, 'sourceDocumentId') ?? 'source-document-1';
+  const body = scriptLlmMode === 'unknown-speaker'
+    ? 'BOGUS: This draft uses a speaker outside the configured show cast.'
+    : [
+      `DAVID: This is The Synthetic Lens. Today we are tracking ${title}.`,
+      'INGRID: The sourced packet points to a concrete development editors can trace back to captured source documents.',
+      'MARCUS: The context matters, but the script keeps uncertainty visible where the packet warns about source limits.',
+    ].join('\n');
+  const output = {
+    title: `${title} Script`,
+    format: 'feature-analysis',
+    body,
+    speakers: scriptLlmMode === 'unknown-speaker' ? ['BOGUS'] : ['DAVID', 'INGRID', 'MARCUS'],
+    citationMap: scriptLlmMode === 'unknown-speaker'
+      ? []
+      : [{
+        line: 'The sourced packet points to a concrete development editors can trace back to captured source documents.',
+        claimId,
+        sourceDocumentIds: [sourceDocumentId],
+      }],
+    warnings: [],
+  };
+  const text = JSON.stringify(output);
+
+  return {
+    text,
+    rawOutput: text,
+    metadata: { adapter: 'test-fake-script-writer' },
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    cost: { usd: 0, currency: 'USD' },
+  };
+}
+
+const llmRuntime = createLlmRuntime({
+  adapters: [
+    createFakeLlmProvider({ provider: 'openai-codex', handler: scriptWriterResult }),
+    createFakeLlmProvider({ provider: 'google-vertex', handler: scriptWriterResult }),
+    createFakeLlmProvider({ provider: 'google-gemini-cli', handler: scriptWriterResult }),
+  ],
+});
+
 const publishStorageAdapterFactory = (): PublishStorageAdapter => ({
   async uploadAsset({ feed, episode, asset }) {
     uploadedPublishAssets.push({ feedId: feed.id, episodeId: episode.id, assetId: asset.id, type: asset.type });
@@ -941,6 +1005,7 @@ const app = buildApp({
   rssFetchImpl: rssFetch,
   researchFetchImpl: researchFetch,
   researchModelServices,
+  llmRuntime,
   publishStorageAdapterFactory,
   rssUpdateAdapter,
   publishUrlValidator,
@@ -969,6 +1034,7 @@ describe('source profile routes', () => {
     uploadedPublishAssets = [];
     rssEntries = new Map<string, RssEpisodeEntry>();
     validatedPublishUrls = [];
+    scriptLlmMode = 'valid';
   });
 
   after(async () => {
@@ -1609,7 +1675,12 @@ describe('source profile routes', () => {
     assert.equal(body.revision.version, 1);
     assert.deepEqual(body.revision.speakers, ['DAVID', 'INGRID', 'MARCUS']);
     assert.match(body.revision.body, /DAVID: This is The Synthetic Lens/);
-    assert.match(body.revision.body, /MARCUS: What remains uncertain/);
+    assert.match(body.revision.body, /MARCUS: The context matters/);
+    assert.equal(body.revision.metadata.source, 'llm');
+    assert.equal(body.revision.metadata.validation.speakerLabels.valid, true);
+    assert.ok(body.revision.metadata.citationMap.length > 0);
+    assert.ok(body.revision.metadata.provenance.citationUrls.length > 0);
+    assert.equal(body.job.output.validation.readyForAudio, true);
 
     const listResponse = await app.inject({
       method: 'GET',
@@ -1618,6 +1689,115 @@ describe('source profile routes', () => {
 
     assert.equal(listResponse.statusCode, 200);
     assert.equal(listResponse.json().scripts.length, 1);
+  });
+
+  it('blocks script generation for blocked research packets', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Blocked Packet Story',
+      status: 'blocked',
+      sourceDocumentIds: [],
+      claims: [],
+      citations: [],
+      warnings: [{
+        id: 'NO_SOURCES',
+        code: 'NO_SOURCES',
+        severity: 'error',
+        message: 'No usable sources are available.',
+      }],
+      content: {
+        summary: 'Blocked packet.',
+        readiness: { status: 'blocked', reasons: ['No usable sources are available.'] },
+      },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/research-packets/${packet.id}/script`,
+    });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 409);
+    assert.equal(body.code, 'RESEARCH_PACKET_BLOCKED');
+    assert.equal(store.scripts.length, 0);
+    assert.equal(store.jobs.at(-1)?.type, 'script.generate');
+    assert.equal(store.jobs.at(-1)?.status, 'failed');
+  });
+
+  it('rejects generated scripts with speaker labels outside the show cast', async () => {
+    scriptLlmMode = 'unknown-speaker';
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Generated Speaker Validation Story',
+      status: 'ready',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{
+        id: 'claim-1',
+        text: 'A sourced claim exists.',
+        sourceDocumentIds: ['source-document-1'],
+        citationUrls: ['https://example.com/generated-speaker'],
+      }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/generated-speaker',
+        title: 'Generated speaker source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary.', readiness: { status: 'ready', reasons: [] } },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/research-packets/${packet.id}/script`,
+    });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(body.code, 'INVALID_SCRIPT_SPEAKER');
+    assert.match(body.error, /BOGUS/);
+    assert.equal(store.scripts.length, 0);
+    assert.equal(store.jobs.at(-1)?.status, 'failed');
+  });
+
+  it('fails safely when the model returns malformed script output', async () => {
+    scriptLlmMode = 'malformed';
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Malformed Model Story',
+      status: 'ready',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{
+        id: 'claim-1',
+        text: 'A sourced malformed-output claim exists.',
+        sourceDocumentIds: ['source-document-1'],
+        citationUrls: ['https://example.com/malformed'],
+      }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/malformed',
+        title: 'Malformed source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary.', readiness: { status: 'ready', reasons: [] } },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/research-packets/${packet.id}/script`,
+    });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 502);
+    assert.equal(body.code, 'MALFORMED_MODEL_OUTPUT');
+    assert.equal(store.scripts.length, 0);
+    assert.equal(store.jobs.at(-1)?.status, 'failed');
   });
 
   it('rejects human script edits with speaker labels outside the show cast', async () => {
@@ -1690,6 +1870,10 @@ describe('source profile routes', () => {
     assert.equal(edited.script.title, 'Edited Revision Story Script');
     assert.notEqual(edited.revision.id, initial.revision.id);
     assert.match(store.scriptRevisions[0].body, /This is The Synthetic Lens/);
+    assert.equal(edited.revision.metadata.source, 'human-edit');
+    assert.equal(edited.revision.metadata.inheritedProvenance, true);
+    assert.deepEqual(edited.revision.metadata.citationMap, initial.revision.metadata.citationMap);
+    assert.equal(edited.revision.metadata.validation.speakerLabels.valid, true);
 
     const approveResponse = await app.inject({
       method: 'POST',


### PR DESCRIPTION
## Summary
- Adds evidence-aware script generation from research packets via the configured `script_writer` model role and prompt registry.
- Persists citation/provenance metadata, validation/readiness metadata, and model invocation details on script revisions.
- Adds revision-safe human edit support that preserves provenance and validates speaker labels against the show cast.
- Blocks generation for blocked research packets and fails safely on malformed model output.

Closes #18.

## Verification
- `npm run check`

## Handoff
- Endpoint: `POST /research-packets/:id/script`
- Revision endpoint: `POST /scripts/:id/revisions`
- UI should surface `validation.readyForAudio`, speaker validation, provenance warnings, citation map, and model runtime metadata before audio production.