### PR TITLE
feat: add task run progress UI

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -92,7 +92,7 @@ Open build wave:
 - #20 Guided episode pipeline UI ✅ implemented locally on `issue-20-guided-pipeline-ui`; `npm run check` passed.
 - #21 Multi-select candidate clustering UI ✅ implemented locally on `issue-21-candidate-clustering-ui`; `npm run check` passed.
 - #22 Settings/admin UI for shows, sources, models, prompts, publishing ✅ implemented locally on `issue-22-settings-admin-ui`; `npm run check` passed.
-- #23 Job progress, logs, warnings, and retry UI
+- #23 Job progress, logs, warnings, and retry UI ✅ implemented locally on `issue-23-job-progress-ui`; `npm run check` passed.
 - #24 Review and approval gates UI
 - #25 UX terminology and inline help cleanup
 

--- a/README.md
+++ b/README.md
@@ -251,9 +251,20 @@ Search/job endpoints:
 - `POST /source-profiles/:id/search`
 - `POST /source-profiles/:id/ingest`
 - `POST /story-candidates/manual`
+- `GET /jobs?showSlug=the-synthetic-lens&limit=30`
 - `GET /jobs/:id`
 - `GET /story-candidates?showSlug=the-synthetic-lens`
 - `POST /research-packets` accepts `{ candidateIds, extraUrls, angle, notes, targetFormat, targetRuntime }`
+
+The local UI includes a show-scoped **Task Runs** panel at `/ui`. It lists
+recent source, scheduled, research, script, production, and publishing jobs,
+polls active runs every five seconds, and opens a detail view with logs,
+warnings, stack-safe failure messages, retryability, linked artifact IDs, and
+collapsed sanitized debug metadata. Scheduled-run retries use
+`POST /scheduled-pipeline-runs/:jobId/retry`; failed audio and cover jobs retry
+through the existing production endpoints and send `retryOfJobId` so the new
+job can be linked back to the original. RSS publish jobs are never auto-retried
+from the task panel.
 
 `GET /story-candidates` defaults to `sort=score`, returning scored candidates
 highest first with unscored candidates last. Use `sort=discovered` to show the

--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -347,6 +347,23 @@
           <div id="failedScheduleRuns" class="scheduler-failures"></div>
         </section>
 
+        <section class="panel job-panel" aria-labelledby="jobRunsTitle">
+          <div class="panel-heading">
+            <div>
+              <h2 id="jobRunsTitle">Task Runs</h2>
+              <p id="jobRunsMeta"></p>
+              <p class="help">Recent source, scheduled, research, script, production, and publishing runs with progress, warnings, failure details, and safe retry actions.</p>
+            </div>
+            <div class="actions inline">
+              <button id="refreshJobs" class="secondary" type="button">Refresh Runs</button>
+            </div>
+          </div>
+          <div class="job-layout">
+            <div id="jobRunList" class="record-list"></div>
+            <article id="jobRunDetail" class="job-detail"></article>
+          </div>
+        </section>
+
         <section class="panel">
           <div class="panel-heading">
             <div>

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -272,6 +272,24 @@ button:disabled {
   color: #70440f;
 }
 
+.status-pill.warning {
+  background: #fff9d9;
+  border-color: #d8cf73;
+  color: #675b00;
+}
+
+.status-pill.failed {
+  background: #fff4f4;
+  border-color: #c55353;
+  color: #7a1f1f;
+}
+
+.status-pill.succeeded {
+  background: #e9f7ee;
+  border-color: #9ac8aa;
+  color: #245b37;
+}
+
 .status-pill.done {
   background: #e9f7ee;
   border-color: #9ac8aa;
@@ -639,6 +657,126 @@ textarea {
   margin: 0;
 }
 
+.job-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(240px, 360px) minmax(0, 1fr);
+}
+
+.job-row {
+  background: #f8fafc;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  color: #20242c;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  text-align: left;
+  width: 100%;
+}
+
+.job-row.selected {
+  border-color: #2468a8;
+  box-shadow: inset 3px 0 0 #2468a8;
+}
+
+.job-row.running {
+  border-color: #7aa7d7;
+}
+
+.job-row.warning {
+  background: #fbfaf1;
+  border-color: #d8cf73;
+}
+
+.job-row.failed {
+  background: #fff4f4;
+  border-color: #c55353;
+}
+
+.job-row span {
+  color: #586575;
+  font-size: 0.86rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.job-detail {
+  background: #f8fafc;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.85rem;
+  min-width: 0;
+  padding: 0.9rem;
+}
+
+.job-detail.failed {
+  border-color: #c55353;
+}
+
+.job-detail.warning {
+  border-color: #d8cf73;
+}
+
+.job-detail-heading {
+  align-items: start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.job-detail h3,
+.job-detail h4,
+.job-detail p {
+  margin: 0;
+}
+
+.job-detail p {
+  color: #586575;
+}
+
+.job-facts,
+.job-artifacts,
+.job-messages,
+.job-retry {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.job-facts {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.job-facts span,
+.job-message {
+  background: white;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  color: #3f4b5a;
+  font-size: 0.88rem;
+  overflow-wrap: anywhere;
+  padding: 0.45rem 0.55rem;
+}
+
+.job-message.warn,
+.job-message.warning {
+  background: #fff9d9;
+  border-color: #d8cf73;
+  color: #675b00;
+}
+
+.job-message.error {
+  background: #fff4f4;
+  border-color: #c55353;
+  color: #7a1f1f;
+}
+
+.job-retry {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
 .row-debug {
   grid-column: 1 / -1;
 }
@@ -808,6 +946,8 @@ textarea {
   .manual-form,
   .script-generate,
   .script-workspace,
+  .job-layout,
+  .job-facts,
   .new-query,
   .query-card .query-grid {
     grid-template-columns: 1fr;
@@ -829,5 +969,9 @@ textarea {
 
   .cluster-summary {
     display: grid;
+  }
+
+  .job-retry {
+    grid-template-columns: 1fr;
   }
 }

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -9,6 +9,8 @@ const state = {
   promptTemplates: [],
   scheduledPipelines: [],
   failedScheduledRuns: [],
+  recentJobs: [],
+  selectedJobId: '',
   storyCandidates: [],
   episodes: [],
   selectedScriptId: '',
@@ -20,6 +22,7 @@ const state = {
     jobs: [],
   },
   productionPoll: null,
+  jobPoll: null,
   selectedCandidateIds: [],
   clusterForm: {
     angle: '',
@@ -111,6 +114,10 @@ const els = {
   schedulerMeta: document.querySelector('#schedulerMeta'),
   schedulerList: document.querySelector('#schedulerList'),
   failedScheduleRuns: document.querySelector('#failedScheduleRuns'),
+  jobRunsMeta: document.querySelector('#jobRunsMeta'),
+  refreshJobs: document.querySelector('#refreshJobs'),
+  jobRunList: document.querySelector('#jobRunList'),
+  jobRunDetail: document.querySelector('#jobRunDetail'),
   episodeMeta: document.querySelector('#episodeMeta'),
   episodeList: document.querySelector('#episodeList'),
   modelMeta: document.querySelector('#modelMeta'),
@@ -817,6 +824,82 @@ function statusClass(status) {
   return status.replaceAll(' ', '-');
 }
 
+function selectedJob() {
+  return state.recentJobs.find((job) => job.id === state.selectedJobId) || state.recentJobs[0] || null;
+}
+
+function latestRunForTypes(types) {
+  return state.recentJobs.find((job) => types.includes(job.type));
+}
+
+function taskState(job) {
+  if (!job) {
+    return 'not started';
+  }
+
+  if (!isTerminalJob(job)) {
+    return 'running';
+  }
+
+  if (job.status === 'failed') {
+    return 'failed';
+  }
+
+  if ((job.summary?.warnings || []).length > 0) {
+    return 'warning';
+  }
+
+  return job.status;
+}
+
+function taskLabel(type) {
+  const labels = {
+    'source.search': 'Source search',
+    'source.ingest': 'RSS import',
+    'research.packet': 'Research brief',
+    'script.generate': 'Script draft',
+    'audio.preview': 'Preview audio',
+    'art.generate': 'Cover art',
+    'publish.rss': 'RSS publishing',
+    'pipeline.scheduled': 'Scheduled pipeline',
+    'source.import': 'Legacy import',
+  };
+
+  return labels[type] || type;
+}
+
+function formatTime(value) {
+  return value ? new Date(value).toLocaleString() : 'not recorded';
+}
+
+function jobProgressText(job) {
+  const started = job.startedAt ? `started ${formatTime(job.startedAt)}` : `created ${formatTime(job.createdAt)}`;
+  const finished = job.finishedAt ? `finished ${formatTime(job.finishedAt)}` : `updated ${formatTime(job.updatedAt)}`;
+  return `${job.progress}% | ${started} | ${finished}`;
+}
+
+function selectJob(jobId) {
+  state.selectedJobId = jobId;
+  render();
+  setStatus('Task run details selected.');
+}
+
+function viewLatestJob(types) {
+  const job = latestRunForTypes(types);
+
+  if (!job) {
+    setStatus('No task run has been recorded for that stage yet.');
+    return;
+  }
+
+  selectJob(job.id);
+}
+
+function latestStageJob(types) {
+  const job = latestRunForTypes(types);
+  return job ? `${taskLabel(job.type)} ${job.status}, ${job.progress}%` : 'No recorded task run yet.';
+}
+
 function stageCard(stage) {
   const card = document.createElement('article');
   card.className = `pipeline-card ${statusClass(stage.status)}${stage.active ? ' active' : ''}`;
@@ -863,6 +946,17 @@ function stageCard(stage) {
   }
 
   card.append(top, artifacts, next, button);
+
+  if (stage.jobTypes?.length) {
+    const jobButton = document.createElement('button');
+    jobButton.type = 'button';
+    jobButton.className = 'secondary';
+    jobButton.textContent = 'View Latest Run';
+    jobButton.disabled = !latestRunForTypes(stage.jobTypes);
+    jobButton.addEventListener('click', () => viewLatestJob(stage.jobTypes));
+    card.append(jobButton);
+  }
+
   return card;
 }
 
@@ -965,6 +1059,7 @@ function buildPipelineStages() {
       action: !profile ? undefined : profileSupportsDiscovery ? runSelectedProfileDiscovery : focusManualStoryForm,
       disabled: discoverRunning || !profile || (!profileSupportsDiscovery && profile.type !== 'manual'),
       active: state.storyCandidates.length > 0,
+      jobTypes: ['source.search', 'source.ingest'],
     },
     {
       number: 3,
@@ -993,6 +1088,7 @@ function buildPipelineStages() {
       action: packet ? () => selectResearchPacket(packet) : state.researchPackets.length > 0 ? () => selectResearchPacket(state.researchPackets[0]) : buildResearchBriefFromSelected,
       disabled: researchRunning || (!packet && state.researchPackets.length === 0 && !candidateAnalysis.canLaunch),
       active: Boolean(packet),
+      jobTypes: ['research.packet'],
     },
     {
       number: 5,
@@ -1006,6 +1102,7 @@ function buildPipelineStages() {
       action: state.selectedScript ? focusScriptEditor : generateScriptFromSelectedResearch,
       disabled: scriptRunning || (!state.selectedScript && (!packet || packetBlocked)),
       active: Boolean(state.selectedScript),
+      jobTypes: ['script.generate'],
     },
     {
       number: 6,
@@ -1019,6 +1116,7 @@ function buildPipelineStages() {
       action: audioAsset && coverAsset ? refreshProductionUntilSettled : createMissingProductionAssets,
       disabled: productionActionRunning || (!scriptApproved && !(audioAsset && coverAsset)),
       active: Boolean(audioAsset || coverAsset),
+      jobTypes: ['audio.preview', 'art.generate'],
     },
     {
       number: 7,
@@ -1046,6 +1144,7 @@ function buildPipelineStages() {
       disabled: publishRunning || episode?.status !== 'approved-for-publish',
       active: episode?.status === 'published',
       primary: true,
+      jobTypes: ['publish.rss'],
     },
   ];
 }
@@ -2155,6 +2254,200 @@ function renderProduction() {
   }
 }
 
+function renderJobRuns() {
+  const activeCount = state.recentJobs.filter((job) => !isTerminalJob(job)).length;
+  const failedCount = state.recentJobs.filter((job) => job.status === 'failed').length;
+  els.jobRunsMeta.textContent = `${state.recentJobs.length} recent run${state.recentJobs.length === 1 ? '' : 's'}${activeCount ? ` | ${activeCount} active` : ''}${failedCount ? ` | ${failedCount} failed` : ''}`;
+  els.jobRunList.innerHTML = '';
+
+  if (state.recentJobs.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = state.selectedShowSlug
+      ? 'No task runs recorded for this show yet.'
+      : 'Choose a show to inspect recent task runs.';
+    els.jobRunList.append(empty);
+  }
+
+  for (const job of state.recentJobs) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `job-row ${statusClass(taskState(job))}${job.id === state.selectedJobId ? ' selected' : ''}`;
+    button.innerHTML = `
+      <strong></strong>
+      <span class="job-row-meta"></span>
+      <span class="job-row-note"></span>
+    `;
+    button.querySelector('strong').textContent = `${taskLabel(job.type)} | ${job.status}`;
+    button.querySelector('.job-row-meta').textContent = jobProgressText(job);
+    button.querySelector('.job-row-note').textContent = (job.summary?.warnings || []).length > 0
+      ? `${job.summary.warnings.length} warning${job.summary.warnings.length === 1 ? '' : 's'}`
+      : job.error || latestStageJob([job.type]);
+    button.addEventListener('click', () => selectJob(job.id));
+    els.jobRunList.append(button);
+  }
+
+  renderJobDetail();
+}
+
+function renderJobDetail() {
+  const job = selectedJob();
+  els.jobRunDetail.innerHTML = '';
+
+  if (!job) {
+    els.jobRunDetail.className = 'job-detail empty';
+    els.jobRunDetail.textContent = 'Select a task run to inspect logs, warnings, retryability, and debug details.';
+    return;
+  }
+
+  els.jobRunDetail.className = `job-detail ${statusClass(taskState(job))}`;
+  state.selectedJobId = job.id;
+
+  const heading = document.createElement('div');
+  heading.className = 'job-detail-heading';
+  const title = document.createElement('div');
+  title.innerHTML = '<h3></h3><p></p>';
+  title.querySelector('h3').textContent = taskLabel(job.type);
+  title.querySelector('p').textContent = `${job.type} | created ${formatTime(job.createdAt)}`;
+  const status = document.createElement('span');
+  status.className = `status-pill ${statusClass(taskState(job))}`;
+  status.textContent = taskState(job);
+  heading.append(title, status);
+
+  const progress = document.createElement('div');
+  progress.className = 'progress-track';
+  const fill = document.createElement('div');
+  fill.className = 'progress-fill';
+  fill.style.width = `${Math.max(0, Math.min(100, job.progress))}%`;
+  progress.append(fill);
+
+  const facts = document.createElement('div');
+  facts.className = 'job-facts';
+  for (const [label, value] of [
+    ['Status', job.status],
+    ['Progress', `${job.progress}%`],
+    ['Attempts', `${job.attempts}/${job.maxAttempts}`],
+    ['Started', formatTime(job.startedAt)],
+    ['Finished', formatTime(job.finishedAt)],
+  ]) {
+    const item = document.createElement('span');
+    item.textContent = `${label}: ${value}`;
+    facts.append(item);
+  }
+
+  const artifacts = document.createElement('div');
+  artifacts.className = 'job-artifacts';
+  const artifactItems = job.summary?.artifacts || [];
+  artifacts.innerHTML = '<h4>Linked records</h4>';
+  if (artifactItems.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No artifact IDs recorded yet.';
+    artifacts.append(empty);
+  } else {
+    const list = document.createElement('div');
+    list.className = 'settings-kv';
+    for (const artifact of artifactItems) {
+      const item = document.createElement('span');
+      item.textContent = `${artifact.label}: ${artifact.value}`;
+      list.append(item);
+    }
+    artifacts.append(list);
+  }
+
+  const warnings = renderJobMessages('Warnings', job.summary?.warnings || [], 'No warnings recorded for this task run.');
+  const failure = renderJobFailure(job);
+  const logs = renderJobLogs(job.logs || []);
+  const retry = renderJobRetry(job);
+  const debug = document.createElement('details');
+  debug.className = 'debug-details';
+  debug.innerHTML = '<summary>Metadata and debug details</summary><pre></pre>';
+  debug.querySelector('pre').textContent = JSON.stringify(sanitizedDebug({
+    id: job.id,
+    showId: job.showId,
+    episodeId: job.episodeId,
+    provider: job.summary?.provider || {},
+    input: job.input,
+    output: job.output,
+  }), null, 2);
+
+  els.jobRunDetail.append(heading, progress, facts, artifacts, warnings, failure, logs, retry, debug);
+}
+
+function renderJobMessages(title, items, emptyText) {
+  const section = document.createElement('section');
+  section.className = 'job-messages';
+  const heading = document.createElement('h4');
+  heading.textContent = title;
+  section.append(heading);
+
+  if (items.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = emptyText;
+    section.append(empty);
+    return section;
+  }
+
+  for (const item of items) {
+    const row = document.createElement('div');
+    row.className = 'job-message';
+    row.textContent = item.message || item.code || JSON.stringify(sanitizedDebug(item));
+    section.append(row);
+  }
+
+  return section;
+}
+
+function renderJobFailure(job) {
+  const failure = job.summary?.failure;
+  const section = document.createElement('section');
+  section.className = 'job-messages';
+  section.innerHTML = '<h4>Failure</h4>';
+  const message = document.createElement('p');
+  message.textContent = failure?.message || job.error || 'No failure recorded.';
+  section.append(message);
+  return section;
+}
+
+function renderJobLogs(logs) {
+  const section = document.createElement('section');
+  section.className = 'job-messages';
+  section.innerHTML = '<h4>Logs and events</h4>';
+
+  if (logs.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No logs recorded yet.';
+    section.append(empty);
+    return section;
+  }
+
+  for (const log of logs.slice(-8)) {
+    const row = document.createElement('div');
+    row.className = `job-message ${log.level || 'info'}`;
+    row.textContent = `${log.at || ''} ${log.level || 'info'}: ${log.message || JSON.stringify(sanitizedDebug(log))}`.trim();
+    section.append(row);
+  }
+
+  return section;
+}
+
+function renderJobRetry(job) {
+  const section = document.createElement('section');
+  section.className = 'job-retry';
+  const retry = job.summary?.retry || { supported: false, reason: 'Retry information is unavailable.' };
+  const note = document.createElement('p');
+  note.textContent = retry.reason;
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = retry.requiresConfirmation ? 'danger' : 'secondary';
+  button.textContent = retry.requiresConfirmation ? 'Retry Requires Publish Review' : 'Retry Run';
+  button.disabled = !retry.supported;
+  if (retry.supported) {
+    button.addEventListener('click', async () => retryJob(job, button));
+  }
+  section.append(note, button);
+  return section;
+}
+
 function renderScripts() {
   els.scriptList.innerHTML = '';
   els.scriptMeta.textContent = `${state.scripts.length} script${state.scripts.length === 1 ? '' : 's'} for this show`;
@@ -2202,6 +2495,7 @@ function render() {
   renderStoryCandidates();
   renderResearchBriefs();
   renderScheduler();
+  renderJobRuns();
   renderEpisodes();
   renderModelProfiles();
   renderQueries();
@@ -2330,6 +2624,54 @@ async function loadScheduledPipelines() {
   state.failedScheduledRuns = failedRunsBody.jobs;
 }
 
+async function loadJobs() {
+  if (!state.selectedShowSlug) {
+    state.recentJobs = [];
+    state.selectedJobId = '';
+    stopJobPolling();
+    return;
+  }
+
+  const body = await api(`/jobs?showSlug=${encodeURIComponent(state.selectedShowSlug)}&limit=30`);
+  state.recentJobs = body.jobs || [];
+
+  if (!state.recentJobs.some((job) => job.id === state.selectedJobId)) {
+    state.selectedJobId = state.recentJobs[0]?.id || '';
+  }
+
+  updateJobPolling();
+}
+
+function stopJobPolling() {
+  if (state.jobPoll) {
+    window.clearInterval(state.jobPoll);
+    state.jobPoll = null;
+  }
+}
+
+function updateJobPolling() {
+  const hasActiveJobs = state.recentJobs.some((job) => !isTerminalJob(job));
+
+  if (!hasActiveJobs) {
+    stopJobPolling();
+    return;
+  }
+
+  if (state.jobPoll) {
+    return;
+  }
+
+  state.jobPoll = window.setInterval(async () => {
+    try {
+      await loadJobs();
+      render();
+    } catch (error) {
+      stopJobPolling();
+      reportError(error);
+    }
+  }, 5000);
+}
+
 async function runScheduledPipeline(id, button) {
   button.disabled = true;
   setStatus('Starting scheduled pipeline...');
@@ -2340,6 +2682,7 @@ async function runScheduledPipeline(id, button) {
       body: JSON.stringify({ actor: 'local-ui' }),
     });
     await loadScheduledPipelines();
+    await loadJobs();
     await loadStoryCandidates();
     render();
     setStatus(`Scheduled pipeline run ${body.job.status}.`);
@@ -2362,11 +2705,49 @@ async function retryScheduledRun(id, button) {
       body: JSON.stringify({ actor: 'local-ui' }),
     });
     await loadScheduledPipelines();
+    await loadJobs();
     await loadStoryCandidates();
     render();
     setStatus(`Scheduled run retry ${body.job.status}.`);
   } catch (error) {
     await loadScheduledPipelines();
+    render();
+    reportError(error);
+  } finally {
+    button.disabled = false;
+  }
+}
+
+async function retryJob(job, button) {
+  const retry = job.summary?.retry;
+
+  if (!retry?.supported || !retry.endpoint) {
+    return;
+  }
+
+  if (job.type === 'publish.rss') {
+    setStatus('RSS publishing retries require the explicit publish action after review.');
+    return;
+  }
+
+  button.disabled = true;
+  setStatus('Retrying task run...');
+
+  try {
+    const body = await api(retry.endpoint, {
+      method: retry.method || 'POST',
+      body: JSON.stringify({ actor: 'local-ui', retryOfJobId: job.id }),
+    });
+    await loadScheduledPipelines();
+    await loadJobs();
+    if (state.selectedScriptId) {
+      await loadProduction();
+    }
+    await loadStoryCandidates();
+    render();
+    setStatus(`Retry created: ${(body.job || {}).status || 'started'}.`);
+  } catch (error) {
+    await loadJobs();
     render();
     reportError(error);
   } finally {
@@ -2471,6 +2852,7 @@ async function runSelectedProfileDiscovery() {
       : `/source-profiles/${profile.id}/search`;
     const body = await api(path, { method: 'POST' });
     await loadStoryCandidates();
+    await loadJobs();
     render();
     setStatus(`${profile.type === 'rss' ? 'RSS import' : 'Source search'} complete: ${body.inserted} inserted, ${body.skipped} skipped.`);
   } catch (error) {
@@ -2508,6 +2890,7 @@ async function buildResearchBriefFromSelected() {
     state.selectedResearchPacketId = body.researchPacket.id;
     els.scriptResearchPacketId.value = body.researchPacket.id;
     await loadResearchPackets();
+    await loadJobs();
     savePipelineState();
     render();
     setStatus(`Research brief created: ${body.researchPacket.status}.`);
@@ -2554,6 +2937,7 @@ async function createMissingProductionAssets() {
         body: JSON.stringify({ actor: 'local-user' }),
       });
       await loadProduction();
+      await loadJobs();
       assets = selectedAssets();
     }
 
@@ -2563,9 +2947,11 @@ async function createMissingProductionAssets() {
         body: JSON.stringify({ actor: 'local-user' }),
       });
       await loadProduction();
+      await loadJobs();
     }
 
     await loadEpisodes();
+    await loadJobs();
     render();
     setStatus('Audio and cover asset tasks updated.');
   } catch (error) {
@@ -2598,6 +2984,7 @@ async function approveEpisodeForPublishing() {
     state.selectedEpisodeId = body.episode.id;
     await loadEpisodes();
     await loadProduction();
+    await loadJobs();
     savePipelineState();
     render();
     setStatus('Review decision saved: episode approved for publishing.');
@@ -2680,6 +3067,10 @@ async function loadAll() {
     await safeLoad('scheduled pipelines', loadScheduledPipelines, () => {
       state.scheduledPipelines = [];
       state.failedScheduledRuns = [];
+    });
+    await safeLoad('task runs', loadJobs, () => {
+      state.recentJobs = [];
+      state.selectedJobId = '';
     });
     await safeLoad('episodes', loadEpisodes, () => {
       state.episodes = [];
@@ -3022,6 +3413,7 @@ async function importLegacyData() {
     });
     await loadStoryCandidates();
     await loadEpisodes();
+    await loadJobs();
     render();
     setStatus(`Legacy import complete: ${body.summary.candidates.inserted} candidates inserted, ${body.summary.candidates.updated} updated.`);
   } catch (error) {
@@ -3077,6 +3469,7 @@ async function ingestSelectedProfile() {
   try {
     const body = await api(`/source-profiles/${profile.id}/ingest`, { method: 'POST' });
     await loadStoryCandidates();
+    await loadJobs();
     render();
     setStatus(`RSS import complete: ${body.inserted} inserted, ${body.skipped} skipped.`);
   } catch (error) {
@@ -3196,6 +3589,7 @@ async function createResearchBrief(candidateId, button) {
     state.selectedCandidateIds = [candidateId];
     state.selectedResearchPacketId = body.researchPacket.id;
     await loadResearchPackets();
+    await loadJobs();
     render();
     els.scriptResearchPacketId.value = body.researchPacket.id;
     savePipelineState();
@@ -3235,6 +3629,7 @@ async function generateScriptDraft(researchPacketId, format) {
     state.production = { episode: null, assets: [], jobs: [] };
     els.scriptResearchPacketId.value = '';
     savePipelineState();
+    await loadJobs();
     render();
     setStatus(`Generated script revision ${body.revision.version}.`);
   } catch (error) {
@@ -3263,6 +3658,7 @@ async function saveScriptRevision(event) {
     state.selectedScript = body.script;
     state.selectedRevision = body.revision;
     await loadProduction();
+    await loadJobs();
     render();
     setStatus(`Saved script revision ${body.revision.version}.`);
   } catch (error) {
@@ -3289,6 +3685,7 @@ async function approveSelectedScript() {
     state.scripts = state.scripts.map((script) => script.id === body.script.id ? body.script : script);
     state.selectedScript = body.script;
     await loadProduction();
+    await loadJobs();
     savePipelineState();
     render();
     setStatus('Review decision saved: script approved for audio.');
@@ -3305,6 +3702,7 @@ async function refreshProductionUntilSettled() {
   }
 
   await loadProduction();
+  await loadJobs();
   render();
 
   if (state.production.jobs.some((job) => !isTerminalJob(job))) {
@@ -3321,7 +3719,7 @@ async function refreshProductionUntilSettled() {
         } catch (error) {
           reportError(error);
         }
-      }, 1500);
+      }, 5000);
     }
   }
 }
@@ -3340,6 +3738,7 @@ async function startAudioPreview() {
       body: JSON.stringify({ actor: 'local-user' }),
     });
     await refreshProductionUntilSettled();
+    await loadJobs();
     setStatus('Preview audio job updated.');
   } catch (error) {
     await loadProduction();
@@ -3362,6 +3761,7 @@ async function startCoverArt() {
       body: JSON.stringify({ actor: 'local-user' }),
     });
     await refreshProductionUntilSettled();
+    await loadJobs();
     setStatus('Cover art job updated.');
   } catch (error) {
     await loadProduction();
@@ -3371,6 +3771,18 @@ async function startCoverArt() {
 }
 
 els.refresh.addEventListener('click', loadAll);
+els.refreshJobs.addEventListener('click', async () => {
+  els.refreshJobs.disabled = true;
+  try {
+    await loadJobs();
+    render();
+    setStatus('Task runs refreshed.');
+  } catch (error) {
+    reportError(error);
+  } finally {
+    els.refreshJobs.disabled = false;
+  }
+});
 els.importLegacy.addEventListener('click', importLegacyData);
 els.newShowToggle.addEventListener('click', () => {
   state.showSetupOpen = true;
@@ -3414,6 +3826,7 @@ els.showSelect.addEventListener('change', async () => {
   await loadStoryCandidates();
   await loadResearchPackets();
   await loadScheduledPipelines();
+  await loadJobs();
   await loadEpisodes();
   await loadScripts();
   render();

--- a/packages/api/src/jobs/summary.ts
+++ b/packages/api/src/jobs/summary.ts
@@ -1,0 +1,256 @@
+import type { JobRecord } from '../search/store.js';
+
+export interface JobRetryInfo {
+  supported: boolean;
+  reason: string;
+  endpoint?: string;
+  method?: 'POST';
+  requiresConfirmation?: boolean;
+}
+
+export interface JobArtifactRef {
+  label: string;
+  value: string;
+}
+
+export interface JobSummary {
+  warnings: Array<Record<string, unknown>>;
+  failure: Record<string, unknown> | null;
+  retry: JobRetryInfo;
+  artifacts: JobArtifactRef[];
+  provider: Record<string, unknown>;
+}
+
+export type JobResponseRecord = JobRecord & {
+  summary: JobSummary;
+};
+
+const SENSITIVE_KEY_PATTERN = /api.?key|authorization|cookie|credential|password|private.?key|provider.?response|raw.?response|secret|token/i;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function hideLocalPath(value: string) {
+  return value.startsWith('/') || value.startsWith('~') || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+export function sanitizeJobValue(value: unknown): unknown {
+  if (!value || typeof value !== 'object') {
+    return typeof value === 'string' && hideLocalPath(value) ? '[hidden local path]' : value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sanitizeJobValue);
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      result[key] = '[hidden]';
+    } else {
+      result[key] = sanitizeJobValue(item);
+    }
+  }
+
+  return result;
+}
+
+function collectWarningItems(value: unknown): Array<Record<string, unknown>> {
+  return asArray(value)
+    .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => sanitizeJobValue(item) as Record<string, unknown>);
+}
+
+function warningLogItems(logs: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return logs
+    .filter((item) => item.level === 'warn' || item.level === 'warning')
+    .map((item) => sanitizeJobValue(item) as Record<string, unknown>);
+}
+
+function stringList(value: unknown): string[] {
+  if (typeof value === 'string' && value.trim()) {
+    return [value];
+  }
+
+  return asArray(value).filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function addArtifact(artifacts: JobArtifactRef[], label: string, value: unknown) {
+  for (const item of stringList(value)) {
+    if (!artifacts.some((artifact) => artifact.label === label && artifact.value === item)) {
+      artifacts.push({ label, value: item });
+    }
+  }
+}
+
+function artifactRefs(job: JobRecord): JobArtifactRef[] {
+  const input = asRecord(job.input);
+  const output = asRecord(job.output);
+  const artifacts: JobArtifactRef[] = [];
+
+  for (const source of [input, output]) {
+    addArtifact(artifacts, 'source profile', source.sourceProfileId);
+    addArtifact(artifacts, 'source profile', source.sourceProfileSlug);
+    addArtifact(artifacts, 'search query', source.queryIds);
+    addArtifact(artifacts, 'scheduled pipeline', source.scheduledPipelineId);
+    addArtifact(artifacts, 'scheduled pipeline', source.scheduledPipelineSlug);
+    addArtifact(artifacts, 'candidate story', source.storyCandidateId);
+    addArtifact(artifacts, 'candidate story', source.candidateIds);
+    addArtifact(artifacts, 'research brief', source.researchPacketId);
+    addArtifact(artifacts, 'source document', source.sourceDocumentIds);
+    addArtifact(artifacts, 'failed source document', source.failedSourceDocumentIds);
+    addArtifact(artifacts, 'script', source.scriptId);
+    addArtifact(artifacts, 'script revision', source.revisionId);
+    addArtifact(artifacts, 'episode', source.episodeId);
+    addArtifact(artifacts, 'audio asset', source.audioPreviewAssetId);
+    addArtifact(artifacts, 'cover asset', source.coverArtAssetId);
+    addArtifact(artifacts, 'asset', source.assetId);
+    addArtifact(artifacts, 'feed', source.feedId);
+    addArtifact(artifacts, 'publishing record', source.publishEventId);
+  }
+
+  if (job.episodeId) {
+    addArtifact(artifacts, 'episode', job.episodeId);
+  }
+
+  return artifacts;
+}
+
+function providerMetadata(job: JobRecord): Record<string, unknown> {
+  const input = asRecord(job.input);
+  const output = asRecord(job.output);
+  const provider: Record<string, unknown> = {};
+
+  const entries: Array<[string, unknown]> = [
+    ['provider', input.provider ?? output.provider],
+    ['adapter', input.adapter ?? output.adapter],
+    ['modelProfile', input.modelProfile ?? output.modelProfile],
+    ['modelProfiles', input.modelProfiles ?? output.modelProfiles],
+    ['promptMetadata', input.promptMetadata ?? output.promptMetadata],
+  ];
+
+  for (const [key, value] of entries) {
+    if (value !== undefined && value !== null) {
+      provider[key] = sanitizeJobValue(value);
+    }
+  }
+
+  return provider;
+}
+
+function retryableFlag(job: JobRecord): boolean {
+  const output = asRecord(job.output);
+  const failure = asRecord(output.failure);
+
+  if (typeof failure.retryable === 'boolean') {
+    return failure.retryable;
+  }
+
+  if (typeof output.retryable === 'boolean') {
+    return output.retryable;
+  }
+
+  return true;
+}
+
+function retryInfo(job: JobRecord): JobRetryInfo {
+  if (job.status !== 'failed') {
+    return {
+      supported: false,
+      reason: 'Only failed task runs can be retried.',
+    };
+  }
+
+  if (!retryableFlag(job)) {
+    return {
+      supported: false,
+      reason: 'This failure is marked non-retryable. Fix the blocking input or approval state first.',
+    };
+  }
+
+  if (job.type === 'pipeline.scheduled') {
+    return {
+      supported: true,
+      method: 'POST',
+      endpoint: `/scheduled-pipeline-runs/${job.id}/retry`,
+      reason: 'Creates a new scheduled run linked to this failed run.',
+    };
+  }
+
+  const scriptId = asRecord(job.input).scriptId;
+  if ((job.type === 'audio.preview' || job.type === 'art.generate') && typeof scriptId === 'string') {
+    return {
+      supported: true,
+      method: 'POST',
+      endpoint: `/scripts/${scriptId}/production/${job.type === 'audio.preview' ? 'audio-preview' : 'cover-art'}`,
+      reason: 'Creates a new production task from the approved script revision.',
+    };
+  }
+
+  if (job.type === 'publish.rss') {
+    return {
+      supported: false,
+      requiresConfirmation: true,
+      reason: 'RSS publishing is never auto-retried. Use the explicit publish action after reviewing the failure.',
+    };
+  }
+
+  if (job.type === 'source.search' || job.type === 'source.ingest') {
+    return {
+      supported: false,
+      reason: 'Run the selected story source/search recipe again; this task type does not have a direct retry endpoint yet.',
+    };
+  }
+
+  return {
+    supported: false,
+    reason: 'No safe retry endpoint is registered for this task type yet.',
+  };
+}
+
+function failureInfo(job: JobRecord): Record<string, unknown> | null {
+  const output = asRecord(job.output);
+  const failure = asRecord(output.failure);
+  const message = typeof failure.message === 'string' ? failure.message : job.error;
+
+  if (!message) {
+    return null;
+  }
+
+  return sanitizeJobValue({
+    message,
+    code: typeof failure.code === 'string' ? failure.code : undefined,
+    retryable: typeof failure.retryable === 'boolean' ? failure.retryable : undefined,
+  }) as Record<string, unknown>;
+}
+
+export function normalizeJobRecord(job: JobRecord): JobResponseRecord {
+  const input = sanitizeJobValue(job.input) as Record<string, unknown>;
+  const output = sanitizeJobValue(job.output) as Record<string, unknown>;
+  const logs = sanitizeJobValue(job.logs) as Array<Record<string, unknown>>;
+
+  const warnings = [
+    ...collectWarningItems(input.warnings),
+    ...collectWarningItems(output.warnings),
+    ...warningLogItems(logs),
+  ];
+
+  return {
+    ...job,
+    input,
+    output,
+    logs,
+    summary: {
+      warnings,
+      failure: failureInfo({ ...job, input, output, logs }),
+      retry: retryInfo({ ...job, input, output, logs }),
+      artifacts: artifactRefs({ ...job, input, output, logs }),
+      provider: providerMetadata({ ...job, input, output, logs }),
+    },
+  };
+}

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -67,6 +67,7 @@ export interface ProductionRoutesOptions {
 
 const requestSchema = z.object({
   actor: z.string().trim().min(1).default('local-user'),
+  retryOfJobId: z.string().trim().min(1).optional(),
 });
 const approvePublishSchema = requestSchema.extend({
   reason: z.string().trim().min(1).optional(),
@@ -1135,6 +1136,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           episodeId: episode.id,
           provider: production.ttsProvider ?? 'vertex-gemini-tts',
           actor: body.actor,
+          retryOfJobId: body.retryOfJobId,
           stage,
           warnings,
         },
@@ -1276,6 +1278,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           promptMetadata: resolvedPrompt.promptMetadata,
           modelProfile,
           actor: body.actor,
+          retryOfJobId: body.retryOfJobId,
           stage,
         },
         logs,

--- a/packages/api/src/search/routes.test.ts
+++ b/packages/api/src/search/routes.test.ts
@@ -173,8 +173,12 @@ class FakeSearchStore implements SourceStore, SearchJobStore {
     return this.jobs.find((job) => job.id === id);
   }
 
-  async listJobs() {
-    return this.jobs;
+  async listJobs(filter: Parameters<SearchJobStore['listJobs']>[0] = {}) {
+    return this.jobs
+      .filter((job) => !filter.showId || job.showId === filter.showId)
+      .filter((job) => !filter.episodeId || job.episodeId === filter.episodeId)
+      .filter((job) => !filter.types || filter.types.includes(job.type))
+      .slice(0, filter.limit ?? 50);
   }
 
   async listStoryCandidateDedupeKeys(showId: string) {
@@ -340,6 +344,62 @@ describe('search routes candidate scoring', () => {
       assert.equal(body.candidates[0].metadata.scoringStatus, 'failed');
       assert.equal(body.candidates[0].scoreBreakdown.scorer.fallback, true);
       assert.match(JSON.stringify(body.job.logs), /Injected scorer failure/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('lists recent jobs with sanitized debug fields, warnings, artifacts, and retry status', async () => {
+    const store = new FakeSearchStore();
+    store.jobs.push({
+      id: 'job-secret',
+      showId: show.id,
+      episodeId: 'episode-1',
+      type: 'audio.preview',
+      status: 'failed',
+      progress: 45,
+      attempts: 1,
+      maxAttempts: 1,
+      input: {
+        scriptId: 'script-1',
+        provider: 'fake-tts',
+        apiKey: 'should-not-leak',
+        localPath: '/tmp/private/input.json',
+      },
+      output: {
+        stage: 'rendering-audio',
+        warnings: [{ code: 'SYNTHETIC_WARNING', message: 'Review audio timing.' }],
+        failure: { message: 'Synthetic TTS failure', code: 'Error', retryable: true },
+        providerResponse: { token: 'hidden' },
+      },
+      logs: [{ at: '2026-04-26T00:00:00.000Z', level: 'warn', message: 'Timing may need review.' }],
+      error: 'Synthetic TTS failure',
+      lockedBy: null,
+      lockedAt: null,
+      startedAt: new Date('2026-04-26T00:00:00Z'),
+      finishedAt: new Date('2026-04-26T00:01:00Z'),
+      createdAt: new Date('2026-04-26T00:00:00Z'),
+      updatedAt: new Date('2026-04-26T00:01:00Z'),
+    });
+    const app = buildApp({ sourceStore: store });
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/jobs?showSlug=example-show&limit=5' });
+      const body = response.json();
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(body.jobs.length, 1);
+      assert.equal(body.jobs[0].input.apiKey, '[hidden]');
+      assert.equal(body.jobs[0].input.localPath, '[hidden local path]');
+      assert.equal(body.jobs[0].output.providerResponse, '[hidden]');
+      assert.equal(body.jobs[0].summary.warnings.length, 2);
+      assert.deepEqual(body.jobs[0].summary.artifacts.find((item: { label: string }) => item.label === 'script'), {
+        label: 'script',
+        value: 'script-1',
+      });
+      assert.equal(body.jobs[0].summary.retry.supported, true);
+      assert.equal(body.jobs[0].summary.retry.endpoint, '/scripts/script-1/production/audio-preview');
+      assert.doesNotMatch(JSON.stringify(body), /should-not-leak|\/tmp\/private/);
     } finally {
       await app.close();
     }

--- a/packages/api/src/search/routes.ts
+++ b/packages/api/src/search/routes.ts
@@ -14,6 +14,7 @@ import type { ModelProfileStore } from '../models/store.js';
 import { createPromptRegistry } from '../prompts/registry.js';
 import type { PromptTemplateStore } from '../prompts/types.js';
 import type { SourceStore } from '../sources/store.js';
+import { normalizeJobRecord } from '../jobs/summary.js';
 
 class ApiError extends Error {
   constructor(
@@ -46,6 +47,8 @@ const manualCandidateSchema = z.object({
   message: 'Provide showId or showSlug.',
   path: ['showSlug'],
 });
+
+const jobStatusSchema = z.enum(['queued', 'running', 'succeeded', 'failed', 'cancelled']);
 
 function sendError(reply: FastifyReply, error: unknown) {
   if (error instanceof ZodError) {
@@ -99,6 +102,26 @@ function requireSearchStore(store: SourceStore & Partial<SearchJobStore>): Sourc
   }
 
   return store as SourceStore & SearchJobStore;
+}
+
+function parseLimit(raw: string | undefined, fallback = 50) {
+  if (!raw) {
+    return fallback;
+  }
+
+  const value = Number(raw);
+
+  return Number.isInteger(value) && value > 0 ? Math.min(value, 100) : fallback;
+}
+
+function parseJobStatus(raw: string | undefined) {
+  return raw ? jobStatusSchema.parse(raw) : undefined;
+}
+
+function parseJobTypes(raw: string | undefined) {
+  return raw
+    ? raw.split(',').map((type) => type.trim()).filter(Boolean)
+    : undefined;
 }
 
 function candidateScorerFor(
@@ -251,6 +274,26 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
     }
   });
 
+  app.get<{ Querystring: { showId?: string; showSlug?: string; status?: string; types?: string; limit?: string } }>('/jobs', async (request, reply) => {
+    try {
+      const store = requireSearchStore(options.getStore());
+      const showId = request.query.showId || request.query.showSlug
+        ? await resolveShowId(store, request.query.showId, request.query.showSlug)
+        : undefined;
+      const status = parseJobStatus(request.query.status);
+      const jobs = await store.listJobs({
+        showId,
+        types: parseJobTypes(request.query.types),
+        limit: parseLimit(request.query.limit),
+      });
+      const filtered = status ? jobs.filter((job) => job.status === status) : jobs;
+
+      return { ok: true, jobs: filtered.map(normalizeJobRecord) };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
   app.get<{ Params: { id: string } }>('/jobs/:id', async (request, reply) => {
     try {
       const store = requireSearchStore(options.getStore());
@@ -260,7 +303,7 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
         throw new ApiError(404, 'JOB_NOT_FOUND', `Job not found: ${request.params.id}`);
       }
 
-      return { ok: true, job };
+      return { ok: true, job: normalizeJobRecord(job) };
     } catch (error) {
       return sendError(reply, error);
     }


### PR DESCRIPTION
## Summary
- Adds normalized/sanitized job responses with warnings, failures, retry state, artifact refs, provider summaries, and stack-safe error details.
- Adds a show-scoped Task Runs panel in `/ui` with recent runs, selected run details, logs/events, warnings/failures, linked records, and collapsed debug metadata.
- Adds active-run polling at a 5s interval and pipeline stage “View Latest Run” links.

## Job endpoints used/added
- Added: `GET /jobs?showSlug=&limit=&status=&types=`
- Normalized existing: `GET /jobs/:id`
- Retry uses existing endpoints where safe:
  - `POST /scheduled-pipeline-runs/:jobId/retry`
  - `POST /scripts/:id/production/audio-preview`
  - `POST /scripts/:id/production/cover-art`

## Retry behavior
- Scheduled failed runs: enabled; creates a new scheduled run.
- Failed `audio.preview` / `art.generate`: enabled when retryable and `scriptId` exists; sends `retryOfJobId`.
- `publish.rss`: disabled with explanation; never auto-retried from Task Runs.
- `source.search` / `source.ingest`: visible but direct retry disabled; user reruns the source/search recipe.

## Known metadata gaps
- Source jobs do not yet expose a direct retry endpoint.
- Some future worker jobs may need richer artifact IDs beyond current input/output fields.
- Publish retry should remain explicit through the publish review flow.

## Verification
- `npm run check` passed in Codex run.
- Added fake/injected tests for sanitized recent job listing, warnings, artifact refs, and retry metadata.

Closes #23.