### PR TITLE
docs: clarify product terminology and UI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ This repo is the productized successor to the local TSL Command Center + Byte Si
 
 ## Repo status
 
-Planning/scaffold phase. See:
+Active MVP build. See:
 
 - [PRD](docs/PRD.md)
 - [Architecture](docs/ARCHITECTURE.md)
+- [UX glossary](docs/UX_GLOSSARY.md)
 - [Configuration schema](schemas/podcast-forge.config.schema.json)
 - [Example config](config/examples/the-synthetic-lens.json)
 - [Development plan](docs/DEVELOPMENT_PLAN.md)
@@ -54,10 +55,11 @@ Available config endpoints:
   validates a config file path. Leading `~/` is expanded, and relative paths
   resolve from the API process working directory.
 
-## Source profile UI
+## Story sources UI
 
-Source profiles and search queries are persisted in Postgres through the
-`@podcast-forge/db` schema. To run the app locally:
+Story sources, called source profiles in backend/API code, and search queries
+are persisted in Postgres through the `@podcast-forge/db` schema. To run the app
+locally:
 
 ```sh
 cp .env.example .env
@@ -67,17 +69,17 @@ npm run db:seed --workspace @podcast-forge/db
 npm run dev --workspace @podcast-forge/api
 ```
 
-Open `http://localhost:3450/ui` to edit source profiles and queries for
-`the-synthetic-lens`. The UI can enable or disable profiles and individual
+Open `http://localhost:3450/ui` to edit story sources and search queries for
+`the-synthetic-lens`. The UI can enable or disable story sources and individual
 queries, edit query text, freshness, include/exclude domains, and weights, and
-create or delete query buckets.
+create or delete search queries.
 
 ## New show onboarding
 
 Shows can be added from the local UI with `New Show`. The onboarding form
 creates the show in `draft` or `active` setup state, adds a feed, creates a
-starter source profile and query, and seeds model profiles for each supported
-agent role. Draft shows are returned by `GET /shows`, so setup can be completed
+starter story source/search query, and seeds AI role settings for each supported
+model role. Draft shows are returned by `GET /shows`, so setup can be completed
 over time without editing seed data, config files, or the database directly.
 
 Show/feed endpoints:
@@ -103,7 +105,7 @@ Source profile endpoints:
 Use `enabledOnly=true` for search jobs so disabled profiles and queries are not
 included in source discovery.
 
-## Model profile routing
+## AI role routing
 
 Model choices are runtime configuration, not code constants. The supported
 roles are `candidate_scorer`, `source_summarizer`, `claim_extractor`,
@@ -112,8 +114,8 @@ and `cover_prompt_writer`.
 
 Seeded configs write each `models` entry into `model_profiles` with
 provider/model, params, fallbacks, prompt template key, and budget. Worker-style
-jobs resolve the active profile by show and role at runtime. `source.search`
-records the resolved `candidate_scorer`; research packet generation records
+tasks resolve the active profile by show and role at runtime. `source.search`
+records the resolved `candidate_scorer`; research brief generation records
 `source_summarizer`, `claim_extractor`, and `research_synthesizer` in both the
 job metadata and packet content.
 
@@ -369,9 +371,12 @@ The local UI at `http://localhost:3450/ui` includes a manual URL form. For RSS,
 create or edit a profile with type `rss`, add enabled query rows containing feed
 URLs, then use the `Ingest RSS` action shown for RSS profiles.
 
-## Research packets
+## Research briefs
 
-Selected story candidates can produce evidence-first research packets. The API
+The UI calls these records research briefs. Backend/API code and route paths
+still use `research_packets` and `/research-packets` for stable identifiers.
+
+Selected candidate stories can produce evidence-first research briefs. The API
 fetches readable source snapshots into `source_documents`, then writes a
 `research_packets` row with source document references, cited claims, citation
 URLs, warning objects, synthesis content, and readiness metadata. When injected
@@ -555,5 +560,5 @@ Publishing endpoints:
 - `POST /episodes/:id/publish/rss`
 
 The local UI at `http://localhost:3450/ui` includes a script review panel where
-editors can paste a research packet ID, generate a draft, edit the latest
-revision, and approve it for audio.
+editors can select or paste a research brief ID, generate a draft, edit the
+latest revision, and approve it for audio.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,9 @@ Shared storage: local filesystem in dev; S3/R2-compatible object storage in prod
 
 ## Core entities
 
+See [UX glossary](UX_GLOSSARY.md) for how these backend entity names map to
+user-facing labels in the app.
+
 - `shows`
 - `feeds`
 - `source_profiles`

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2,7 +2,7 @@
 
 ## 1. Summary
 
-Podcast Forge is an agent-powered podcast building tool for producing research-backed episodes from configurable source profiles. It combines news/search ingestion, source fetching, evidence clustering, research agents, script-writing agents, TTS/art production, human approval gates, RSS publishing, and analytics tracking in one packaged app.
+Podcast Forge is an agent-powered podcast building tool for producing research-backed episodes from configurable story sources. It combines news/search ingestion, source fetching, evidence clustering, research agents, script-writing agents, TTS/art production, human approval gates, RSS publishing, and analytics tracking in one packaged app.
 
 The first production target is **The Synthetic Lens** workflow currently running through the local TSL Command Center and Byte Sized scripts. The product should be designed as multi-show and configurable from the start.
 
@@ -34,8 +34,8 @@ Creators need a configurable system that can repeatedly turn source material int
 ## 4. Core use cases
 
 1. Configure a show: title, feed, voice cast, tone, runtime targets, publishing destination.
-2. Configure source profiles: Brave/news queries, RSS feeds, domains, blocked domains, source freshness, scoring weights.
-3. Run a fresh search and ingest story candidates.
+2. Configure story sources/search recipes: Brave/news queries, RSS feeds, domains, blocked domains, source freshness, scoring weights.
+3. Run a fresh search and ingest candidate stories.
 4. Cluster related stories into episode candidates.
 5. Fetch and snapshot source documents.
 6. Build a research packet with claims, citations, and warnings.
@@ -197,7 +197,7 @@ Each role should support:
 MVP should productize the existing TSL flow:
 
 1. Postgres schema and migrations.
-2. Configurable show/source/model profiles.
+2. Configurable shows, story sources, and AI role settings.
 3. Brave search + RSS/manual URL ingestion.
 4. Candidate scoring and story list UI.
 5. Research packet creation with source snapshots.

--- a/docs/UX_GLOSSARY.md
+++ b/docs/UX_GLOSSARY.md
@@ -1,0 +1,33 @@
+# UX Glossary
+
+Podcast Forge keeps backend, database, and API identifiers technical so audit records stay stable. User-facing screens, docs for operators, and inline help should use clearer editorial language unless the exact API/table name is necessary.
+
+## When to Use Each Term
+
+- Use backend terms in schema files, migrations, route paths, TypeScript types, logs, debug details, API examples, and troubleshooting notes that refer to exact records.
+- Use user-facing terms in UI headings, buttons, empty states, onboarding copy, help text, operator docs, and review checklists.
+- If both are needed, lead with the user-facing term and include the backend term in parentheses only when it helps someone map UI to an API or audit record.
+
+## Term Map
+
+| Backend term | User-facing term | Definition | Use the backend term when... | Use the user-facing term when... |
+| --- | --- | --- | --- | --- |
+| Source Profile | Story Sources / Search Recipe | A saved source configuration that controls where a show discovers candidate stories, including provider type, freshness, weights, and domain filters. | Referring to `source_profiles`, API payload fields, migrations, route names, or debug output. | Labeling the source list, setup help, or operator steps for configuring discovery. |
+| Source Query | Search Query | A specific query string, RSS URL, or source instruction under a story source. | Referring to `source_queries` rows or `/source-queries` endpoints. | Asking users to add or edit the query text that finds stories. |
+| Story Candidate | Candidate Story / Possible Story | A deduped item discovered from search, RSS, manual URL entry, or import that may become an episode. | Referring to `story_candidates`, exact status values, or API examples. | Showing story lists, scores, selection actions, and empty states. |
+| Research Packet | Research Brief / Episode Brief | The evidence bundle for a possible episode: fetched source snapshots, cited claims, warnings, synthesis, and readiness. | Referring to `research_packets`, endpoint paths, or persisted provenance fields. | Guiding editors through research review, warning checks, and script drafting. |
+| Model Profile | AI Role Settings / Model Role | The provider, model, parameters, budget, fallbacks, and prompt connection for an agent role. | Referring to `model_profiles`, resolver behavior, or model routing internals. | Showing role configuration in settings or explaining which AI role handles scoring, research, writing, metadata, or art prompts. |
+| Prompt Template | Prompt Template / Agent Instructions | Reusable instructions and response schema hints for an AI role. | Referring to `prompt_templates`, template keys, versions, or render endpoints. | Describing editable role instructions to operators. |
+| Job | Task / Run | A tracked unit of work with status, progress, logs, input, output, and retry/failure metadata. | Referring to `jobs`, job types such as `source.search`, or debug logs. | Showing progress, retry actions, or scheduled/manual run history. |
+| Episode Asset | Audio/Cover Asset | A persisted generated or uploaded production file such as preview audio or cover art. | Referring to `episode_assets`, storage metadata, MIME type, checksums, or object keys. | Showing production output, review steps, or publishing checklist items. |
+| Approval Event | Review Decision | A persisted human or system decision to approve, reject, or override a gate. | Referring to `approval_events` rows or audit trails. | Asking an editor to approve audio, override a warning, or approve publishing. |
+| Publish Event | Publishing Record | A persisted RSS/storage publication action with GUIDs, URLs, changelog, and adapter metadata. | Referring to `publish_events`, idempotency behavior, or API responses. | Showing publishing history, checklist completion, or feed update results. |
+
+## Technical Terms That May Stay Visible
+
+Some terms are useful to operators and should not be hidden behind vague copy:
+
+- RSS, feed GUID, OP3, URL, HTTP(S), MIME type, checksum, object key, and cron when the user is configuring or auditing those exact systems.
+- Provider/model names and role keys when the screen is explicitly about AI role settings.
+- IDs in forms that still require exact API record IDs, paired with friendly labels such as "Research brief ID."
+- Raw JSON, route names, table names, and logs inside collapsible debug or technical-details areas.

--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -3,14 +3,18 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Podcast Forge Sources</title>
+    <title>Podcast Forge Command Center</title>
     <link rel="stylesheet" href="/styles.css">
   </head>
   <body>
     <header class="topbar">
       <div>
         <h1>Podcast Forge</h1>
-        <p id="status">Loading sources...</p>
+        <p id="status">Loading workspace...</p>
+        <details id="errorDetails" class="debug-details" hidden>
+          <summary>Technical details</summary>
+          <pre id="errorDetailsBody"></pre>
+        </details>
       </div>
       <div class="actions inline">
         <button id="importLegacy" class="secondary" type="button">Import Legacy</button>
@@ -29,7 +33,8 @@
         </div>
         <section>
           <div class="section-title">
-            <h2>Source Profiles</h2>
+            <h2>Story Sources</h2>
+            <p class="help">Search recipes and RSS feeds that discover possible stories.</p>
           </div>
           <div id="profileList" class="list"></div>
         </section>
@@ -40,7 +45,7 @@
           <div class="panel-heading">
             <div>
               <h2>New Show Setup</h2>
-              <p id="showSetupMeta"></p>
+              <p id="showSetupMeta">Set the show identity, feed destination, starter story source, and default AI role settings. Draft shows can be finished later.</p>
             </div>
             <label class="field compact-field">
               <span>Status</span>
@@ -92,7 +97,7 @@
               <input id="showFeedUrl" type="url">
             </label>
             <label class="field">
-              <span>Public asset base</span>
+              <span>Public asset base URL</span>
               <input id="showPublicBase" type="url">
             </label>
           </div>
@@ -103,29 +108,30 @@
               <input id="showOutputPath" type="text" placeholder="feeds/show.xml">
             </label>
             <label class="field">
-              <span>Starter source query</span>
+              <span>Starter search query</span>
               <input id="showSourceQuery" type="text">
+              <small>Creates the first story source search recipe for this show.</small>
             </label>
             <label class="field">
               <span>Publishing mode</span>
               <select id="showPublishingMode">
-                <option value="approval-gated">approval-gated</option>
-                <option value="autopublish-later">autopublish-later</option>
+                <option value="approval-gated">Approval required</option>
+                <option value="autopublish-later">Autopublish later</option>
               </select>
             </label>
           </div>
 
           <div class="grid">
             <label class="field">
-              <span>Model provider</span>
+              <span>Default AI provider</span>
               <input id="showModelProvider" type="text" value="openai" required>
             </label>
             <label class="field">
-              <span>Model</span>
+              <span>Default model</span>
               <input id="showModelName" type="text" value="gpt-5.5" required>
             </label>
             <label class="field">
-              <span>Reasoning</span>
+              <span>Reasoning setting</span>
               <input id="showReasoningEffort" type="text" value="high">
             </label>
           </div>
@@ -139,8 +145,9 @@
         <form id="profileForm" class="panel" hidden>
           <div class="panel-heading">
             <div>
-              <h2 id="profileTitle">Source profile</h2>
+              <h2 id="profileTitle">Story Source</h2>
               <p id="profileMeta"></p>
+              <p class="help">Use story sources to decide where candidates come from, how fresh results should be, and which domains are trusted or blocked.</p>
             </div>
             <label class="toggle">
               <input id="profileEnabled" type="checkbox">
@@ -171,8 +178,9 @@
               <input id="profileWeight" type="number" min="0" step="0.001" required>
             </label>
             <label class="field">
-              <span>Freshness</span>
+              <span>Freshness window</span>
               <input id="profileFreshness" type="text" placeholder="pd, pw, pm">
+              <small>Provider codes such as pd, pw, or pm keep search results recent.</small>
             </label>
           </div>
 
@@ -188,16 +196,16 @@
           </div>
 
           <div class="actions">
-            <button id="ingestProfile" class="secondary" type="button" hidden>Ingest RSS</button>
-            <button type="submit">Save Profile</button>
+            <button id="ingestProfile" class="secondary" type="button" hidden>Import RSS Items</button>
+            <button type="submit">Save Story Source</button>
           </div>
         </form>
 
         <section class="panel">
           <div class="panel-heading">
             <div>
-              <h2>Manual URL</h2>
-              <p id="manualResult"></p>
+              <h2>Add Manual Story</h2>
+              <p id="manualResult">Paste a source URL when a story should be tracked even if search did not find it.</p>
             </div>
           </div>
           <form id="manualForm" class="manual-form">
@@ -226,8 +234,9 @@
         <section class="panel">
           <div class="panel-heading">
             <div>
-              <h2>Model Profiles</h2>
+              <h2>AI Role Settings</h2>
               <p id="modelMeta"></p>
+              <p class="help">Each role controls which model and prompt template handles scoring, research, writing, or cover prompts.</p>
             </div>
           </div>
           <div id="modelProfileList" class="model-grid"></div>
@@ -236,8 +245,9 @@
         <section class="panel">
           <div class="panel-heading">
             <div>
-              <h2>Story Candidates</h2>
+              <h2>Candidate Stories</h2>
               <p id="candidateMeta"></p>
+              <p class="help">Scores rank fit, significance, novelty, and source quality. Create a research brief from a candidate before script drafting.</p>
             </div>
           </div>
           <div id="candidateList" class="record-list"></div>
@@ -246,8 +256,20 @@
         <section class="panel">
           <div class="panel-heading">
             <div>
+              <h2>Research Briefs</h2>
+              <p id="researchBriefMeta"></p>
+              <p class="help">Briefs collect fetched sources, cited claims, and warnings so editors can see what is known and what needs review.</p>
+            </div>
+          </div>
+          <div id="researchBriefList" class="record-list"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-heading">
+            <div>
               <h2>Scheduled Pipelines</h2>
               <p id="schedulerMeta"></p>
+              <p class="help">Recurring runs can prepare ingest, research, scripts, audio, and publishing tasks. Publishing still waits for approval unless autopublish is explicitly enabled.</p>
             </div>
           </div>
           <div id="schedulerList" class="record-list"></div>
@@ -259,6 +281,7 @@
             <div>
               <h2>Episodes</h2>
               <p id="episodeMeta"></p>
+              <p class="help">Publishing checklist: approved script, audio and cover assets, configured feed, valid public URLs, and an explicit publish action. Published episodes keep feed GUIDs, public URLs, and publishing records for audit review.</p>
             </div>
           </div>
           <div id="episodeList" class="record-list"></div>
@@ -267,13 +290,14 @@
         <section id="queriesPanel" class="panel" hidden>
           <div class="panel-heading">
             <div>
-              <h2>Queries</h2>
+              <h2>Search Queries</h2>
               <p id="queryCount"></p>
+              <p class="help">Use focused queries and domain filters to keep candidate stories relevant to this show.</p>
             </div>
           </div>
           <form id="newQueryForm" class="new-query">
-            <textarea id="newQueryText" rows="2" placeholder="New query text" required></textarea>
-            <button type="submit">Create Query</button>
+            <textarea id="newQueryText" rows="2" placeholder="New search query" required></textarea>
+            <button type="submit">Create Search Query</button>
           </form>
           <div id="queryList" class="query-list"></div>
         </section>
@@ -283,18 +307,19 @@
             <div>
               <h2>Scripts</h2>
               <p id="scriptMeta"></p>
+              <p class="help">Draft scripts from approved research briefs, then save revisions and approve one revision before audio production.</p>
             </div>
           </div>
           <form id="scriptGenerateForm" class="script-generate">
             <label class="field">
-              <span>Research packet ID</span>
+              <span>Research brief ID</span>
               <input id="scriptResearchPacketId" type="text" required>
             </label>
             <label class="field">
               <span>Format</span>
               <input id="scriptFormat" type="text" placeholder="feature-analysis">
             </label>
-            <button type="submit">Generate Script</button>
+            <button type="submit">Generate Script Draft</button>
           </form>
           <div class="script-workspace">
             <div id="scriptList" class="list"></div>
@@ -314,12 +339,12 @@
               <section id="productionPanel" class="production-panel" hidden>
                 <div class="panel-heading compact">
                   <div>
-                    <h3>Production</h3>
+                    <h3>Audio and Cover Assets</h3>
                     <p id="productionMeta"></p>
                   </div>
                   <div class="actions inline">
-                    <button id="generateAudioPreview" class="secondary" type="button">Preview MP3</button>
-                    <button id="generateCoverArt" class="secondary" type="button">Cover Art</button>
+                    <button id="generateAudioPreview" class="secondary" type="button">Create Preview MP3</button>
+                    <button id="generateCoverArt" class="secondary" type="button">Create Cover Art</button>
                   </div>
                 </div>
                 <div id="productionJobs" class="production-jobs"></div>

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -62,9 +62,44 @@ button:disabled {
 }
 
 .topbar p,
-.panel p {
+.panel p,
+.section-title p {
   color: #586575;
   margin: 0.25rem 0 0;
+}
+
+.help,
+.field small {
+  color: #687486;
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+
+.field small {
+  display: block;
+}
+
+.debug-details {
+  color: #3f4b5a;
+  font-size: 0.85rem;
+  margin-top: 0.45rem;
+  max-width: min(720px, 100%);
+}
+
+.debug-details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.debug-details pre {
+  background: #111827;
+  border-radius: 6px;
+  color: #e5e7eb;
+  margin: 0.5rem 0 0;
+  max-height: 18rem;
+  overflow: auto;
+  padding: 0.75rem;
+  white-space: pre-wrap;
 }
 
 .layout {
@@ -218,6 +253,10 @@ textarea {
   margin-top: 0;
 }
 
+.row-actions {
+  justify-content: flex-start;
+}
+
 .new-query {
   display: grid;
   gap: 0.75rem;
@@ -307,6 +346,10 @@ textarea {
   padding: 0.75rem;
 }
 
+.record-row > button {
+  justify-self: start;
+}
+
 .record-row strong,
 .record-row span,
 .record-row p {
@@ -347,6 +390,10 @@ textarea {
 
 .scheduler-failures h3 {
   margin: 0;
+}
+
+.row-debug {
+  grid-column: 1 / -1;
 }
 
 .production-row.failed {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -3,6 +3,7 @@ const state = {
   profiles: [],
   queries: [],
   scripts: [],
+  researchPackets: [],
   modelProfiles: [],
   scheduledPipelines: [],
   failedScheduledRuns: [],
@@ -24,6 +25,8 @@ const state = {
 
 const els = {
   status: document.querySelector('#status'),
+  errorDetails: document.querySelector('#errorDetails'),
+  errorDetailsBody: document.querySelector('#errorDetailsBody'),
   refresh: document.querySelector('#refresh'),
   importLegacy: document.querySelector('#importLegacy'),
   showSelect: document.querySelector('#showSelect'),
@@ -68,6 +71,8 @@ const els = {
   manualResult: document.querySelector('#manualResult'),
   candidateMeta: document.querySelector('#candidateMeta'),
   candidateList: document.querySelector('#candidateList'),
+  researchBriefMeta: document.querySelector('#researchBriefMeta'),
+  researchBriefList: document.querySelector('#researchBriefList'),
   schedulerMeta: document.querySelector('#schedulerMeta'),
   schedulerList: document.querySelector('#schedulerList'),
   failedScheduleRuns: document.querySelector('#failedScheduleRuns'),
@@ -97,8 +102,81 @@ const els = {
   productionAssets: document.querySelector('#productionAssets'),
 };
 
-function setStatus(message) {
+class ApiRequestError extends Error {
+  constructor(message, debugDetails) {
+    super(message);
+    this.name = 'ApiRequestError';
+    this.debugDetails = debugDetails;
+  }
+}
+
+function debugText(value) {
+  if (!value) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function setStatus(message, debugDetails = '') {
   els.status.textContent = message;
+  const detail = debugText(debugDetails);
+  els.errorDetails.hidden = !detail;
+  els.errorDetailsBody.textContent = detail;
+}
+
+function reportError(error, fallback = 'Something went wrong. Open technical details for the API response.') {
+  if (error instanceof ApiRequestError) {
+    setStatus(error.message, error.debugDetails);
+    return error.message;
+  }
+
+  const message = error instanceof Error && error.message ? error.message : fallback;
+  setStatus(fallback, message);
+  return fallback;
+}
+
+function friendlyApiMessage(body, status) {
+  const code = typeof body?.code === 'string' ? body.code : '';
+  const raw = typeof body?.error === 'string' ? body.error : '';
+
+  const messages = {
+    VALIDATION_ERROR: 'Please check the form values and try again.',
+    CONFIG_FILE_NOT_FOUND: 'The requested config file could not be found.',
+    SOURCE_PROFILE_NOT_FOUND: 'That story source could not be found. Refresh and try again.',
+    SOURCE_PROFILE_SHOW_MISMATCH: 'That story source belongs to a different show.',
+    SOURCE_URL_REQUIRED: 'Choose a candidate story with a URL, or add an extra source URL before creating a research brief.',
+    STORY_CANDIDATE_NOT_FOUND: 'That candidate story could not be found. Refresh and try again.',
+    STORY_CANDIDATE_IGNORED: 'Ignored candidate stories cannot be used for research briefs.',
+    CANDIDATE_SHOW_MISMATCH: 'All selected candidate stories must belong to the same show.',
+    RESEARCH_PACKET_NOT_FOUND: 'That research brief could not be found. Check the ID and try again.',
+    RESEARCH_PACKET_OR_WARNING_NOT_FOUND: 'That research brief or warning could not be found.',
+    SCHEDULED_PIPELINE_NOT_FOUND: 'That scheduled pipeline could not be found. Refresh and try again.',
+    SCHEDULED_RUN_NOT_FOUND: 'That scheduled run could not be found. Refresh and try again.',
+    PUBLISH_BLOCKED: 'Publishing is blocked until the checklist items are complete.',
+  };
+
+  if (messages[code]) {
+    return messages[code];
+  }
+
+  if (status === 404) {
+    return 'That record could not be found. Refresh and try again.';
+  }
+
+  if (status === 409) {
+    return raw || 'This action is blocked by the current review or publishing state.';
+  }
+
+  if (status >= 500) {
+    return 'The local API hit a server error. Open technical details for the response.';
+  }
+
+  return raw || `Request failed with status ${status}.`;
 }
 
 function linesToList(value) {
@@ -133,10 +211,24 @@ async function api(path, options = {}) {
     return undefined;
   }
 
-  const body = await response.json();
+  const text = await response.text();
+  let body;
+
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch (error) {
+    throw new ApiRequestError(
+      response.ok ? 'The API returned an unreadable response.' : `Request failed with status ${response.status}.`,
+      text,
+    );
+  }
 
   if (!response.ok || body.ok === false) {
-    throw new Error(body.error || `Request failed: ${response.status}`);
+    throw new ApiRequestError(friendlyApiMessage(body, response.status), {
+      path,
+      status: response.status,
+      response: body,
+    });
   }
 
   return body;
@@ -148,6 +240,15 @@ function selectedProfile() {
 
 function renderShows() {
   els.showSelect.innerHTML = '';
+
+  if (state.shows.length === 0) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'No shows yet';
+    option.disabled = true;
+    els.showSelect.append(option);
+    return;
+  }
 
   for (const show of state.shows) {
     const option = document.createElement('option');
@@ -165,7 +266,9 @@ function renderProfiles() {
   if (state.profiles.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No source profiles found.';
+    empty.textContent = state.selectedShowSlug
+      ? 'No story sources yet. Create one during show setup or add a story source through the API, then add search queries or RSS feeds.'
+      : 'No show selected. Create a show first, then add story sources.';
     els.profileList.append(empty);
     return;
   }
@@ -188,7 +291,9 @@ function renderProfiles() {
 
 function renderShowSetup() {
   els.showSetupForm.hidden = !state.showSetupOpen;
-  els.showSetupMeta.textContent = state.showSetupOpen ? 'Draft setups stay visible in the show list.' : '';
+  els.showSetupMeta.textContent = state.showSetupOpen
+    ? 'Set the show identity, feed destination, starter story source, and default AI role settings. Draft shows can be finished later.'
+    : 'Set the show identity, feed destination, starter story source, and default AI role settings. Draft shows can be finished later.';
 }
 
 function renderProfileForm() {
@@ -221,7 +326,7 @@ function renderQueries() {
   if (state.queries.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No queries configured for this source profile.';
+    empty.textContent = 'No search queries yet. Add a focused query or RSS feed URL, then run search or import RSS items to find candidate stories.';
     els.queryList.append(empty);
     return;
   }
@@ -238,7 +343,7 @@ function renderQueries() {
         <button class="danger" name="delete" type="button">Delete</button>
       </div>
       <label class="field">
-        <span>Query</span>
+        <span>Search query</span>
         <textarea name="query" rows="2" required></textarea>
       </label>
       <div class="query-grid">
@@ -247,7 +352,7 @@ function renderQueries() {
           <input name="weight" type="number" min="0" step="0.001" required>
         </label>
         <label class="field">
-          <span>Freshness</span>
+          <span>Freshness window</span>
           <input name="freshness" type="text">
         </label>
         <label class="field">
@@ -260,7 +365,7 @@ function renderQueries() {
         </label>
       </div>
       <div class="actions">
-        <button type="submit">Save Query</button>
+        <button type="submit">Save Search Query</button>
       </div>
     `;
 
@@ -284,12 +389,12 @@ function renderQueries() {
 
 function renderStoryCandidates() {
   els.candidateList.innerHTML = '';
-  els.candidateMeta.textContent = `${state.storyCandidates.length} recent candidate${state.storyCandidates.length === 1 ? '' : 's'}`;
+  els.candidateMeta.textContent = `${state.storyCandidates.length} recent candidate stor${state.storyCandidates.length === 1 ? 'y' : 'ies'}`;
 
   if (state.storyCandidates.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No story candidates found.';
+    empty.textContent = 'No candidate stories yet. Add search queries, import RSS items, run a scheduled pipeline, or submit a manual story URL.';
     els.candidateList.append(empty);
     return;
   }
@@ -308,8 +413,70 @@ function renderStoryCandidates() {
     const summary = document.createElement('p');
     summary.textContent = candidate.summary || candidate.url || 'No summary recorded.';
 
-    row.append(title, meta, summary);
+    const createBrief = document.createElement('button');
+    createBrief.type = 'button';
+    createBrief.className = 'secondary';
+    createBrief.textContent = 'Create Research Brief';
+    createBrief.addEventListener('click', async () => {
+      await createResearchBrief(candidate.id, createBrief);
+    });
+
+    row.append(title, meta, summary, createBrief);
     els.candidateList.append(row);
+  }
+}
+
+function renderResearchBriefs() {
+  els.researchBriefList.innerHTML = '';
+  els.researchBriefMeta.textContent = `${state.researchPackets.length} research brief${state.researchPackets.length === 1 ? '' : 's'} for this show`;
+
+  if (state.researchPackets.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = 'No research briefs yet. Create one from a candidate story after sources have been discovered or added manually.';
+    els.researchBriefList.append(empty);
+    return;
+  }
+
+  for (const packet of state.researchPackets) {
+    const row = document.createElement('article');
+    row.className = 'record-row';
+
+    const title = document.createElement('strong');
+    title.textContent = packet.title;
+
+    const warningCount = packet.warnings?.length || 0;
+    const meta = document.createElement('span');
+    meta.textContent = `${packet.status} | ${packet.citations?.length || 0} citation${packet.citations?.length === 1 ? '' : 's'} | ${warningCount} warning${warningCount === 1 ? '' : 's'}`;
+
+    const summary = document.createElement('p');
+    summary.textContent = warningCount > 0
+      ? 'Review warnings before drafting or approving production.'
+      : 'Ready for script drafting when the editor is comfortable with the source mix.';
+
+    const actions = document.createElement('div');
+    actions.className = 'actions inline row-actions';
+    const useForScript = document.createElement('button');
+    useForScript.type = 'button';
+    useForScript.className = 'secondary';
+    useForScript.textContent = 'Use for Script';
+    useForScript.addEventListener('click', () => {
+      els.scriptResearchPacketId.value = packet.id;
+      setStatus('Research brief selected for script drafting.');
+    });
+    actions.append(useForScript);
+
+    if (warningCount > 0) {
+      const details = document.createElement('details');
+      details.className = 'debug-details row-debug';
+      details.innerHTML = '<summary>Warning details</summary><pre></pre>';
+      details.querySelector('pre').textContent = JSON.stringify(packet.warnings, null, 2);
+      row.append(title, meta, summary, actions, details);
+    } else {
+      row.append(title, meta, summary, actions);
+    }
+
+    els.researchBriefList.append(row);
   }
 }
 
@@ -320,7 +487,7 @@ function renderEpisodes() {
   if (state.episodes.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No episodes found.';
+    empty.textContent = 'No episodes yet. Approve a script for audio, create assets, complete the publishing checklist, then publish to RSS.';
     els.episodeList.append(empty);
     return;
   }
@@ -346,12 +513,12 @@ function renderEpisodes() {
 
 function renderModelProfiles() {
   els.modelProfileList.innerHTML = '';
-  els.modelMeta.textContent = `${state.modelProfiles.length} role profile${state.modelProfiles.length === 1 ? '' : 's'}`;
+  els.modelMeta.textContent = `${state.modelProfiles.length} AI role setting${state.modelProfiles.length === 1 ? '' : 's'}`;
 
   if (state.modelProfiles.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No model profiles configured.';
+    empty.textContent = 'No AI role settings configured. Use New Show to seed defaults or create role settings through the API before using model-backed scoring, research, or writing.';
     els.modelProfileList.append(empty);
     return;
   }
@@ -361,14 +528,14 @@ function renderModelProfiles() {
     row.className = 'record-row';
 
     const title = document.createElement('strong');
-    title.textContent = profile.role;
+    title.textContent = profile.role.replaceAll('_', ' ');
 
     const meta = document.createElement('span');
     meta.textContent = `${profile.provider} | ${profile.model}`;
 
     const detail = document.createElement('p');
-    const params = profile.config?.params ? JSON.stringify(profile.config.params) : 'No params';
-    detail.textContent = `${profile.promptTemplateKey || 'default prompt'} | ${params}`;
+    const params = profile.config?.params ? JSON.stringify(profile.config.params) : 'No custom settings';
+    detail.textContent = `${profile.promptTemplateKey || 'default agent instructions'} | ${params}`;
 
     row.append(title, meta, detail);
     els.modelProfileList.append(row);
@@ -383,7 +550,7 @@ function renderScheduler() {
   if (state.scheduledPipelines.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No scheduled pipelines configured.';
+    empty.textContent = 'No scheduled pipelines yet. Create one through the API to run recurring source discovery, research, script, audio, or publishing preparation.';
     els.schedulerList.append(empty);
   }
 
@@ -399,7 +566,7 @@ function renderScheduler() {
     meta.textContent = `${pipeline.enabled ? 'enabled' : 'disabled'} | ${pipeline.cron} | next ${nextRun}`;
 
     const detail = document.createElement('p');
-    detail.textContent = `${pipeline.workflow.join(' -> ')}${pipeline.autopublish ? ' | autopublish' : ' | approval required'}`;
+    detail.textContent = `${pipeline.workflow.join(' -> ')}${pipeline.autopublish ? ' | autopublish enabled' : ' | approval required before publishing'}`;
 
     const run = document.createElement('button');
     run.type = 'button';
@@ -418,7 +585,7 @@ function renderScheduler() {
   }
 
   const heading = document.createElement('h3');
-  heading.textContent = 'Failed Runs';
+  heading.textContent = 'Failed Scheduled Runs';
   els.failedScheduleRuns.append(heading);
 
   for (const job of state.failedScheduledRuns) {
@@ -429,7 +596,14 @@ function renderScheduler() {
     title.textContent = `${job.input.scheduledPipelineSlug || job.input.scheduledPipelineId} | ${job.status}`;
 
     const meta = document.createElement('span');
-    meta.textContent = job.error || `Updated ${new Date(job.updatedAt).toLocaleString()}`;
+    meta.textContent = job.error ? 'Run failed. Open details for the API error.' : `Updated ${new Date(job.updatedAt).toLocaleString()}`;
+    let details;
+    if (job.error) {
+      details = document.createElement('details');
+      details.className = 'debug-details row-debug';
+      details.innerHTML = '<summary>Technical details</summary><pre></pre>';
+      details.querySelector('pre').textContent = job.error;
+    }
 
     const retry = document.createElement('button');
     retry.type = 'button';
@@ -440,6 +614,9 @@ function renderScheduler() {
     });
 
     row.append(title, meta, retry);
+    if (details) {
+      row.append(details);
+    }
     els.failedScheduleRuns.append(row);
   }
 }
@@ -474,14 +651,14 @@ function renderProduction() {
   els.generateAudioPreview.disabled = !approved || audioRunning;
   els.generateCoverArt.disabled = !approved || artRunning;
   els.productionMeta.textContent = approved
-    ? (state.production.episode ? `Episode ${state.production.episode.slug}` : 'No production jobs yet.')
-    : 'Approve the selected revision before producing assets.';
+    ? (state.production.episode ? `Episode ${state.production.episode.slug}` : 'No audio or cover asset tasks yet.')
+    : 'Approval gate: approve the selected revision before creating audio or cover assets.';
 
   els.productionJobs.innerHTML = '';
   if (state.production.jobs.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No production jobs yet.';
+    empty.textContent = 'No audio or cover asset tasks yet. Approve the script revision, then create a preview MP3 or cover art.';
     els.productionJobs.append(empty);
   }
 
@@ -491,7 +668,7 @@ function renderProduction() {
     const title = document.createElement('strong');
     title.textContent = `${job.type} | ${job.status}`;
     const meta = document.createElement('span');
-    meta.textContent = job.error || `Progress ${job.progress}%`;
+    meta.textContent = job.error ? 'Task failed. Open details for logs and provider metadata.' : `Progress ${job.progress}%`;
     const progress = document.createElement('div');
     progress.className = 'progress-track';
     const fill = document.createElement('div');
@@ -499,12 +676,23 @@ function renderProduction() {
     fill.style.width = `${Math.max(0, Math.min(100, job.progress))}%`;
     progress.append(fill);
     row.append(title, meta, progress);
+    if (job.error || job.logs?.length) {
+      const details = document.createElement('details');
+      details.className = 'debug-details row-debug';
+      details.innerHTML = '<summary>Technical details</summary><pre></pre>';
+      details.querySelector('pre').textContent = JSON.stringify({ error: job.error, logs: job.logs, output: job.output }, null, 2);
+      row.append(details);
+    }
     els.productionJobs.append(row);
   }
 
   els.productionAssets.innerHTML = '';
   const assets = [latestAsset('audio-preview'), latestAsset('cover-art')].filter(Boolean);
   if (assets.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = 'No audio or cover assets recorded yet.';
+    els.productionAssets.append(empty);
     return;
   }
 
@@ -527,7 +715,7 @@ function renderScripts() {
   if (state.scripts.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = 'No scripts generated yet.';
+    empty.textContent = 'No scripts yet. Select a research brief, paste its ID into the draft form, and generate a script draft.';
     els.scriptList.append(empty);
   }
 
@@ -562,6 +750,7 @@ function render() {
   renderProfiles();
   renderProfileForm();
   renderStoryCandidates();
+  renderResearchBriefs();
   renderScheduler();
   renderEpisodes();
   renderModelProfiles();
@@ -645,6 +834,16 @@ async function loadStoryCandidates() {
   state.storyCandidates = body.storyCandidates;
 }
 
+async function loadResearchPackets() {
+  if (!state.selectedShowSlug) {
+    state.researchPackets = [];
+    return;
+  }
+
+  const body = await api(`/research-packets?showSlug=${encodeURIComponent(state.selectedShowSlug)}&limit=25`);
+  state.researchPackets = body.researchPackets;
+}
+
 async function loadScheduledPipelines() {
   if (!state.selectedShowSlug) {
     state.scheduledPipelines = [];
@@ -676,7 +875,7 @@ async function runScheduledPipeline(id, button) {
   } catch (error) {
     await loadScheduledPipelines();
     render();
-    setStatus(error.message);
+    reportError(error);
   } finally {
     button.disabled = false;
   }
@@ -694,11 +893,11 @@ async function retryScheduledRun(id, button) {
     await loadScheduledPipelines();
     await loadStoryCandidates();
     render();
-    setStatus(`Scheduled retry ${body.job.status}.`);
+    setStatus(`Scheduled run retry ${body.job.status}.`);
   } catch (error) {
     await loadScheduledPipelines();
     render();
-    setStatus(error.message);
+    reportError(error);
   } finally {
     button.disabled = false;
   }
@@ -739,19 +938,20 @@ async function loadProduction() {
 async function loadAll() {
   try {
     els.refresh.disabled = true;
-    setStatus('Loading sources...');
+    setStatus('Loading workspace...');
     await loadShows();
     await loadProfiles();
     await loadQueries();
     await loadModelProfiles();
     await loadStoryCandidates();
+    await loadResearchPackets();
     await loadScheduledPipelines();
     await loadEpisodes();
     await loadScripts();
     render();
-    setStatus('Source profiles loaded.');
+    setStatus('Workspace loaded.');
   } catch (error) {
-    setStatus(error.message);
+    reportError(error, 'Could not load the workspace. Open technical details for the API response.');
   } finally {
     els.refresh.disabled = false;
   }
@@ -817,7 +1017,7 @@ async function createShow(event) {
     await loadAll();
     setStatus(`Show created: ${body.show.title}`);
   } catch (error) {
-    setStatus(error.message);
+    reportError(error);
   }
 }
 
@@ -835,7 +1035,7 @@ async function importLegacyData() {
     render();
     setStatus(`Legacy import complete: ${body.summary.candidates.inserted} candidates inserted, ${body.summary.candidates.updated} updated.`);
   } catch (error) {
-    setStatus(error.message);
+    reportError(error);
   } finally {
     els.importLegacy.disabled = false;
   }
@@ -860,14 +1060,18 @@ async function saveProfile(event) {
     excludeDomains: linesToList(els.profileExcludeDomains.value),
   };
 
-  const body = await api(`/source-profiles/${profile.id}`, {
-    method: 'PATCH',
-    body: JSON.stringify(payload),
-  });
-  const index = state.profiles.findIndex((candidate) => candidate.id === profile.id);
-  state.profiles[index] = body.sourceProfile;
-  render();
-  setStatus('Profile saved.');
+  try {
+    const body = await api(`/source-profiles/${profile.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+    const index = state.profiles.findIndex((candidate) => candidate.id === profile.id);
+    state.profiles[index] = body.sourceProfile;
+    render();
+    setStatus('Story source saved.');
+  } catch (error) {
+    reportError(error);
+  }
 }
 
 async function ingestSelectedProfile() {
@@ -884,9 +1088,9 @@ async function ingestSelectedProfile() {
     const body = await api(`/source-profiles/${profile.id}/ingest`, { method: 'POST' });
     await loadStoryCandidates();
     render();
-    setStatus(`RSS ingest complete: ${body.inserted} inserted, ${body.skipped} skipped.`);
+    setStatus(`RSS import complete: ${body.inserted} inserted, ${body.skipped} skipped.`);
   } catch (error) {
-    setStatus(error.message);
+    reportError(error);
   } finally {
     els.ingestProfile.disabled = false;
   }
@@ -915,17 +1119,16 @@ async function submitManualUrl(event) {
 
     if (body.inserted) {
       els.manualForm.reset();
-      els.manualResult.textContent = `Created candidate: ${body.candidate.title}`;
+      els.manualResult.textContent = `Created candidate story: ${body.candidate.title}`;
       await loadStoryCandidates();
       render();
       setStatus('Manual URL submitted.');
     } else {
       els.manualResult.textContent = `Skipped: ${body.reason}`;
-      setStatus('Manual URL matched an existing candidate.');
+      setStatus('Manual URL matched an existing candidate story.');
     }
   } catch (error) {
-    els.manualResult.textContent = error.message;
-    setStatus(error.message);
+    els.manualResult.textContent = reportError(error);
   }
 }
 
@@ -938,14 +1141,18 @@ async function saveQuery(id, form) {
     includeDomains: linesToList(form.elements.includeDomains.value),
     excludeDomains: linesToList(form.elements.excludeDomains.value),
   };
-  const body = await api(`/source-queries/${id}`, {
-    method: 'PATCH',
-    body: JSON.stringify(payload),
-  });
-  const index = state.queries.findIndex((query) => query.id === id);
-  state.queries[index] = body.sourceQuery;
-  render();
-  setStatus('Query saved.');
+  try {
+    const body = await api(`/source-queries/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+    const index = state.queries.findIndex((query) => query.id === id);
+    state.queries[index] = body.sourceQuery;
+    render();
+    setStatus('Search query saved.');
+  } catch (error) {
+    reportError(error);
+  }
 }
 
 async function createQuery(event) {
@@ -955,28 +1162,56 @@ async function createQuery(event) {
     return;
   }
 
-  const body = await api(`/source-profiles/${state.selectedProfileId}/queries`, {
-    method: 'POST',
-    body: JSON.stringify({
-      query: els.newQueryText.value.trim(),
-      enabled: true,
-      weight: 1,
-      freshness: selectedProfile()?.freshness || null,
-      includeDomains: [],
-      excludeDomains: [],
-    }),
-  });
-  state.queries.push(body.sourceQuery);
-  els.newQueryText.value = '';
-  render();
-  setStatus('Query created.');
+  try {
+    const body = await api(`/source-profiles/${state.selectedProfileId}/queries`, {
+      method: 'POST',
+      body: JSON.stringify({
+        query: els.newQueryText.value.trim(),
+        enabled: true,
+        weight: 1,
+        freshness: selectedProfile()?.freshness || null,
+        includeDomains: [],
+        excludeDomains: [],
+      }),
+    });
+    state.queries.push(body.sourceQuery);
+    els.newQueryText.value = '';
+    render();
+    setStatus('Search query created.');
+  } catch (error) {
+    reportError(error);
+  }
 }
 
 async function deleteQuery(id) {
-  await api(`/source-queries/${id}`, { method: 'DELETE' });
-  state.queries = state.queries.filter((query) => query.id !== id);
-  render();
-  setStatus('Query deleted.');
+  try {
+    await api(`/source-queries/${id}`, { method: 'DELETE' });
+    state.queries = state.queries.filter((query) => query.id !== id);
+    render();
+    setStatus('Search query deleted.');
+  } catch (error) {
+    reportError(error);
+  }
+}
+
+async function createResearchBrief(candidateId, button) {
+  button.disabled = true;
+  setStatus('Creating research brief...');
+
+  try {
+    const body = await api(`/story-candidates/${candidateId}/research-packet`, {
+      method: 'POST',
+      body: JSON.stringify({ extraUrls: [] }),
+    });
+    await loadResearchPackets();
+    render();
+    els.scriptResearchPacketId.value = body.researchPacket.id;
+    setStatus(`Research brief created: ${body.researchPacket.status}.`);
+  } catch (error) {
+    reportError(error);
+  } finally {
+    button.disabled = false;
+  }
 }
 
 async function generateScript(event) {
@@ -987,21 +1222,25 @@ async function generateScript(event) {
     return;
   }
 
-  const body = await api(`/research-packets/${researchPacketId}/script`, {
-    method: 'POST',
-    body: JSON.stringify({
-      format: els.scriptFormat.value.trim() || undefined,
-      actor: 'local-user',
-    }),
-  });
-  state.scripts = [body.script, ...state.scripts.filter((script) => script.id !== body.script.id)];
-  state.selectedScriptId = body.script.id;
-  state.selectedScript = body.script;
-  state.selectedRevision = body.revision;
-  state.production = { episode: null, assets: [], jobs: [] };
-  els.scriptResearchPacketId.value = '';
-  render();
-  setStatus(`Generated script revision ${body.revision.version}.`);
+  try {
+    const body = await api(`/research-packets/${researchPacketId}/script`, {
+      method: 'POST',
+      body: JSON.stringify({
+        format: els.scriptFormat.value.trim() || undefined,
+        actor: 'local-user',
+      }),
+    });
+    state.scripts = [body.script, ...state.scripts.filter((script) => script.id !== body.script.id)];
+    state.selectedScriptId = body.script.id;
+    state.selectedScript = body.script;
+    state.selectedRevision = body.revision;
+    state.production = { episode: null, assets: [], jobs: [] };
+    els.scriptResearchPacketId.value = '';
+    render();
+    setStatus(`Generated script revision ${body.revision.version}.`);
+  } catch (error) {
+    reportError(error);
+  }
 }
 
 async function saveScriptRevision(event) {
@@ -1011,21 +1250,25 @@ async function saveScriptRevision(event) {
     return;
   }
 
-  const body = await api(`/scripts/${state.selectedScript.id}/revisions`, {
-    method: 'POST',
-    body: JSON.stringify({
-      title: els.scriptTitle.value.trim(),
-      body: els.scriptBody.value.trim(),
-      actor: 'local-user',
-      changeSummary: 'Edited in local UI.',
-    }),
-  });
-  state.scripts = [body.script, ...state.scripts.filter((script) => script.id !== body.script.id)];
-  state.selectedScript = body.script;
-  state.selectedRevision = body.revision;
-  await loadProduction();
-  render();
-  setStatus(`Saved script revision ${body.revision.version}.`);
+  try {
+    const body = await api(`/scripts/${state.selectedScript.id}/revisions`, {
+      method: 'POST',
+      body: JSON.stringify({
+        title: els.scriptTitle.value.trim(),
+        body: els.scriptBody.value.trim(),
+        actor: 'local-user',
+        changeSummary: 'Edited in local UI.',
+      }),
+    });
+    state.scripts = [body.script, ...state.scripts.filter((script) => script.id !== body.script.id)];
+    state.selectedScript = body.script;
+    state.selectedRevision = body.revision;
+    await loadProduction();
+    render();
+    setStatus(`Saved script revision ${body.revision.version}.`);
+  } catch (error) {
+    reportError(error);
+  }
 }
 
 async function approveSelectedScript() {
@@ -1033,18 +1276,22 @@ async function approveSelectedScript() {
     return;
   }
 
-  const body = await api(`/scripts/${state.selectedScript.id}/revisions/${state.selectedRevision.id}/approve-for-audio`, {
-    method: 'POST',
-    body: JSON.stringify({
-      actor: 'local-user',
-      reason: 'Approved in local UI.',
-    }),
-  });
-  state.scripts = state.scripts.map((script) => script.id === body.script.id ? body.script : script);
-  state.selectedScript = body.script;
-  await loadProduction();
-  render();
-  setStatus('Script approved for audio.');
+  try {
+    const body = await api(`/scripts/${state.selectedScript.id}/revisions/${state.selectedRevision.id}/approve-for-audio`, {
+      method: 'POST',
+      body: JSON.stringify({
+        actor: 'local-user',
+        reason: 'Approved in local UI.',
+      }),
+    });
+    state.scripts = state.scripts.map((script) => script.id === body.script.id ? body.script : script);
+    state.selectedScript = body.script;
+    await loadProduction();
+    render();
+    setStatus('Review decision saved: script approved for audio.');
+  } catch (error) {
+    reportError(error);
+  }
 }
 
 async function refreshProductionUntilSettled() {
@@ -1067,7 +1314,7 @@ async function refreshProductionUntilSettled() {
             state.productionPoll = null;
           }
         } catch (error) {
-          setStatus(error.message);
+          reportError(error);
         }
       }, 1500);
     }
@@ -1092,7 +1339,7 @@ async function startAudioPreview() {
   } catch (error) {
     await loadProduction();
     render();
-    setStatus(error.message);
+    reportError(error);
   }
 }
 
@@ -1114,7 +1361,7 @@ async function startCoverArt() {
   } catch (error) {
     await loadProduction();
     render();
-    setStatus(error.message);
+    reportError(error);
   }
 }
 
@@ -1152,6 +1399,7 @@ els.showSelect.addEventListener('change', async () => {
   await loadQueries();
   await loadModelProfiles();
   await loadStoryCandidates();
+  await loadResearchPackets();
   await loadScheduledPipelines();
   await loadEpisodes();
   await loadScripts();

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -17,11 +17,11 @@ describe('api config endpoints', () => {
     assert.deepEqual(response.json(), { ok: true, service: 'podcast-forge-api' });
   });
 
-  it('serves the source profile UI shell', async () => {
+  it('serves the local command center UI shell', async () => {
     const response = await app.inject({ method: 'GET', url: '/ui' });
 
     assert.equal(response.statusCode, 200);
-    assert.match(response.body, /Podcast Forge Sources/);
+    assert.match(response.body, /Podcast Forge Command Center/);
   });
 
   it('returns the bundled example config', async () => {


### PR DESCRIPTION
## Summary
- Adds `docs/UX_GLOSSARY.md` with backend-to-user-facing terminology guidance.
- Updates UI and docs copy toward creator-friendly language: Story Sources, Candidate Stories, Research Briefs, AI Role Settings, Tasks/Runs, assets, and review decisions.
- Adds inline help, clearer empty states, and friendlier API error display with collapsible technical details.

## Verification
- git diff --check
- node --check packages/api/public/ui.js
- npm run check

## Terms intentionally left technical
- Backend identifiers, API/table names, role keys, debug JSON/log details, RSS/cron/provider/model/feed GUID/OP3/MIME/checksum/object-key terms where exact operator meaning matters.

Closes #25