### PR TITLE
feat: add production adapters and guarded publishing

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -88,7 +88,7 @@ Open build wave:
 - #16 LLM candidate scoring and ranking ✅ merged (#33)
 - #17 Multi-candidate research packet builder
 - #18 LLM script generation and revision validation ✅ implemented locally on `issue-18-script-generation`; `npm run check` passed. Commit/push may need recovery if sandbox `.git` permissions block writes.
-- #19 Real production adapters for audio, cover art, and publishing
+- #19 Real production adapters for audio, cover art, and publishing ✅ implemented locally on `main` worktree because sandbox `.git/FETCH_HEAD` was read-only; `npm run check` passed. Commit/push may need recovery if sandbox `.git` permissions block writes.
 - #20 Guided episode pipeline UI
 - #21 Multi-select candidate clustering UI
 - #22 Settings/admin UI for shows, sources, models, prompts, publishing

--- a/README.md
+++ b/README.md
@@ -486,8 +486,15 @@ Script endpoints:
 
 Approved script revisions can produce durable production jobs. The API creates
 or reuses an episode record for the script, writes `audio.preview` and
-`art.generate` jobs with logs/progress, and links output rows in
-`episode_assets`.
+`art.generate` jobs with stage/progress logs, provider metadata, retryable
+failure metadata, and links output rows in `episode_assets`.
+
+The default development adapters are fake/local and deterministic. They write
+placeholder audio and image files under `production.localAssetDir`,
+`production.outputDir`, or `/tmp/podcast-forge-production-assets`, then persist
+duration, byte size, MIME type, checksum, object key, local path, provider, and
+adapter metadata for review screens. Tests inject fake adapters and never call
+live audio, image, storage, or RSS providers.
 
 ```sh
 curl -X POST http://localhost:3450/scripts/:id/production/audio-preview \
@@ -496,10 +503,16 @@ curl -X POST http://localhost:3450/scripts/:id/production/audio-preview \
 
 curl -X POST http://localhost:3450/scripts/:id/production/cover-art \
   -H 'content-type: application/json' \
-  -d '{"actor":"producer@example.com"}'
+  -d '{"actor":"producer@example.com","prompt":"Quiet editorial cover art with abstract waveform lines."}'
 
 curl http://localhost:3450/scripts/:id/production
 ```
+
+If no cover prompt is provided and an LLM runtime plus `cover_prompt_writer`
+profile is configured, the cover-art job uses the prompt registry and stores the
+prompt-writer output and invocation metadata with the job and asset. Otherwise
+it falls back to a deterministic prompt from the show, script, and research
+packet context.
 
 Production endpoints:
 
@@ -510,10 +523,17 @@ Production endpoints:
 ## Approval-gated RSS publishing
 
 Episodes must reach `approved-for-publish` before `publish.rss` can update a
-feed. The publish job uploads the selected audio and cover art through the
-configured feed storage adapter, preserves the feed OP3 wrapping setting, upserts
-the RSS item by episode/feed GUID, validates the resulting public URLs, records a
+feed. The endpoint returns `PUBLISH_BLOCKED` with `blockedReasons` when approval,
+feed config, or required audio/cover assets are missing or unsafe. The publish
+job uploads the selected audio and cover art through the configured feed storage
+adapter, preserves the feed OP3 wrapping setting and metadata, upserts the RSS
+item by episode/feed GUID, validates the resulting public URLs, records a
 `publish_events` audit row, and marks the episode `published`.
+
+Publishing an already-published episode without `republish: true` is an
+idempotent no-op and returns the stored publish metadata without re-uploading
+assets or mutating RSS. Explicit re-publish requires `republish: true` and a
+non-empty `changelog`.
 
 ```sh
 curl -X POST http://localhost:3450/episodes/:id/approve-for-publish \
@@ -523,6 +543,10 @@ curl -X POST http://localhost:3450/episodes/:id/approve-for-publish \
 curl -X POST http://localhost:3450/episodes/:id/publish/rss \
   -H 'content-type: application/json' \
   -d '{"actor":"publisher@example.com"}'
+
+curl -X POST http://localhost:3450/episodes/:id/publish/rss \
+  -H 'content-type: application/json' \
+  -d '{"actor":"publisher@example.com","republish":true,"changelog":"Corrected feed metadata."}'
 ```
 
 Publishing endpoints:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,7 @@ Public publishing requires:
 
 - episode has approved script or approved preview audio.
 - required assets exist.
+- asset and feed public URLs are valid HTTP(S) when configured.
 - research warnings resolved or explicitly overridden.
 - publish target configured.
 - user-triggered publish action.
@@ -106,6 +107,16 @@ Public publishing requires:
 Scheduled pipeline publishing follows the same rule. A recurring pipeline can
 prepare or queue publish work, but RSS publication stays blocked on approval
 unless the schedule is explicitly configured for autopublish.
+
+Production adapters are injectable. The default development adapters are
+deterministic local fakes that create placeholder files and persist local path,
+object key, URL, duration, size, MIME, checksum, provider, adapter, warnings,
+and prompt metadata. Real TTS/image/storage/RSS adapters should stay behind the
+same contracts so tests can continue to run without live provider calls.
+
+Publishing is idempotent by episode/feed GUID. A second publish call for an
+already-published episode is a no-op unless the caller sets `republish: true`,
+which requires a changelog and writes an explicit publish event.
 
 ## Migration strategy from current tools
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -241,6 +241,7 @@ export function buildApp(options: BuildAppOptions = {}) {
       resolvedSourceStore ??= createDbSourceStore();
       return resolvedSourceStore;
     },
+    llmRuntime,
     audioPreviewProvider,
     coverArtProvider,
     publishStorageAdapterFactory,

--- a/packages/api/src/production/providers.ts
+++ b/packages/api/src/production/providers.ts
@@ -1,5 +1,8 @@
 import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
+import type { ResearchPacketRecord } from '../research/store.js';
 import type { ShowRecord } from '../sources/store.js';
 import type { ScriptRecord, ScriptRevisionRecord } from '../scripts/store.js';
 
@@ -8,13 +11,19 @@ export interface ProductionConfig {
   artProvider?: string;
   publicBaseUrl?: string;
   storage?: string;
+  localAssetDir?: string;
+  outputDir?: string;
+  failAudioPreview?: boolean | string;
+  failCoverArt?: boolean | string;
 }
 
 export interface ProductionProviderContext {
   show: ShowRecord;
   script: ScriptRecord;
   revision: ScriptRevisionRecord;
+  episodeId: string;
   episodeSlug: string;
+  researchPacket?: ResearchPacketRecord | null;
   production: ProductionConfig;
 }
 
@@ -39,6 +48,10 @@ export interface CoverArtProvider {
   generateCoverArt(context: ProductionProviderContext & { prompt: string }): Promise<GeneratedProductionAsset>;
 }
 
+function localAssetRoot(production: ProductionConfig) {
+  return production.localAssetDir ?? production.outputDir ?? join('/tmp', 'podcast-forge-production-assets');
+}
+
 function assetUrl(publicBaseUrl: string | undefined, objectKey: string) {
   if (!publicBaseUrl) {
     return null;
@@ -47,12 +60,26 @@ function assetUrl(publicBaseUrl: string | undefined, objectKey: string) {
   return `${publicBaseUrl.replace(/\/$/, '')}/${objectKey}`;
 }
 
-function checksum(value: string) {
+function checksum(value: string | Buffer) {
   return createHash('sha256').update(value).digest('hex');
+}
+
+async function writeDeterministicAsset(production: ProductionConfig, objectKey: string, body: Buffer | string) {
+  const localPath = join(localAssetRoot(production), objectKey);
+  await mkdir(dirname(localPath), { recursive: true });
+  await writeFile(localPath, body);
+  return localPath;
 }
 
 export const deterministicAudioPreviewProvider: AudioPreviewProvider = {
   async generatePreviewAudio(context) {
+    if (context.production.failAudioPreview) {
+      const message = typeof context.production.failAudioPreview === 'string'
+        ? context.production.failAudioPreview
+        : 'Configured fake audio preview failure.';
+      throw new Error(message);
+    }
+
     const provider = context.production.ttsProvider ?? 'vertex-gemini-tts';
     const objectKey = `shows/${context.show.slug}/episodes/${context.episodeSlug}/audio-preview.mp3`;
     const body = [
@@ -64,6 +91,7 @@ export const deterministicAudioPreviewProvider: AudioPreviewProvider = {
     ].join('\n');
     const byteSize = Buffer.byteLength(body);
     const words = context.revision.body.split(/\s+/).filter(Boolean).length;
+    const localPath = await writeDeterministicAsset(context.production, objectKey, body);
 
     return {
       provider,
@@ -72,10 +100,12 @@ export const deterministicAudioPreviewProvider: AudioPreviewProvider = {
       byteSize,
       durationSeconds: Math.max(1, Math.round(words / 2.6)),
       checksum: checksum(body),
+      localPath,
       objectKey,
       publicUrl: assetUrl(context.production.publicBaseUrl, objectKey),
       metadata: {
         adapter: provider,
+        adapterKind: 'fake-local-audio-preview',
         voiceMap: context.show.cast.map((member) => ({ speaker: member.name, voice: member.voice })),
         generatedBy: 'deterministic-preview-adapter',
       },
@@ -83,24 +113,35 @@ export const deterministicAudioPreviewProvider: AudioPreviewProvider = {
   },
 };
 
-const pngOneByOneByteSize = 68;
-const pngOneByOneChecksum = checksum('podcast-forge-cover-art-placeholder-v1');
-
 export const deterministicCoverArtProvider: CoverArtProvider = {
   async generateCoverArt(context) {
+    if (context.production.failCoverArt) {
+      const message = typeof context.production.failCoverArt === 'string'
+        ? context.production.failCoverArt
+        : 'Configured fake cover art failure.';
+      throw new Error(message);
+    }
+
     const provider = context.production.artProvider ?? 'configured-art-provider';
     const objectKey = `shows/${context.show.slug}/episodes/${context.episodeSlug}/cover.png`;
+    const body = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+      'base64',
+    );
+    const localPath = await writeDeterministicAsset(context.production, objectKey, body);
 
     return {
       provider,
       label: 'Cover art',
       mimeType: 'image/png',
-      byteSize: pngOneByOneByteSize,
-      checksum: pngOneByOneChecksum,
+      byteSize: body.byteLength,
+      checksum: checksum(body),
+      localPath,
       objectKey,
       publicUrl: assetUrl(context.production.publicBaseUrl, objectKey),
       metadata: {
         adapter: provider,
+        adapterKind: 'fake-local-cover-art',
         prompt: context.prompt,
         generatedBy: 'deterministic-cover-adapter',
       },

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -1,8 +1,14 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { z, ZodError } from 'zod';
 
+import { LlmJsonOutputError, LlmRuntimeError, type LlmRuntime } from '../llm/types.js';
 import { hasModelProfileStore, resolveModelProfile } from '../models/resolver.js';
 import type { ModelProfileStore } from '../models/store.js';
+import { createPromptRegistry } from '../prompts/registry.js';
+import { PromptRenderError, renderPromptTemplate } from '../prompts/renderer.js';
+import { PROMPT_OUTPUT_SCHEMAS, type CoverPromptResult } from '../prompts/schemas.js';
+import type { PromptTemplateStore } from '../prompts/types.js';
+import type { ResearchPacketRecord, ResearchStore } from '../research/store.js';
 import type { CreateJobInput, JobRecord, SearchJobStore, UpdateJobInput } from '../search/store.js';
 import type { ScriptRecord, ScriptRevisionRecord, ScriptStore } from '../scripts/store.js';
 import type { SourceStore, ShowRecord } from '../sources/store.js';
@@ -37,6 +43,7 @@ class ApiError extends Error {
     public readonly statusCode: number,
     public readonly code: string,
     message: string,
+    public readonly details: Record<string, unknown> = {},
   ) {
     super(message);
   }
@@ -46,8 +53,11 @@ export interface ProductionRoutesOptions {
   getStore(): SourceStore
     & Partial<SearchJobStore>
     & Partial<ModelProfileStore>
+    & Partial<PromptTemplateStore>
+    & Partial<ResearchStore>
     & Partial<ScriptStore>
     & Partial<ProductionStore>;
+  llmRuntime?: LlmRuntime;
   audioPreviewProvider?: AudioPreviewProvider;
   coverArtProvider?: CoverArtProvider;
   publishStorageAdapterFactory?: (feed: FeedRecord) => PublishStorageAdapter;
@@ -64,6 +74,11 @@ const approvePublishSchema = requestSchema.extend({
 const publishRssSchema = requestSchema.extend({
   feedId: z.string().trim().min(1).optional(),
   changelog: z.string().trim().min(1).optional(),
+  republish: z.boolean().default(false),
+});
+const coverArtSchema = requestSchema.extend({
+  prompt: z.string().trim().min(1).optional(),
+  artDirection: z.string().trim().min(1).optional(),
 });
 
 function sendError(reply: FastifyReply, error: unknown, job?: JobRecord) {
@@ -82,6 +97,38 @@ function sendError(reply: FastifyReply, error: unknown, job?: JobRecord) {
       ok: false,
       code: error.code,
       error: error.message,
+      ...error.details,
+      job,
+    });
+  }
+
+  if (error instanceof LlmJsonOutputError) {
+    return reply.code(502).send({
+      ok: false,
+      code: 'MALFORMED_MODEL_OUTPUT',
+      error: error.message,
+      details: error.details,
+      metadata: error.metadata,
+      job,
+    });
+  }
+
+  if (error instanceof LlmRuntimeError) {
+    return reply.code(502).send({
+      ok: false,
+      code: 'MODEL_INVOCATION_FAILED',
+      error: error.message,
+      metadata: error.metadata,
+      job,
+    });
+  }
+
+  if (error instanceof PromptRenderError) {
+    return reply.code(500).send({
+      ok: false,
+      code: error.code,
+      error: error.message,
+      details: error.details,
       job,
     });
   }
@@ -173,11 +220,45 @@ function requireJobStore(store: Partial<SearchJobStore>): Pick<SearchJobStore, '
   return store as Pick<SearchJobStore, 'createJob' | 'updateJob' | 'getJob' | 'listJobs'>;
 }
 
+function hasResearchStore(store: object): store is Pick<ResearchStore, 'getResearchPacket'> {
+  return 'getResearchPacket' in store && typeof store.getResearchPacket === 'function';
+}
+
 function log(level: 'info' | 'warn' | 'error', message: string, metadata: Record<string, unknown> = {}) {
   return {
     at: new Date().toISOString(),
     level,
     message,
+    ...metadata,
+  };
+}
+
+function retryableFailure(error: unknown) {
+  if (error instanceof ApiError && error.statusCode >= 400 && error.statusCode < 500) {
+    return false;
+  }
+
+  if (error instanceof LlmJsonOutputError || error instanceof PromptRenderError) {
+    return false;
+  }
+
+  if (error instanceof LlmRuntimeError) {
+    return error.metadata.attempts.some((attempt) => attempt.error?.retryable);
+  }
+
+  return true;
+}
+
+function failureOutput(stage: string, error: unknown, metadata: Record<string, unknown> = {}) {
+  const message = error instanceof Error ? error.message : 'Production job failed.';
+  return {
+    stage,
+    retryable: retryableFailure(error),
+    failure: {
+      message,
+      retryable: retryableFailure(error),
+      code: error instanceof ApiError ? error.code : error instanceof Error ? error.name : 'UNKNOWN_ERROR',
+    },
     ...metadata,
   };
 }
@@ -220,6 +301,40 @@ function assertApprovedScript(script: ScriptRecord): asserts script is ScriptRec
   }
 }
 
+function revisionValidation(revision: ScriptRevisionRecord) {
+  const validation = revision.metadata.validation;
+  return validation && typeof validation === 'object' && !Array.isArray(validation)
+    ? validation as Record<string, unknown>
+    : {};
+}
+
+function revisionWarnings(revision: ScriptRevisionRecord): Array<Record<string, unknown>> {
+  const validation = revisionValidation(revision);
+  const provenance = validation.provenance && typeof validation.provenance === 'object' && !Array.isArray(validation.provenance)
+    ? validation.provenance as Record<string, unknown>
+    : {};
+  const warnings = provenance.warnings;
+
+  return Array.isArray(warnings)
+    ? warnings.filter((warning): warning is Record<string, unknown> => {
+      return Boolean(warning && typeof warning === 'object' && !Array.isArray(warning));
+    })
+    : [];
+}
+
+function assertRevisionReadyForAudio(revision: ScriptRevisionRecord) {
+  if (!revision.body.trim()) {
+    throw new ApiError(409, 'SCRIPT_REVISION_EMPTY', 'Approved script revision has no body to render.');
+  }
+
+  const validation = revisionValidation(revision);
+  if (validation.readyForAudio === false) {
+    throw new ApiError(409, 'SCRIPT_REVISION_NOT_READY_FOR_AUDIO', 'Approved script revision failed readiness validation.', {
+      validation,
+    });
+  }
+}
+
 function assertEpisodeReadyForPublishApproval(episode: EpisodeRecord) {
   if (!['audio-ready', 'approved-for-publish', 'published'].includes(episode.status)) {
     throw new ApiError(409, 'EPISODE_NOT_AUDIO_READY', 'Episode must have production audio before publish approval.');
@@ -254,6 +369,8 @@ async function loadApprovedScript(
   if (!revision || revision.scriptId !== script.id) {
     throw new ApiError(404, 'SCRIPT_REVISION_NOT_FOUND', `Script revision not found: ${script.approvedRevisionId}`);
   }
+
+  assertRevisionReadyForAudio(revision);
 
   return { script, revision };
 }
@@ -292,13 +409,133 @@ function modelProfileRecord(profile: Awaited<ReturnType<typeof resolveModelProfi
   return profile ? { ...profile } : {};
 }
 
-function coverPrompt(show: ShowRecord, script: ScriptRecord, revision: ScriptRevisionRecord, modelProfile: Record<string, unknown>) {
+function scriptExcerpt(revision: ScriptRevisionRecord) {
+  return revision.body.length > 1500 ? `${revision.body.slice(0, 1500)}...` : revision.body;
+}
+
+function coverPrompt(
+  show: ShowRecord,
+  script: ScriptRecord,
+  revision: ScriptRevisionRecord,
+  modelProfile: Record<string, unknown>,
+  researchPacket?: ResearchPacketRecord | null,
+  artDirection?: string,
+) {
   return [
     `${show.title} cover art for "${script.title}".`,
     `Editorial tone: sourced, restrained news analysis.`,
     `Script format: ${revision.format}.`,
+    researchPacket ? `Research packet: ${researchPacket.title}; status ${researchPacket.status}.` : '',
+    artDirection ? `Art direction: ${artDirection}.` : '',
     Object.keys(modelProfile).length > 0 ? `Prompt model: ${modelProfile.provider}/${modelProfile.model}.` : '',
   ].filter(Boolean).join(' ');
+}
+
+async function resolveResearchPacket(
+  store: object,
+  script: ScriptRecord,
+): Promise<ResearchPacketRecord | null> {
+  if (!hasResearchStore(store)) {
+    return null;
+  }
+
+  return await store.getResearchPacket(script.researchPacketId) ?? null;
+}
+
+async function resolveCoverPrompt(input: {
+  store: SourceStore & Partial<ModelProfileStore> & Partial<PromptTemplateStore>;
+  show: ShowRecord;
+  script: ScriptRecord;
+  revision: ScriptRevisionRecord;
+  researchPacket: ResearchPacketRecord | null;
+  providedPrompt?: string;
+  artDirection?: string;
+  llmRuntime?: LlmRuntime;
+  modelProfile: Awaited<ReturnType<typeof resolveModelProfile>>;
+}): Promise<{ prompt: string; promptResult?: CoverPromptResult; promptMetadata: Record<string, unknown> }> {
+  if (input.providedPrompt) {
+    return {
+      prompt: input.providedPrompt,
+      promptMetadata: {
+        source: 'provided',
+        artDirection: input.artDirection ?? null,
+      },
+    };
+  }
+
+  if (input.llmRuntime && input.modelProfile) {
+    const rendered = await renderPromptTemplate(createPromptRegistry({ store: input.store }), {
+      key: input.modelProfile.promptTemplateKey ?? undefined,
+      role: input.modelProfile.promptTemplateKey ? undefined : 'cover_prompt_writer',
+      showId: input.show.id,
+      variables: {
+        episode_metadata: {
+          title: input.script.title,
+          showTitle: input.show.title,
+          format: input.revision.format,
+          researchPacket: input.researchPacket
+            ? {
+              id: input.researchPacket.id,
+              title: input.researchPacket.title,
+              status: input.researchPacket.status,
+              summary: input.researchPacket.content.summary,
+              warnings: input.researchPacket.warnings,
+            }
+            : null,
+        },
+        script_excerpt: scriptExcerpt(input.revision),
+        art_direction: input.artDirection ?? 'restrained editorial cover art for a news podcast episode',
+      },
+    });
+    const result = await input.llmRuntime.generateJson<CoverPromptResult>({
+      profile: input.modelProfile,
+      messages: rendered.messages,
+      schemaName: 'cover_prompt_result',
+      schemaHint: PROMPT_OUTPUT_SCHEMAS.cover_prompt_result.schemaHint,
+      validate: (value) => PROMPT_OUTPUT_SCHEMAS.cover_prompt_result.validate(value) as CoverPromptResult,
+      requestMetadata: {
+        scriptId: input.script.id,
+        revisionId: input.revision.id,
+        researchPacketId: input.researchPacket?.id ?? null,
+        promptTemplateKey: rendered.template.key,
+        promptTemplateVersion: rendered.template.version,
+      },
+    });
+
+    return {
+      prompt: result.value.prompt,
+      promptResult: result.value,
+      promptMetadata: {
+        source: 'cover_prompt_writer',
+        modelProfile: input.modelProfile,
+        invocation: result.metadata,
+        template: {
+          key: rendered.template.key,
+          version: rendered.template.version,
+        },
+        negativePrompt: result.value.negativePrompt ?? null,
+        altText: result.value.altText,
+        safetyNotes: result.value.safetyNotes,
+        artDirection: input.artDirection ?? null,
+      },
+    };
+  }
+
+  return {
+    prompt: coverPrompt(
+      input.show,
+      input.script,
+      input.revision,
+      modelProfileRecord(input.modelProfile),
+      input.researchPacket,
+      input.artDirection,
+    ),
+    promptMetadata: {
+      source: 'deterministic-fallback',
+      modelProfile: modelProfileRecord(input.modelProfile),
+      artDirection: input.artDirection ?? null,
+    },
+  };
 }
 
 function assetInput(
@@ -336,6 +573,106 @@ function selectAsset(assets: EpisodeAssetRecord[], types: Array<EpisodeAssetReco
   return asset;
 }
 
+interface PublishBlockedReason {
+  code: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+function validHttpUrl(value: string | null) {
+  if (!value) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function publishBlockers(
+  episode: EpisodeRecord,
+  assets: EpisodeAssetRecord[],
+  feed: FeedRecord | null,
+  options: { republish: boolean; changelog?: string | null },
+): PublishBlockedReason[] {
+  const blockers: PublishBlockedReason[] = [];
+  const audioAsset = assets.find((asset) => ['audio-final', 'audio-preview'].includes(asset.type));
+  const coverAsset = assets.find((asset) => asset.type === 'cover-art');
+
+  if (episode.status === 'published' && episode.feedGuid && !options.republish) {
+    return [];
+  }
+
+  if (episode.status === 'published' && options.republish && !options.changelog) {
+    blockers.push({
+      code: 'REPUBLISH_CHANGELOG_REQUIRED',
+      message: 'Re-publishing an already published episode requires an explicit changelog.',
+    });
+  } else if (episode.status !== 'approved-for-publish' && !(episode.status === 'published' && episode.feedGuid)) {
+    blockers.push({
+      code: 'EPISODE_NOT_APPROVED_FOR_PUBLISH',
+      message: 'Episode must be approved for publish before RSS publishing can run.',
+      metadata: { status: episode.status },
+    });
+  }
+
+  if (!feed) {
+    blockers.push({
+      code: 'PUBLISH_FEED_REQUIRED',
+      message: 'Show has no configured RSS feed.',
+    });
+  } else {
+    if (!validHttpUrl(feed.publicFeedUrl) || !validHttpUrl(feed.publicBaseUrl)) {
+      blockers.push({
+        code: 'PUBLISH_FEED_PUBLIC_URL_INVALID',
+        message: 'Feed public URLs must be valid http(s) URLs when configured.',
+        metadata: { publicFeedUrl: feed.publicFeedUrl, publicBaseUrl: feed.publicBaseUrl },
+      });
+    }
+  }
+
+  if (!audioAsset) {
+    blockers.push({
+      code: 'AUDIO_ASSET_REQUIRED',
+      message: 'Episode is missing required audio asset.',
+    });
+  } else {
+    if (!audioAsset.mimeType?.startsWith('audio/')) {
+      blockers.push({
+        code: 'AUDIO_ASSET_MIME_INVALID',
+        message: 'Audio asset must have an audio MIME type.',
+        metadata: { assetId: audioAsset.id, mimeType: audioAsset.mimeType },
+      });
+    }
+
+    if (audioAsset.byteSize !== null && audioAsset.byteSize <= 0) {
+      blockers.push({
+        code: 'AUDIO_ASSET_SIZE_INVALID',
+        message: 'Audio asset byte size must be positive when known.',
+        metadata: { assetId: audioAsset.id, byteSize: audioAsset.byteSize },
+      });
+    }
+  }
+
+  if (!coverAsset) {
+    blockers.push({
+      code: 'COVER_ART_ASSET_REQUIRED',
+      message: 'Episode is missing required cover art asset.',
+    });
+  } else if (!coverAsset.mimeType?.startsWith('image/')) {
+    blockers.push({
+      code: 'COVER_ART_ASSET_MIME_INVALID',
+      message: 'Cover art asset must have an image MIME type.',
+      metadata: { assetId: coverAsset.id, mimeType: coverAsset.mimeType },
+    });
+  }
+
+  return blockers;
+}
+
 async function resolveFeed(
   productionStore: ProductionStore,
   episode: EpisodeRecord,
@@ -365,6 +702,22 @@ async function resolveFeed(
   }
 
   return feed;
+}
+
+async function maybeResolveFeed(
+  productionStore: ProductionStore,
+  episode: EpisodeRecord,
+  requestedFeedId?: string,
+) {
+  try {
+    return await resolveFeed(productionStore, episode, requestedFeedId);
+  } catch (error) {
+    if (error instanceof ApiError && ['PUBLISH_FEED_REQUIRED', 'FEED_NOT_FOUND', 'FEED_SHOW_MISMATCH'].includes(error.code)) {
+      return null;
+    }
+
+    throw error;
+  }
 }
 
 function feedGuid(episode: EpisodeRecord, feed: FeedRecord) {
@@ -449,6 +802,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
     let jobStore: Pick<SearchJobStore, 'createJob' | 'updateJob'> | undefined;
     let productionStore: ProductionStore | undefined;
     const logs: Array<Record<string, unknown>> = [];
+    let stage = 'initializing';
 
     try {
       const rawStore = options.getStore();
@@ -461,19 +815,99 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         throw new ApiError(404, 'EPISODE_NOT_FOUND', `Episode not found: ${request.params.id}`);
       }
 
-      assertApprovedForPublish(episode);
-      const feed = await resolveFeed(productionStore, episode, body.feedId);
       const assets = await productionStore.listEpisodeAssets(episode.id);
+      const maybeFeed = await maybeResolveFeed(productionStore, episode, body.feedId);
+      const blockers = publishBlockers(episode, assets, maybeFeed, {
+        republish: body.republish,
+        changelog: body.changelog ?? null,
+      });
+
+      if (blockers.length > 0) {
+        throw new ApiError(409, 'PUBLISH_BLOCKED', 'Episode cannot be published until blocking issues are resolved.', {
+          blockedReasons: blockers,
+        });
+      }
+
+      const feed = maybeFeed;
+
+      if (!feed) {
+        throw new ApiError(409, 'PUBLISH_BLOCKED', 'Episode cannot be published until blocking issues are resolved.', {
+          blockedReasons: [{
+            code: 'PUBLISH_FEED_REQUIRED',
+            message: 'Show has no configured RSS feed.',
+          }],
+        });
+      }
+
       const audioAsset = selectAsset(assets, ['audio-final', 'audio-preview'], 'audio');
       const coverAsset = selectAsset(assets, ['cover-art'], 'cover art');
       const guid = feedGuid(episode, feed);
       const storageAdapter = options.publishStorageAdapterFactory?.(feed) ?? createPublishStorageAdapter(feed);
+
+      if (episode.status === 'published' && episode.feedGuid && !body.republish) {
+        const previousPublish = episode.metadata.publish && typeof episode.metadata.publish === 'object' && !Array.isArray(episode.metadata.publish)
+          ? episode.metadata.publish as Record<string, unknown>
+          : {};
+
+        logs.push(log('info', 'Episode is already published; returning idempotent publish result.', {
+          episodeId: episode.id,
+          feedId: feed.id,
+          feedGuid: guid,
+          actor: body.actor,
+        }));
+        job = await createJob(jobStore, {
+          showId: episode.showId,
+          episodeId: episode.id,
+          type: 'publish.rss',
+          status: 'running',
+          progress: 0,
+          attempts: 1,
+          input: {
+            stage: 'idempotent',
+            episodeId: episode.id,
+            feedId: feed.id,
+            feedGuid: guid,
+            actor: body.actor,
+            republish: false,
+            changelog: body.changelog ?? null,
+          },
+          logs,
+          startedAt: new Date(),
+        });
+        job = await updateJob(jobStore, job.id, {
+          status: 'succeeded',
+          progress: 100,
+          logs,
+          output: {
+            stage: 'idempotent',
+            idempotent: true,
+            episodeId: episode.id,
+            feedId: feed.id,
+            feedGuid: guid,
+            audioUrl: previousPublish.audioUrl ?? null,
+            unwrappedAudioUrl: previousPublish.unwrappedAudioUrl ?? null,
+            coverUrl: previousPublish.coverUrl ?? null,
+            rssUrl: previousPublish.rssUrl ?? feed.publicFeedUrl,
+            rssInserted: false,
+          },
+          finishedAt: new Date(),
+        }) ?? job;
+
+        return reply.code(200).send({
+          ok: true,
+          idempotent: true,
+          job,
+          episode,
+          publishEvent: null,
+        });
+      }
 
       logs.push(log('info', 'Starting publish.rss job.', {
         episodeId: episode.id,
         feedId: feed.id,
         feedGuid: guid,
         actor: body.actor,
+        republish: body.republish,
       }));
       job = await createJob(jobStore, {
         showId: episode.showId,
@@ -488,6 +922,8 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           feedGuid: guid,
           actor: body.actor,
           changelog: body.changelog ?? null,
+          republish: body.republish,
+          stage,
         },
         logs,
         startedAt: new Date(),
@@ -501,26 +937,37 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         metadata: {
           jobId: job.id,
           actor: body.actor,
+          republish: body.republish,
         },
       });
 
+      stage = 'uploading-assets';
       logs.push(log('info', 'Uploading publish assets.', {
         audioAssetId: audioAsset.id,
         coverAssetId: coverAsset.id,
       }));
-      job = await updateJob(jobStore, job.id, { progress: 35, logs }) ?? job;
+      job = await updateJob(jobStore, job.id, {
+        progress: 35,
+        logs,
+        output: { stage },
+      }) ?? job;
       const [audioUpload, coverUpload] = await Promise.all([
         storageAdapter.uploadAsset({ feed, episode, asset: audioAsset }),
         storageAdapter.uploadAsset({ feed, episode, asset: coverAsset }),
       ]);
       const rssAudioUrl = feed.op3Wrap ? op3Wrap(audioUpload.publicUrl) : audioUpload.publicUrl;
 
+      stage = 'updating-rss';
       logs.push(log('info', 'Updating RSS feed.', {
         op3Wrapped: feed.op3Wrap,
         audioUrl: rssAudioUrl,
         coverUrl: coverUpload.publicUrl,
       }));
-      job = await updateJob(jobStore, job.id, { progress: 70, logs }) ?? job;
+      job = await updateJob(jobStore, job.id, {
+        progress: 70,
+        logs,
+        output: { stage },
+      }) ?? job;
       const publishedAt = episode.publishedAt ?? new Date();
       const rss = await rssUpdateAdapter.upsertEpisode({
         feed,
@@ -537,6 +984,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           publishedAt,
         },
       });
+      stage = 'validating-public-urls';
       const validations = await urlValidator.validate([rssAudioUrl, coverUpload.publicUrl, rss.rssUrl]);
       const invalidUrl = validations.find((validation) => !validation.ok);
 
@@ -561,6 +1009,13 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
             unwrappedAudioUrl: audioUpload.publicUrl,
             coverUrl: coverUpload.publicUrl,
             op3Wrapped: feed.op3Wrap,
+            op3: {
+              enabled: feed.op3Wrap,
+              originalAudioUrl: audioUpload.publicUrl,
+              wrappedAudioUrl: rssAudioUrl,
+            },
+            republished: body.republish,
+            changelog: body.changelog ?? null,
             validatedUrls: validations,
           },
         },
@@ -578,6 +1033,11 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           audioUpload,
           coverUpload,
           rss,
+          op3: {
+            enabled: feed.op3Wrap,
+            originalAudioUrl: audioUpload.publicUrl,
+            wrappedAudioUrl: rssAudioUrl,
+          },
           validatedUrls: validations,
         },
       }) ?? publishEvent;
@@ -592,6 +1052,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         progress: 100,
         logs,
         output: {
+          stage: 'completed',
           episodeId: updatedEpisode.id,
           feedId: feed.id,
           publishEventId: publishEvent.id,
@@ -617,6 +1078,10 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           progress: job.progress,
           logs,
           error: message,
+          output: failureOutput(stage, error, {
+            episodeId: job.episodeId,
+            publishEventId: publishEvent?.id ?? null,
+          }),
           finishedAt: new Date(),
         }) ?? job;
       }
@@ -636,6 +1101,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
     let job: JobRecord | undefined;
     let jobStore: Pick<SearchJobStore, 'createJob' | 'updateJob'> | undefined;
     const logs: Array<Record<string, unknown>> = [];
+    let stage = 'initializing';
 
     try {
       const rawStore = options.getStore();
@@ -647,12 +1113,14 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const show = await getShow(rawStore, script.showId);
       const episode = await getOrCreateEpisode(productionStore, script, revision);
       const production = productionConfig(show);
+      const warnings = revisionWarnings(revision);
 
       logs.push(log('info', 'Starting audio.preview job.', {
         scriptId: script.id,
         revisionId: revision.id,
         episodeId: episode.id,
         provider: production.ttsProvider ?? 'vertex-gemini-tts',
+        warningCount: warnings.length,
       }));
       job = await createJob(jobStore, {
         showId: script.showId,
@@ -667,18 +1135,30 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           episodeId: episode.id,
           provider: production.ttsProvider ?? 'vertex-gemini-tts',
           actor: body.actor,
+          stage,
+          warnings,
         },
         logs,
         startedAt: new Date(),
       });
 
+      stage = 'rendering-audio';
       logs.push(log('info', 'Rendering preview audio.', { provider: production.ttsProvider ?? 'vertex-gemini-tts' }));
-      job = await updateJob(jobStore, job.id, { progress: 45, logs }) ?? job;
-      const generated = await audioPreviewProvider.generatePreviewAudio({ show, script, revision, episodeSlug: episode.slug, production });
+      job = await updateJob(jobStore, job.id, { progress: 45, logs, output: { stage } }) ?? job;
+      const generated = await audioPreviewProvider.generatePreviewAudio({
+        show,
+        script,
+        revision,
+        episodeId: episode.id,
+        episodeSlug: episode.slug,
+        production,
+      });
+      stage = 'persisting-asset';
       const asset = await productionStore.createEpisodeAsset(assetInput(episode, 'audio-preview', generated, {
         scriptId: script.id,
         revisionId: revision.id,
         jobId: job.id,
+        warnings,
       }));
       const updatedEpisode = await productionStore.updateEpisodeProduction(episode.id, {
         status: 'audio-ready',
@@ -700,11 +1180,19 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         progress: 100,
         logs,
         output: {
+          stage: 'completed',
           episodeId: updatedEpisode.id,
           assetId: asset.id,
           publicUrl: asset.publicUrl,
           objectKey: asset.objectKey,
           durationSeconds: asset.durationSeconds,
+          byteSize: asset.byteSize,
+          mimeType: asset.mimeType,
+          checksum: asset.checksum,
+          provider: asset.metadata.provider,
+          adapter: asset.metadata.adapter,
+          retryable: false,
+          warnings,
         },
         finishedAt: new Date(),
       }) ?? job;
@@ -719,6 +1207,10 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           progress: job.progress,
           logs,
           error: message,
+          output: failureOutput(stage, error, {
+            scriptId: request.params.id,
+            provider: job.input.provider,
+          }),
           finishedAt: new Date(),
         }) ?? job;
       }
@@ -731,21 +1223,34 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
     let job: JobRecord | undefined;
     let jobStore: Pick<SearchJobStore, 'createJob' | 'updateJob'> | undefined;
     const logs: Array<Record<string, unknown>> = [];
+    let stage = 'initializing';
 
     try {
       const rawStore = options.getStore();
-      const body = requestSchema.parse(request.body ?? {});
+      const body = coverArtSchema.parse(request.body ?? {});
       const scriptStore = requireScriptStore(rawStore);
       const productionStore = requireProductionStore(rawStore);
       jobStore = requireJobStore(rawStore);
       const { script, revision } = await loadApprovedScript(scriptStore, request.params.id);
       const show = await getShow(rawStore, script.showId);
       const episode = await getOrCreateEpisode(productionStore, script, revision);
+      const researchPacket = await resolveResearchPacket(rawStore, script);
       const production = productionConfig(show);
       const modelProfile = hasModelProfileStore(rawStore)
         ? await resolveModelProfile(rawStore, { showId: show.id, role: 'cover_prompt_writer' })
         : undefined;
-      const prompt = coverPrompt(show, script, revision, modelProfileRecord(modelProfile));
+      const resolvedPrompt = await resolveCoverPrompt({
+        store: rawStore,
+        show,
+        script,
+        revision,
+        researchPacket,
+        providedPrompt: body.prompt,
+        artDirection: body.artDirection,
+        llmRuntime: options.llmRuntime,
+        modelProfile,
+      });
+      const prompt = resolvedPrompt.prompt;
 
       logs.push(log('info', 'Starting art.generate job.', {
         scriptId: script.id,
@@ -753,6 +1258,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         episodeId: episode.id,
         provider: production.artProvider ?? 'configured-art-provider',
         modelProfileId: modelProfile?.id,
+        promptSource: resolvedPrompt.promptMetadata.source,
       }));
       job = await createJob(jobStore, {
         showId: script.showId,
@@ -767,20 +1273,37 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           episodeId: episode.id,
           provider: production.artProvider ?? 'configured-art-provider',
           prompt,
+          promptMetadata: resolvedPrompt.promptMetadata,
           modelProfile,
           actor: body.actor,
+          stage,
         },
         logs,
         startedAt: new Date(),
       });
 
+      stage = 'generating-cover-art';
       logs.push(log('info', 'Generating cover art.', { provider: production.artProvider ?? 'configured-art-provider' }));
-      job = await updateJob(jobStore, job.id, { progress: 50, logs }) ?? job;
-      const generated = await coverArtProvider.generateCoverArt({ show, script, revision, episodeSlug: episode.slug, production, prompt });
+      job = await updateJob(jobStore, job.id, { progress: 50, logs, output: { stage } }) ?? job;
+      const generated = await coverArtProvider.generateCoverArt({
+        show,
+        script,
+        revision,
+        episodeId: episode.id,
+        episodeSlug: episode.slug,
+        researchPacket,
+        production,
+        prompt,
+      });
+      stage = 'persisting-asset';
       const asset = await productionStore.createEpisodeAsset(assetInput(episode, 'cover-art', generated, {
         scriptId: script.id,
         revisionId: revision.id,
         jobId: job.id,
+        prompt,
+        promptResult: resolvedPrompt.promptResult,
+        promptMetadata: resolvedPrompt.promptMetadata,
+        researchPacketId: researchPacket?.id ?? null,
         modelProfile,
       }));
       const updatedEpisode = await productionStore.updateEpisodeProduction(episode.id, {
@@ -801,11 +1324,21 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         progress: 100,
         logs,
         output: {
+          stage: 'completed',
           episodeId: updatedEpisode.id,
           assetId: asset.id,
           publicUrl: asset.publicUrl,
           objectKey: asset.objectKey,
+          byteSize: asset.byteSize,
+          mimeType: asset.mimeType,
+          checksum: asset.checksum,
+          prompt,
+          promptResult: resolvedPrompt.promptResult,
+          promptMetadata: resolvedPrompt.promptMetadata,
+          provider: asset.metadata.provider,
+          adapter: asset.metadata.adapter,
           modelProfile,
+          retryable: false,
         },
         finishedAt: new Date(),
       }) ?? job;
@@ -820,6 +1353,10 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           progress: job.progress,
           logs,
           error: message,
+          output: failureOutput(stage, error, {
+            scriptId: request.params.id,
+            provider: job.input.provider,
+          }),
           finishedAt: new Date(),
         }) ?? job;
       }

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -771,6 +771,24 @@ function quotedValue(content: string, key: string): string | undefined {
 }
 
 function scriptWriterResult(request: LlmProviderRequest): LlmProviderResult {
+  if (request.attempt.role === 'cover_prompt_writer') {
+    const output = {
+      prompt: 'A restrained editorial podcast cover with abstract newsroom light, no logos, no real people.',
+      negativePrompt: 'logos, real people, sensational disaster imagery',
+      altText: 'Abstract editorial cover art for a sourced AI news episode.',
+      safetyNotes: ['Avoids depicting real people or unsupported scenes.'],
+    };
+    const text = JSON.stringify(output);
+
+    return {
+      text,
+      rawOutput: text,
+      metadata: { adapter: 'test-fake-cover-prompt-writer' },
+      usage: { inputTokens: 5, outputTokens: 8, totalTokens: 13 },
+      cost: { usd: 0, currency: 'USD' },
+    };
+  }
+
   if (request.attempt.role !== 'script_writer') {
     const text = JSON.stringify({ ok: true });
     return { text, rawOutput: text, metadata: { adapter: 'test-fake' } };
@@ -819,6 +837,7 @@ function scriptWriterResult(request: LlmProviderRequest): LlmProviderResult {
 const llmRuntime = createLlmRuntime({
   adapters: [
     createFakeLlmProvider({ provider: 'openai-codex', handler: scriptWriterResult }),
+    createFakeLlmProvider({ provider: 'openai', handler: scriptWriterResult }),
     createFakeLlmProvider({ provider: 'google-vertex', handler: scriptWriterResult }),
     createFakeLlmProvider({ provider: 'google-gemini-cli', handler: scriptWriterResult }),
   ],
@@ -1932,6 +1951,11 @@ describe('source profile routes', () => {
     assert.equal(audioBody.asset.type, 'audio-preview');
     assert.equal(audioBody.asset.mimeType, 'audio/mpeg');
     assert.equal(audioBody.asset.metadata.provider, 'vertex-gemini-tts');
+    assert.equal(audioBody.asset.metadata.adapterKind, 'fake-local-audio-preview');
+    assert.match(audioBody.asset.localPath, /audio-preview\.mp3$/);
+    assert.equal(audioBody.job.output.stage, 'completed');
+    assert.equal(audioBody.job.output.byteSize, audioBody.asset.byteSize);
+    assert.equal(audioBody.job.output.mimeType, 'audio/mpeg');
     assert.equal(audioBody.episode.status, 'audio-ready');
     assert.equal(audioBody.episode.metadata.audioPreviewAssetId, audioBody.asset.id);
 
@@ -1946,9 +1970,13 @@ describe('source profile routes', () => {
     assert.equal(artBody.job.type, 'art.generate');
     assert.equal(artBody.job.status, 'succeeded');
     assert.equal(artBody.job.input.modelProfile.role, 'cover_prompt_writer');
+    assert.equal(artBody.job.input.promptMetadata.source, 'cover_prompt_writer');
+    assert.equal(artBody.job.output.promptResult.altText, 'Abstract editorial cover art for a sourced AI news episode.');
     assert.equal(artBody.asset.type, 'cover-art');
     assert.equal(artBody.asset.mimeType, 'image/png');
     assert.equal(artBody.asset.metadata.provider, 'openai-gpt-image');
+    assert.equal(artBody.asset.metadata.promptMetadata.source, 'cover_prompt_writer');
+    assert.match(artBody.asset.localPath, /cover\.png$/);
     assert.equal(artBody.episode.id, audioBody.episode.id);
     assert.equal(artBody.episode.metadata.coverArtAssetId, artBody.asset.id);
 
@@ -1981,9 +2009,50 @@ describe('source profile routes', () => {
     const body = response.json();
 
     assert.equal(response.statusCode, 409);
-    assert.equal(body.code, 'EPISODE_NOT_APPROVED_FOR_PUBLISH');
+    assert.equal(body.code, 'PUBLISH_BLOCKED');
+    assert.deepEqual(body.blockedReasons.map((reason: { code: string }) => reason.code), ['EPISODE_NOT_APPROVED_FOR_PUBLISH']);
     assert.equal(store.jobs.some((job) => job.type === 'publish.rss'), false);
     assert.equal(uploadedPublishAssets.length, 0);
+  });
+
+  it('uses a provided cover prompt without invoking the prompt writer', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Provided Prompt Story',
+      status: 'approved',
+      sourceDocumentIds: [],
+      claims: [{ id: 'claim-1', text: 'A provided prompt claim exists.', sourceDocumentIds: [], citationUrls: ['https://example.com/prompt'] }],
+      citations: [],
+      warnings: [],
+      content: { summary: 'A packet summary for provided prompt testing.' },
+    });
+    const scriptResponse = await app.inject({
+      method: 'POST',
+      url: `/research-packets/${packet.id}/script`,
+    });
+    const initial = scriptResponse.json();
+
+    await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/approve-for-audio`,
+      payload: { actor: 'producer@example.com' },
+    });
+
+    const artResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/production/cover-art`,
+      payload: {
+        actor: 'producer@example.com',
+        prompt: 'Use a quiet newsroom desk with abstract waveform lines.',
+      },
+    });
+    const artBody = artResponse.json();
+
+    assert.equal(artResponse.statusCode, 201);
+    assert.equal(artBody.job.input.prompt, 'Use a quiet newsroom desk with abstract waveform lines.');
+    assert.equal(artBody.job.input.promptMetadata.source, 'provided');
+    assert.equal(artBody.asset.metadata.prompt, 'Use a quiet newsroom desk with abstract waveform lines.');
   });
 
   it('publishes approved episodes to RSS with uploaded assets, OP3 wrapping, and URL validation', async () => {
@@ -2046,11 +2115,56 @@ describe('source profile routes', () => {
     const secondBody = secondResponse.json();
 
     assert.equal(firstResponse.statusCode, 201);
-    assert.equal(secondResponse.statusCode, 201);
+    assert.equal(secondResponse.statusCode, 200);
     assert.equal(firstBody.episode.feedGuid, secondBody.episode.feedGuid);
     assert.equal(firstBody.job.output.rssInserted, true);
+    assert.equal(secondBody.idempotent, true);
+    assert.equal(secondBody.job.output.idempotent, true);
     assert.equal(secondBody.job.output.rssInserted, false);
     assert.equal(rssEntries.size, 1);
+    assert.equal(uploadedPublishAssets.length, 2);
+    assert.equal(store.publishEvents.filter((event) => event.status === 'succeeded').length, 1);
+  });
+
+  it('requires an explicit changelog to re-publish an already published episode', async () => {
+    const { episode } = await createProducedEpisode('Republish Changelog Story');
+
+    await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/approve-for-publish`,
+      payload: { actor: 'editor@example.com' },
+    });
+    await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/publish/rss`,
+      payload: { actor: 'publisher@example.com' },
+    });
+
+    const blockedResponse = await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/publish/rss`,
+      payload: { actor: 'publisher@example.com', republish: true },
+    });
+    const blockedBody = blockedResponse.json();
+
+    assert.equal(blockedResponse.statusCode, 409);
+    assert.equal(blockedBody.code, 'PUBLISH_BLOCKED');
+    assert.deepEqual(blockedBody.blockedReasons.map((reason: { code: string }) => reason.code), ['REPUBLISH_CHANGELOG_REQUIRED']);
+
+    const republishResponse = await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/publish/rss`,
+      payload: {
+        actor: 'publisher@example.com',
+        republish: true,
+        changelog: 'Corrected the episode description and regenerated feed metadata.',
+      },
+    });
+    const republishBody = republishResponse.json();
+
+    assert.equal(republishResponse.statusCode, 201);
+    assert.equal(republishBody.job.output.rssInserted, false);
+    assert.equal(republishBody.publishEvent.changelog, 'Corrected the episode description and regenerated feed metadata.');
     assert.equal(store.publishEvents.filter((event) => event.status === 'succeeded').length, 2);
   });
 
@@ -2099,6 +2213,8 @@ describe('source profile routes', () => {
     assert.equal(failedResponse.statusCode, 500);
     assert.equal(failedBody.job.status, 'failed');
     assert.equal(failedBody.job.error, 'Synthetic TTS failure');
+    assert.equal(failedBody.job.output.stage, 'rendering-audio');
+    assert.equal(failedBody.job.output.retryable, true);
 
     const retryResponse = await app.inject({
       method: 'POST',


### PR DESCRIPTION
## Summary
- Adds deterministic local/fake audio and cover-art production adapters with durable asset metadata.
- Hardens production jobs with progress/stage output, warnings, retryable failure metadata, and provider/model details.
- Adds guarded RSS publishing with approval checks, URL/feed validation, OP3 metadata, idempotency, and explicit republish changelog handling.

## Verification
- npm run check
- git diff --check

Closes #19