### PR TITLE
feat: add review approval gates UI

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -93,7 +93,7 @@ Open build wave:
 - #21 Multi-select candidate clustering UI ✅ implemented locally on `issue-21-candidate-clustering-ui`; `npm run check` passed.
 - #22 Settings/admin UI for shows, sources, models, prompts, publishing ✅ implemented locally on `issue-22-settings-admin-ui`; `npm run check` passed.
 - #23 Job progress, logs, warnings, and retry UI ✅ implemented locally on `issue-23-job-progress-ui`; `npm run check` passed.
-- #24 Review and approval gates UI
+- #24 Review and approval gates UI ✅ implemented locally on `issue-24-review-approval-gates`; `npm run check` passed.
 - #25 UX terminology and inline help cleanup
 
 ## Recommended execution plan

--- a/README.md
+++ b/README.md
@@ -457,6 +457,10 @@ curl http://localhost:3450/research-packets/:id
 curl -X POST http://localhost:3450/research-packets/:id/override-warning \
   -H 'content-type: application/json' \
   -d '{"warningId":"INSUFFICIENT_INDEPENDENT_SOURCES","reason":"Editor approved with direct source material.","actor":"local-user"}'
+
+curl -X POST http://localhost:3450/research-packets/:id/approve \
+  -H 'content-type: application/json' \
+  -d '{"actor":"editor@example.com","reason":"Sources, claims, citations, and warnings reviewed."}'
 ```
 
 Research endpoints:
@@ -466,13 +470,17 @@ Research endpoints:
 - `GET /research-packets?showSlug=the-synthetic-lens`
 - `GET /research-packets/:id`
 - `POST /research-packets/:id/override-warning`
+- `POST /research-packets/:id/approve`
 
 Packet `status` is a readiness value: `ready`, `needs_more_sources`, or
 `blocked`. The same object is also available at `content.readiness` with reasons
 and counts such as `independentSourceCount`, `usableSourceCount`, and
 `selectedCandidateCount`. Script generation should consume packet `claims`,
 `citations`, `sourceDocumentIds`, and `warnings`, and should surface non-ready
-or warning-bearing packets for editorial review before production.
+or warning-bearing packets for editorial review before production. Research
+approval records an `approval_events` row with gate `research-brief`; approval is
+blocked until the packet is ready and all warnings have explicit override
+reasons.
 
 ## Script generation workflow
 
@@ -566,8 +574,9 @@ Production endpoints:
 ## Approval-gated RSS publishing
 
 Episodes must reach `approved-for-publish` before `publish.rss` can update a
-feed. The endpoint returns `PUBLISH_BLOCKED` with `blockedReasons` when approval,
-feed config, or required audio/cover assets are missing or unsafe. The publish
+feed. The endpoint returns `PUBLISH_BLOCKED` with `blockedReasons` when research
+approval, warning overrides, publish approval, feed config, or required
+audio/cover assets are missing or unsafe. The publish
 job uploads the selected audio and cover art through the configured feed storage
 adapter, preserves the feed OP3 wrapping setting and metadata, upserts the RSS
 item by episode/feed GUID, validates the resulting public URLs, records a
@@ -597,6 +606,10 @@ Publishing endpoints:
 - `POST /episodes/:id/approve-for-publish`
 - `POST /episodes/:id/publish/rss`
 
-The local UI at `http://localhost:3450/ui` includes a script review panel where
-editors can select or paste a research brief ID, generate a draft, edit the
-latest revision, and approve it for audio.
+The local UI at `http://localhost:3450/ui` includes a Review Gates panel where
+editors can inspect research sources, claims, citations, warnings, script
+validation/provenance, audio and cover previews, asset metadata, and the publish
+readiness checklist. The checklist blocks publish approval and RSS publishing
+until research is approved, warnings are overridden, the selected script is
+approved for audio, audio and cover assets are valid, feed/RSS targets are
+configured, and the final publish action is explicit.

--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -375,6 +375,22 @@
           <div id="episodeList" class="record-list"></div>
         </section>
 
+        <section class="panel review-panel" aria-labelledby="reviewTitle">
+          <div class="panel-heading">
+            <div>
+              <h2 id="reviewTitle">Review Gates</h2>
+              <p id="reviewMeta">Select a research brief, script draft, and episode assets to review publishing readiness.</p>
+              <p class="help">Review decisions are saved through API approval endpoints. Publishing stays blocked until the checklist is complete and the editor explicitly publishes.</p>
+            </div>
+          </div>
+          <div class="review-grid">
+            <article id="reviewResearch" class="review-card"></article>
+            <article id="reviewScript" class="review-card"></article>
+            <article id="reviewProduction" class="review-card"></article>
+            <article id="publishChecklist" class="review-card"></article>
+          </div>
+        </section>
+
         <section id="queriesPanel" class="panel" hidden>
           <div class="panel-heading">
             <div>

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -530,6 +530,126 @@ textarea {
   margin-top: 0.75rem;
 }
 
+.review-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.review-card {
+  background: #f8fafc;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 0.85rem;
+}
+
+.review-heading {
+  align-items: start;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.review-heading h3,
+.review-heading p,
+.review-subsection h4,
+.review-subsection p {
+  margin: 0;
+}
+
+.review-heading p,
+.review-subsection p,
+.asset-preview p {
+  color: #586575;
+  font-size: 0.9rem;
+}
+
+.review-subsection,
+.review-list,
+.checklist,
+.asset-preview-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.review-list-item,
+.checklist-item,
+.asset-preview {
+  background: white;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  padding: 0.6rem;
+}
+
+.review-list-item {
+  color: #3f4b5a;
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.script-review-body {
+  background: white;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  color: #27303b;
+  max-height: 18rem;
+  overflow: auto;
+  padding: 0.75rem;
+  white-space: pre-wrap;
+}
+
+.asset-preview-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.asset-preview audio,
+.asset-preview img {
+  display: block;
+  margin-top: 0.5rem;
+  max-width: 100%;
+}
+
+.asset-preview img {
+  border-radius: 6px;
+}
+
+.checklist-item {
+  align-items: start;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.checklist-item p {
+  color: #586575;
+  font-size: 0.88rem;
+  margin: 0.15rem 0 0;
+}
+
+.checklist-mark {
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 700;
+  padding: 0.2rem 0.45rem;
+}
+
+.checklist-item.passed .checklist-mark {
+  background: #e8f6ef;
+  color: #1d6b43;
+}
+
+.checklist-item.blocked .checklist-mark {
+  background: #fff1df;
+  color: #8a4d0a;
+}
+
+.compact-action {
+  margin-left: 0.5rem;
+}
+
 .production-row {
   align-items: center;
   background: #f8fafc;
@@ -946,6 +1066,8 @@ textarea {
   .manual-form,
   .script-generate,
   .script-workspace,
+  .review-grid,
+  .asset-preview-grid,
   .job-layout,
   .job-facts,
   .new-query,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -16,6 +16,7 @@ const state = {
   selectedScriptId: '',
   selectedScript: null,
   selectedRevision: null,
+  selectedRevisions: [],
   production: {
     episode: null,
     assets: [],
@@ -120,6 +121,11 @@ const els = {
   jobRunDetail: document.querySelector('#jobRunDetail'),
   episodeMeta: document.querySelector('#episodeMeta'),
   episodeList: document.querySelector('#episodeList'),
+  reviewMeta: document.querySelector('#reviewMeta'),
+  reviewResearch: document.querySelector('#reviewResearch'),
+  reviewScript: document.querySelector('#reviewScript'),
+  reviewProduction: document.querySelector('#reviewProduction'),
+  publishChecklist: document.querySelector('#publishChecklist'),
   modelMeta: document.querySelector('#modelMeta'),
   modelProfileList: document.querySelector('#modelProfileList'),
   queriesPanel: document.querySelector('#queriesPanel'),
@@ -241,6 +247,7 @@ function friendlyApiMessage(body, status) {
     CANDIDATE_SHOW_MISMATCH: 'All selected candidate stories must belong to the same show.',
     RESEARCH_PACKET_NOT_FOUND: 'That research brief could not be found. Check the ID and try again.',
     RESEARCH_PACKET_OR_WARNING_NOT_FOUND: 'That research brief or warning could not be found.',
+    RESEARCH_APPROVAL_BLOCKED: 'Research approval is blocked until the brief is ready and warnings have override reasons.',
     SCHEDULED_PIPELINE_NOT_FOUND: 'That scheduled pipeline could not be found. Refresh and try again.',
     SCHEDULED_RUN_NOT_FOUND: 'That scheduled run could not be found. Refresh and try again.',
     DUPLICATE_SHOW_SLUG: 'Another show already uses that slug. Choose a unique show slug.',
@@ -251,6 +258,7 @@ function friendlyApiMessage(body, status) {
     INVALID_CRON: 'The cron schedule is not valid. Check the cadence and try again.',
     SCHEDULED_RUN_NOT_FAILED: 'Only failed scheduled runs can be retried.',
     PUBLISH_BLOCKED: 'Publishing is blocked until the checklist items are complete.',
+    PUBLISH_APPROVAL_BLOCKED: 'Publish approval is blocked until the checklist items are complete.',
   };
 
   if (messages[code]) {
@@ -643,6 +651,132 @@ function selectedAssets() {
   return assets.length > 0 ? assets : state.production.assets;
 }
 
+function researchReadinessStatus(packet) {
+  const readiness = asObject(packet?.content?.readiness);
+  return typeof readiness.status === 'string' ? readiness.status : packet?.status || 'missing';
+}
+
+function unresolvedResearchWarnings(packet) {
+  return asArray(packet?.warnings).filter((warning) => !warning.override);
+}
+
+function researchApproved(packet) {
+  return Boolean(packet?.approvedAt);
+}
+
+function selectedFeed() {
+  const episode = selectedEpisode();
+  return state.feeds.find((feed) => feed.id === episode?.feedId) || state.feeds[0] || null;
+}
+
+function assetWarningItems(asset) {
+  return [
+    ...asArray(asset?.metadata?.warnings),
+    ...asArray(asset?.metadata?.validation?.warnings),
+  ].filter(Boolean);
+}
+
+function productionWarningItems() {
+  return [
+    ...asArray(selectedEpisode()?.warnings),
+    ...selectedAssets().flatMap(assetWarningItems),
+    ...state.production.jobs.flatMap((job) => asArray(job.summary?.warnings)),
+  ];
+}
+
+function validHttpUrl(value) {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function publishChecklistState() {
+  const packet = selectedResearchPacket();
+  const script = state.selectedScript;
+  const revision = state.selectedRevision;
+  const episode = selectedEpisode();
+  const assets = selectedAssets();
+  const feed = selectedFeed();
+  const audioAsset = assets.find((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview');
+  const coverAsset = assets.find((asset) => asset.type === 'cover-art');
+  const unresolvedWarnings = unresolvedResearchWarnings(packet);
+  const productionWarnings = productionWarningItems();
+  const scriptApproved = Boolean(script && revision && script.status === 'approved-for-audio' && script.approvedRevisionId === revision.id);
+  const feedPublicUrl = feed?.publicFeedUrl || '';
+  const publicBaseUrl = publicAssetBaseForFeed(feed || {});
+  const feedConfigured = Boolean(feed);
+  const targetConfigured = Boolean(feed?.rssFeedPath || outputPathForFeed(feed || {}) || feedPublicUrl);
+  const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
+  const audioValid = Boolean(audioAsset && audioAsset.mimeType?.startsWith('audio/') && (audioAsset.byteSize === null || audioAsset.byteSize > 0));
+  const coverValid = Boolean(coverAsset && coverAsset.mimeType?.startsWith('image/'));
+
+  return [
+    {
+      key: 'research',
+      label: 'Research brief approved',
+      passed: Boolean(packet && researchApproved(packet) && unresolvedWarnings.length === 0 && ['ready', 'approved', 'research-ready'].includes(researchReadinessStatus(packet))),
+      reason: !packet
+        ? 'Select a research brief.'
+        : !['ready', 'approved', 'research-ready'].includes(researchReadinessStatus(packet))
+          ? `Research status is ${researchReadinessStatus(packet)}.`
+          : unresolvedWarnings.length > 0
+            ? `${unresolvedWarnings.length} research warning${unresolvedWarnings.length === 1 ? '' : 's'} need override reasons.`
+            : !researchApproved(packet) ? 'Approve the research brief after review.' : 'Research review decision recorded.',
+    },
+    {
+      key: 'script',
+      label: 'Script approved for audio',
+      passed: scriptApproved,
+      reason: scriptApproved ? 'Script review decision recorded.' : 'Approve the selected script revision.',
+    },
+    {
+      key: 'audio',
+      label: 'Valid audio asset exists',
+      passed: audioValid,
+      reason: audioAsset ? (audioValid ? 'Audio asset has an audio MIME type and usable size.' : 'Audio asset metadata is incomplete or invalid.') : 'Create a preview MP3 or attach final audio.',
+    },
+    {
+      key: 'cover',
+      label: 'Cover art asset exists',
+      passed: coverValid,
+      reason: coverAsset ? (coverValid ? 'Cover art has an image MIME type.' : 'Cover art MIME type is not an image.') : 'Create cover art before publishing.',
+    },
+    {
+      key: 'feed',
+      label: 'Feed metadata configured',
+      passed: feedConfigured && feedUrlsValid,
+      reason: !feedConfigured ? 'Configure a feed for this show.' : feedUrlsValid ? 'Feed metadata is available.' : 'Feed public URLs must be valid http(s) URLs.',
+    },
+    {
+      key: 'target',
+      label: 'RSS/public target configured',
+      passed: feedConfigured && targetConfigured,
+      reason: targetConfigured ? 'RSS path or public feed URL is configured.' : 'Configure an RSS path, output path, or public feed URL.',
+    },
+    {
+      key: 'warnings',
+      label: 'No blocking warnings remain',
+      passed: unresolvedWarnings.length === 0 && productionWarnings.length === 0,
+      reason: unresolvedWarnings.length + productionWarnings.length === 0
+        ? 'No unresolved research or production warnings are selected.'
+        : `${unresolvedWarnings.length + productionWarnings.length} warning${unresolvedWarnings.length + productionWarnings.length === 1 ? '' : 's'} require review.`,
+    },
+    {
+      key: 'publishApproval',
+      label: 'Episode approved for publishing',
+      passed: Boolean(episode && ['approved-for-publish', 'published'].includes(episode.status)),
+      reason: episode ? (episode.status === 'published' ? 'Episode is already published.' : episode.status === 'approved-for-publish' ? 'Publish approval recorded.' : 'Approve audio and cover assets for publishing.') : 'Create production assets to create an episode record.',
+    },
+  ];
+}
+
 function pipelineStorageKey(showSlug = state.selectedShowSlug) {
   return showSlug ? `podcast-forge:pipeline:${showSlug}` : '';
 }
@@ -702,6 +836,7 @@ function clearPipelineSelections() {
   state.selectedScriptId = '';
   state.selectedScript = null;
   state.selectedRevision = null;
+  state.selectedRevisions = [];
   state.selectedEpisodeId = '';
   state.selectedAssetIds = [];
   state.production = { episode: null, assets: [], jobs: [] };
@@ -1023,6 +1158,10 @@ function buildPipelineStages() {
   const packetWarningCount = packet?.warnings?.length || 0;
   const packetBlocked = packet?.status === 'blocked';
   const profileSupportsDiscovery = profile && ['brave', 'rss'].includes(profile.type);
+  const checklist = publishChecklistState();
+  const publishChecklistReady = checklist.every((item) => item.passed);
+  const publishPreApprovalReady = checklist.filter((item) => item.key !== 'publishApproval').every((item) => item.passed);
+  const firstChecklistBlocker = checklist.find((item) => !item.passed)?.reason;
 
   return [
     {
@@ -1121,27 +1260,27 @@ function buildPipelineStages() {
     {
       number: 7,
       title: 'Review approvals',
-      status: approvalsRunning ? 'running' : episode?.status === 'approved-for-publish' || episode?.status === 'published' ? 'done' : episode?.status === 'audio-ready' ? 'ready' : state.selectedScript && !scriptApproved ? 'needs review' : 'blocked',
+      status: approvalsRunning ? 'running' : episode?.status === 'approved-for-publish' || episode?.status === 'published' ? 'done' : episode?.status === 'audio-ready' && publishPreApprovalReady ? 'ready' : state.selectedScript && !scriptApproved ? 'needs review' : 'blocked',
       artifact: episode ? `${episode.title} (${episode.status})` : latestScriptText(),
       next: episode?.status === 'audio-ready'
-        ? 'Approve the episode for publishing after reviewing assets.'
+        ? (publishPreApprovalReady ? 'Approve the episode for publishing after reviewing assets.' : firstChecklistBlocker || 'Complete the publish checklist before approval.')
         : state.selectedScript && !scriptApproved ? 'Approve the script revision before production can run.' : 'Finish script approval and production assets first.',
       actionLabel: episode?.status === 'audio-ready' ? 'Approve for Publishing' : 'Approve Script for Audio',
       action: episode?.status === 'audio-ready' ? approveEpisodeForPublishing : approveSelectedScript,
-      disabled: approvalsRunning || !(episode?.status === 'audio-ready' || (state.selectedScript && state.selectedRevision && !scriptApproved)),
+      disabled: approvalsRunning || !(episode?.status === 'audio-ready' ? publishPreApprovalReady : (state.selectedScript && state.selectedRevision && !scriptApproved)),
       active: Boolean(episode?.status === 'approved-for-publish' || episode?.status === 'published'),
     },
     {
       number: 8,
       title: 'Publish',
-      status: publishRunning ? 'running' : episode?.status === 'published' ? 'done' : episode?.status === 'approved-for-publish' ? 'ready' : 'blocked',
+      status: publishRunning ? 'running' : episode?.status === 'published' ? 'done' : episode?.status === 'approved-for-publish' && publishChecklistReady ? 'ready' : 'blocked',
       artifact: episode?.feedGuid || episode?.metadata?.publish?.rssUrl || 'No publishing record yet.',
       next: episode?.status === 'published'
         ? 'RSS publishing has a recorded feed GUID or publish result.'
-        : episode?.status === 'approved-for-publish' ? 'Publish to the configured RSS feed.' : 'Approval for publishing is required before RSS output.',
+        : episode?.status === 'approved-for-publish' ? (publishChecklistReady ? 'Publish to the configured RSS feed.' : firstChecklistBlocker || 'Complete the publish checklist first.') : 'Approval for publishing is required before RSS output.',
       actionLabel: episode?.status === 'published' ? 'Already Published' : 'Publish to RSS',
       action: publishSelectedEpisode,
-      disabled: publishRunning || episode?.status !== 'approved-for-publish',
+      disabled: publishRunning || episode?.status !== 'approved-for-publish' || !publishChecklistReady,
       active: episode?.status === 'published',
       primary: true,
       jobTypes: ['publish.rss'],
@@ -2485,6 +2624,319 @@ function renderScripts() {
   renderProduction();
 }
 
+function reviewSectionHeading(title, status, detail) {
+  const heading = document.createElement('div');
+  heading.className = 'review-heading';
+  const copy = document.createElement('div');
+  const h3 = document.createElement('h3');
+  h3.textContent = title;
+  const p = document.createElement('p');
+  p.textContent = detail;
+  copy.append(h3, p);
+  const pill = document.createElement('span');
+  pill.className = `status-pill ${statusClass(status)}`;
+  pill.textContent = status;
+  heading.append(copy, pill);
+  return heading;
+}
+
+function reviewFacts(items) {
+  const facts = document.createElement('div');
+  facts.className = 'settings-kv';
+  for (const [label, value] of items) {
+    const item = document.createElement('span');
+    item.textContent = `${label}: ${value}`;
+    facts.append(item);
+  }
+  return facts;
+}
+
+function reviewList(title, items, emptyText, mapper = (item) => item) {
+  const section = document.createElement('section');
+  section.className = 'review-subsection';
+  const heading = document.createElement('h4');
+  heading.textContent = title;
+  section.append(heading);
+
+  if (items.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-inline';
+    empty.textContent = emptyText;
+    section.append(empty);
+    return section;
+  }
+
+  const list = document.createElement('div');
+  list.className = 'review-list';
+  for (const item of items) {
+    const row = document.createElement('div');
+    row.className = 'review-list-item';
+    row.textContent = mapper(item);
+    list.append(row);
+  }
+  section.append(list);
+  return section;
+}
+
+function renderResearchReview() {
+  const packet = selectedResearchPacket();
+  els.reviewResearch.innerHTML = '';
+
+  if (!packet) {
+    els.reviewResearch.append(
+      reviewSectionHeading('Research Brief', 'blocked', 'No research brief is selected.'),
+      settingsEmpty('Select or create a research brief before review.'),
+    );
+    return;
+  }
+
+  const readiness = researchReadinessStatus(packet);
+  const unresolved = unresolvedResearchWarnings(packet);
+  const approved = researchApproved(packet);
+  const status = approved && unresolved.length === 0 ? 'done' : unresolved.length > 0 || readiness !== 'ready' ? 'needs review' : 'ready';
+  const candidateIds = asArray(packet.content?.candidateIds).filter((id) => typeof id === 'string');
+  const sourceUrls = asArray(packet.citations).map((citation) => citation.url).filter(Boolean);
+
+  els.reviewResearch.append(
+    reviewSectionHeading('Research Brief', status, packet.title),
+    reviewFacts([
+      ['Readiness', readiness],
+      ['Review decision', approved ? `approved ${formatTime(packet.approvedAt)}` : 'not approved'],
+      ['Independent sources', packet.content?.independentSourceCount ?? 'unknown'],
+      ['Usable sources', packet.content?.usableSourceCount ?? 'unknown'],
+      ['Selected candidates', packet.content?.selectedCandidateCount ?? (candidateIds.length || 'unknown')],
+    ]),
+    reviewList('Selected candidates', candidateIds, 'No selected candidate IDs were recorded.', (id) => id),
+    reviewList('Source URLs', sourceUrls, 'No citation URLs were recorded.', (url) => url),
+    reviewList('Claims and citations', asArray(packet.claims), 'No claims were recorded for this brief.', (claim) => {
+      const citations = asArray(claim.citationUrls).join(', ') || 'missing citation URL';
+      return `${claim.text || claim.id || 'Claim'} | ${citations}`;
+    }),
+  );
+
+  const warnings = document.createElement('section');
+  warnings.className = 'review-subsection';
+  warnings.innerHTML = '<h4>Warnings</h4>';
+  if (asArray(packet.warnings).length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-inline';
+    empty.textContent = 'No research warnings recorded.';
+    warnings.append(empty);
+  } else {
+    for (const warning of asArray(packet.warnings)) {
+      const row = document.createElement('div');
+      row.className = `warning-item ${warning.severity === 'error' ? 'error' : ''}`;
+      const message = document.createElement('span');
+      message.textContent = `${warning.code || 'warning'}: ${warning.message || 'No message recorded.'}${warning.override ? ` | overridden by ${warning.override.actor}` : ''}`;
+      row.append(message);
+      if (!warning.override) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'secondary compact-action';
+        button.textContent = 'Override';
+        button.addEventListener('click', () => overrideResearchWarning(packet.id, warning));
+        row.append(button);
+      }
+      warnings.append(row);
+    }
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'actions inline';
+  const approve = document.createElement('button');
+  approve.type = 'button';
+  approve.className = 'secondary';
+  approve.textContent = approved ? 'Research Approved' : 'Approve Research Brief';
+  approve.disabled = approved || readiness !== 'ready' || unresolved.length > 0 || isActionRunning('approval');
+  approve.title = approve.disabled && !approved ? 'Research must be ready and warnings must be overridden before approval.' : '';
+  approve.addEventListener('click', approveSelectedResearch);
+  actions.append(approve);
+  els.reviewResearch.append(warnings, actions);
+}
+
+function renderScriptReview() {
+  const script = state.selectedScript;
+  const revision = state.selectedRevision;
+  els.reviewScript.innerHTML = '';
+
+  if (!script || !revision) {
+    els.reviewScript.append(
+      reviewSectionHeading('Script Draft', 'blocked', 'No script revision is selected.'),
+      settingsEmpty('Generate or select a script draft before review.'),
+    );
+    return;
+  }
+
+  const validation = asObject(revision.metadata?.validation);
+  const speakerValidation = asObject(validation.speakerLabels);
+  const provenanceValidation = asObject(validation.provenance);
+  const warningItems = [
+    ...asArray(revision.metadata?.warnings),
+    ...asArray(revision.metadata?.provenance?.warnings),
+    ...asArray(provenanceValidation.warnings),
+  ];
+  const approved = script.status === 'approved-for-audio' && script.approvedRevisionId === revision.id;
+
+  els.reviewScript.append(
+    reviewSectionHeading('Script Draft', approved ? 'done' : warningItems.length > 0 ? 'needs review' : 'ready', `${script.title} | revision ${revision.version}`),
+    reviewFacts([
+      ['Review decision', approved ? `approved ${formatTime(script.approvedAt)}` : 'not approved'],
+      ['Speaker validation', speakerValidation.valid === false ? 'failed' : 'passed or not recorded'],
+      ['Provenance validation', provenanceValidation.valid === false ? 'failed' : `${provenanceValidation.warningCount ?? warningItems.length} warning(s)`],
+      ['Revision history', `${state.selectedRevisions.length || 1} revision${(state.selectedRevisions.length || 1) === 1 ? '' : 's'}`],
+    ]),
+    reviewList('Revision history', state.selectedRevisions, 'Only the selected revision is loaded.', (item) => `v${item.version} by ${item.author} | ${formatTime(item.createdAt)}${item.changeSummary ? ` | ${item.changeSummary}` : ''}`),
+    reviewList('Citation map and provenance warnings', warningItems, 'No missing-provenance warnings recorded.', (item) => item.message || item.code || JSON.stringify(sanitizedDebug(item))),
+  );
+
+  const body = document.createElement('pre');
+  body.className = 'script-review-body';
+  body.textContent = revision.body || 'No script body recorded.';
+  const actions = document.createElement('div');
+  actions.className = 'actions inline';
+  const approve = document.createElement('button');
+  approve.type = 'button';
+  approve.className = 'secondary';
+  approve.textContent = approved ? 'Script Approved' : 'Approve Script for Audio';
+  approve.disabled = approved || isActionRunning('approval');
+  approve.addEventListener('click', approveSelectedScript);
+  actions.append(approve);
+  els.reviewScript.append(body, actions);
+}
+
+function renderProductionReview() {
+  const episode = selectedEpisode();
+  const assets = selectedAssets();
+  const audioAsset = assets.find((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview');
+  const coverAsset = assets.find((asset) => asset.type === 'cover-art');
+  const warnings = productionWarningItems();
+  els.reviewProduction.innerHTML = '';
+
+  els.reviewProduction.append(
+    reviewSectionHeading('Audio and Cover Assets', episode?.status === 'approved-for-publish' || episode?.status === 'published' ? 'done' : audioAsset && coverAsset ? 'ready' : 'blocked', episode ? episode.title : 'No episode record yet.'),
+    reviewFacts([
+      ['Episode status', episode?.status || 'missing'],
+      ['Audio', audioAsset ? audioAsset.mimeType || 'recorded' : 'missing'],
+      ['Cover art', coverAsset ? coverAsset.mimeType || 'recorded' : 'missing'],
+      ['Production warnings', warnings.length],
+    ]),
+  );
+
+  const media = document.createElement('div');
+  media.className = 'asset-preview-grid';
+  const audioBox = document.createElement('div');
+  audioBox.className = 'asset-preview';
+  const audioTitle = document.createElement('strong');
+  audioTitle.textContent = 'Audio preview';
+  audioBox.append(audioTitle);
+  if (audioAsset?.publicUrl) {
+    const player = document.createElement('audio');
+    player.controls = true;
+    player.src = audioAsset.publicUrl;
+    audioBox.append(player);
+  } else {
+    const empty = document.createElement('p');
+    empty.textContent = audioAsset ? 'Audio asset recorded without a public preview URL.' : 'No audio asset recorded.';
+    audioBox.append(empty);
+  }
+  const coverBox = document.createElement('div');
+  coverBox.className = 'asset-preview';
+  const coverTitle = document.createElement('strong');
+  coverTitle.textContent = 'Cover art';
+  coverBox.append(coverTitle);
+  if (coverAsset?.publicUrl) {
+    const image = document.createElement('img');
+    image.src = coverAsset.publicUrl;
+    image.alt = coverAsset.label || 'Cover art preview';
+    coverBox.append(image);
+  } else {
+    const empty = document.createElement('p');
+    empty.textContent = coverAsset ? 'Cover art asset recorded without a public preview URL.' : 'No cover art asset recorded.';
+    coverBox.append(empty);
+  }
+  media.append(audioBox, coverBox);
+  els.reviewProduction.append(media);
+
+  els.reviewProduction.append(
+    reviewList('Asset metadata', assets, 'No production assets recorded.', (asset) => {
+      const provider = asset.metadata?.provider || asset.metadata?.adapter || asset.metadata?.adapterKind || 'unknown provider';
+      const size = asset.byteSize === null || asset.byteSize === undefined ? 'size unknown' : `${asset.byteSize} bytes`;
+      const duration = asset.durationSeconds ? ` | ${asset.durationSeconds}s` : '';
+      return `${asset.type} | ${asset.mimeType || 'unknown MIME'} | ${size}${duration} | ${provider}`;
+    }),
+    reviewList('Production warnings and failures', warnings, 'No production warnings recorded.', (item) => item.message || item.code || JSON.stringify(sanitizedDebug(item))),
+  );
+
+  const actions = document.createElement('div');
+  actions.className = 'actions inline';
+  const approve = document.createElement('button');
+  approve.type = 'button';
+  approve.className = 'secondary';
+  approve.textContent = episode?.status === 'approved-for-publish' || episode?.status === 'published' ? 'Assets Approved' : 'Approve Assets for Publishing';
+  const preApprovalReady = publishChecklistState().filter((item) => item.key !== 'publishApproval').every((item) => item.passed);
+  approve.disabled = !episode || episode.status !== 'audio-ready' || !preApprovalReady || isActionRunning('approval');
+  approve.title = approve.disabled ? 'Complete the checklist before publish approval.' : '';
+  approve.addEventListener('click', approveEpisodeForPublishing);
+  actions.append(approve);
+  els.reviewProduction.append(actions);
+}
+
+function renderPublishChecklist() {
+  const episode = selectedEpisode();
+  const checklist = publishChecklistState();
+  const ready = checklist.every((item) => item.passed);
+  const canApprove = checklist.filter((item) => item.key !== 'publishApproval').every((item) => item.passed);
+  els.publishChecklist.innerHTML = '';
+  els.publishChecklist.append(reviewSectionHeading('Publishing Checklist', ready ? 'ready' : 'blocked', episode ? `${episode.title} | ${episode.status}` : 'No episode selected.'));
+
+  const list = document.createElement('div');
+  list.className = 'checklist';
+  for (const item of checklist) {
+    const row = document.createElement('div');
+    row.className = `checklist-item ${item.passed ? 'passed' : 'blocked'}`;
+    const mark = document.createElement('span');
+    mark.className = 'checklist-mark';
+    mark.textContent = item.passed ? 'OK' : 'Block';
+    const text = document.createElement('div');
+    const label = document.createElement('strong');
+    label.textContent = item.label;
+    const reason = document.createElement('p');
+    reason.textContent = item.reason;
+    text.append(label, reason);
+    row.append(mark, text);
+    list.append(row);
+  }
+  els.publishChecklist.append(list);
+
+  const actions = document.createElement('div');
+  actions.className = 'actions inline';
+  const approve = document.createElement('button');
+  approve.type = 'button';
+  approve.className = 'secondary';
+  approve.textContent = episode?.status === 'approved-for-publish' || episode?.status === 'published' ? 'Publish Approval Saved' : 'Approve for Publishing';
+  approve.disabled = !episode || episode.status !== 'audio-ready' || !canApprove || isActionRunning('approval');
+  approve.addEventListener('click', approveEpisodeForPublishing);
+  const publish = document.createElement('button');
+  publish.type = 'button';
+  publish.textContent = episode?.status === 'published' ? 'Published' : 'Publish to RSS';
+  publish.disabled = !episode || episode.status !== 'approved-for-publish' || !ready || isActionRunning('publish');
+  publish.title = publish.disabled && episode?.status !== 'published' ? 'Publishing is disabled until every checklist item passes.' : '';
+  publish.addEventListener('click', publishSelectedEpisode);
+  actions.append(approve, publish);
+  els.publishChecklist.append(actions);
+}
+
+function renderReviewGates() {
+  const show = selectedShow();
+  els.reviewMeta.textContent = show
+    ? `${show.title} | Review research, script, production assets, and publish readiness.`
+    : 'Select a show before reviewing approval gates.';
+  renderResearchReview();
+  renderScriptReview();
+  renderProductionReview();
+  renderPublishChecklist();
+}
+
 function render() {
   renderShows();
   renderSettings();
@@ -2497,6 +2949,7 @@ function render() {
   renderScheduler();
   renderJobRuns();
   renderEpisodes();
+  renderReviewGates();
   renderModelProfiles();
   renderQueries();
   renderScripts();
@@ -2550,6 +3003,7 @@ async function loadScripts() {
     state.selectedScriptId = '';
     state.selectedScript = null;
     state.selectedRevision = null;
+    state.selectedRevisions = [];
     return;
   }
 
@@ -2565,6 +3019,7 @@ async function loadScripts() {
   } else {
     state.selectedScript = null;
     state.selectedRevision = null;
+    state.selectedRevisions = [];
     state.production = { episode: null, assets: [], jobs: [] };
   }
 }
@@ -2773,6 +3228,7 @@ async function loadScript(id) {
   state.selectedScriptId = id;
   state.selectedScript = body.script;
   state.selectedRevision = body.latestRevision || null;
+  state.selectedRevisions = body.revisions || [];
   await loadProduction();
 }
 
@@ -2970,6 +3426,14 @@ async function approveEpisodeForPublishing() {
     return;
   }
 
+  const checklist = publishChecklistState().filter((item) => item.key !== 'publishApproval');
+
+  if (!checklist.every((item) => item.passed)) {
+    setStatus(`Publish approval is blocked: ${checklist.find((item) => !item.passed)?.reason || 'checklist incomplete'}`);
+    render();
+    return;
+  }
+
   setActionRunning('approval', true);
   setStatus('Saving publish approval...');
 
@@ -2999,6 +3463,14 @@ async function publishSelectedEpisode() {
   const episode = selectedEpisode();
 
   if (!episode || episode.status !== 'approved-for-publish') {
+    return;
+  }
+
+  const checklist = publishChecklistState();
+
+  if (!checklist.every((item) => item.passed)) {
+    setStatus(`Publishing is blocked: ${checklist.find((item) => !item.passed)?.reason || 'checklist incomplete'}`);
+    render();
     return;
   }
 
@@ -3080,6 +3552,7 @@ async function loadAll() {
       state.selectedScriptId = '';
       state.selectedScript = null;
       state.selectedRevision = null;
+      state.selectedRevisions = [];
       state.production = { episode: null, assets: [], jobs: [] };
     });
     render();
@@ -3625,6 +4098,7 @@ async function generateScriptDraft(researchPacketId, format) {
     state.selectedScriptId = body.script.id;
     state.selectedScript = body.script;
     state.selectedRevision = body.revision;
+    state.selectedRevisions = [body.revision];
     state.selectedResearchPacketId = researchPacketId;
     state.production = { episode: null, assets: [], jobs: [] };
     els.scriptResearchPacketId.value = '';
@@ -3657,6 +4131,7 @@ async function saveScriptRevision(event) {
     state.scripts = [body.script, ...state.scripts.filter((script) => script.id !== body.script.id)];
     state.selectedScript = body.script;
     state.selectedRevision = body.revision;
+    state.selectedRevisions = [body.revision, ...state.selectedRevisions.filter((revision) => revision.id !== body.revision.id)];
     await loadProduction();
     await loadJobs();
     render();
@@ -3689,6 +4164,77 @@ async function approveSelectedScript() {
     savePipelineState();
     render();
     setStatus('Review decision saved: script approved for audio.');
+  } catch (error) {
+    reportError(error);
+  } finally {
+    setActionRunning('approval', false);
+  }
+}
+
+async function overrideResearchWarning(packetId, warning) {
+  const reason = window.prompt('Override reason for this research warning:');
+
+  if (!reason || !reason.trim()) {
+    setStatus('Warning override cancelled. A reason is required.');
+    return;
+  }
+
+  setActionRunning('approval', true);
+  setStatus('Saving research warning override...');
+
+  try {
+    const body = await api(`/research-packets/${packetId}/override-warning`, {
+      method: 'POST',
+      body: JSON.stringify({
+        warningId: warning.id,
+        warningCode: warning.code,
+        actor: 'local-user',
+        reason: reason.trim(),
+      }),
+    });
+    state.researchPackets = state.researchPackets.map((packet) => packet.id === body.researchPacket.id ? body.researchPacket : packet);
+    state.selectedResearchPacketId = body.researchPacket.id;
+    await loadJobs();
+    savePipelineState();
+    render();
+    setStatus('Review decision saved: research warning override recorded.');
+  } catch (error) {
+    reportError(error);
+  } finally {
+    setActionRunning('approval', false);
+  }
+}
+
+async function approveSelectedResearch() {
+  const packet = selectedResearchPacket();
+
+  if (!packet) {
+    return;
+  }
+
+  const reason = window.prompt('Research approval note:', 'Sources, claims, citations, and warnings reviewed.');
+
+  if (reason === null) {
+    setStatus('Research approval cancelled.');
+    return;
+  }
+
+  setActionRunning('approval', true);
+  setStatus('Saving research approval...');
+
+  try {
+    const body = await api(`/research-packets/${packet.id}/approve`, {
+      method: 'POST',
+      body: JSON.stringify({
+        actor: 'local-user',
+        reason: reason.trim() || 'Sources, claims, citations, and warnings reviewed.',
+      }),
+    });
+    state.researchPackets = state.researchPackets.map((candidate) => candidate.id === body.researchPacket.id ? body.researchPacket : candidate);
+    state.selectedResearchPacketId = body.researchPacket.id;
+    savePipelineState();
+    render();
+    setStatus('Review decision saved: research brief approved.');
   } catch (error) {
     reportError(error);
   } finally {

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -580,6 +580,81 @@ interface PublishBlockedReason {
   metadata?: Record<string, unknown>;
 }
 
+function researchReadinessStatus(packet: ResearchPacketRecord) {
+  const readiness = packet.content.readiness;
+  const contentStatus = readiness && typeof readiness === 'object' && !Array.isArray(readiness)
+    ? (readiness as Record<string, unknown>).status
+    : undefined;
+
+  return typeof contentStatus === 'string' ? contentStatus : packet.status;
+}
+
+function unresolvedResearchWarnings(packet: ResearchPacketRecord) {
+  return packet.warnings.filter((warning) => !warning.override);
+}
+
+async function loadEpisodeResearchPacket(store: object, episode: EpisodeRecord) {
+  if (!episode.researchPacketId) {
+    return null;
+  }
+
+  if (!hasResearchStore(store)) {
+    throw new ApiError(503, 'RESEARCH_STORE_UNAVAILABLE', 'Research store method is unavailable: getResearchPacket');
+  }
+
+  return store.getResearchPacket(episode.researchPacketId);
+}
+
+function researchBlockers(episode: EpisodeRecord, researchPacket: ResearchPacketRecord | null | undefined): PublishBlockedReason[] {
+  if (!episode.researchPacketId) {
+    return [{
+      code: 'RESEARCH_BRIEF_REQUIRED',
+      message: 'Episode must be linked to an approved research brief before publishing.',
+    }];
+  }
+
+  if (!researchPacket) {
+    return [{
+      code: 'RESEARCH_BRIEF_NOT_FOUND',
+      message: 'Linked research brief could not be loaded for publish review.',
+      metadata: { researchPacketId: episode.researchPacketId },
+    }];
+  }
+
+  const blockers: PublishBlockedReason[] = [];
+  const readiness = researchReadinessStatus(researchPacket);
+  const unresolvedWarnings = unresolvedResearchWarnings(researchPacket);
+
+  if (!['ready', 'approved', 'research-ready'].includes(readiness)) {
+    blockers.push({
+      code: 'RESEARCH_BRIEF_NOT_READY',
+      message: 'Research brief is not ready for publishing review.',
+      metadata: { researchPacketId: researchPacket.id, status: researchPacket.status, readiness },
+    });
+  }
+
+  if (!researchPacket.approvedAt) {
+    blockers.push({
+      code: 'RESEARCH_BRIEF_NOT_APPROVED',
+      message: 'Research brief must have a recorded review decision before publishing.',
+      metadata: { researchPacketId: researchPacket.id },
+    });
+  }
+
+  if (unresolvedWarnings.length > 0) {
+    blockers.push({
+      code: 'RESEARCH_WARNINGS_UNRESOLVED',
+      message: 'Research warnings must be resolved with explicit editorial overrides before publishing.',
+      metadata: {
+        researchPacketId: researchPacket.id,
+        warningIds: unresolvedWarnings.map((warning) => warning.id),
+      },
+    });
+  }
+
+  return blockers;
+}
+
 function validHttpUrl(value: string | null) {
   if (!value) {
     return true;
@@ -597,7 +672,8 @@ function publishBlockers(
   episode: EpisodeRecord,
   assets: EpisodeAssetRecord[],
   feed: FeedRecord | null,
-  options: { republish: boolean; changelog?: string | null },
+  options: { republish: boolean; changelog?: string | null; requirePublishApproval?: boolean },
+  researchPacket?: ResearchPacketRecord | null,
 ): PublishBlockedReason[] {
   const blockers: PublishBlockedReason[] = [];
   const audioAsset = assets.find((asset) => ['audio-final', 'audio-preview'].includes(asset.type));
@@ -607,12 +683,14 @@ function publishBlockers(
     return [];
   }
 
+  blockers.push(...researchBlockers(episode, researchPacket));
+
   if (episode.status === 'published' && options.republish && !options.changelog) {
     blockers.push({
       code: 'REPUBLISH_CHANGELOG_REQUIRED',
       message: 'Re-publishing an already published episode requires an explicit changelog.',
     });
-  } else if (episode.status !== 'approved-for-publish' && !(episode.status === 'published' && episode.feedGuid)) {
+  } else if (options.requirePublishApproval !== false && episode.status !== 'approved-for-publish' && !(episode.status === 'published' && episode.feedGuid)) {
     blockers.push({
       code: 'EPISODE_NOT_APPROVED_FOR_PUBLISH',
       message: 'Episode must be approved for publish before RSS publishing can run.',
@@ -781,8 +859,16 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
 
       assertEpisodeReadyForPublishApproval(episode);
       const assets = await productionStore.listEpisodeAssets(episode.id);
-      selectAsset(assets, ['audio-final', 'audio-preview'], 'audio');
-      selectAsset(assets, ['cover-art'], 'cover art');
+      const feed = await maybeResolveFeed(productionStore, episode);
+      const researchPacket = await loadEpisodeResearchPacket(rawStore, episode);
+      const blockers = publishBlockers(episode, assets, feed, { republish: false, requirePublishApproval: false }, researchPacket);
+
+      if (blockers.length > 0) {
+        throw new ApiError(409, 'PUBLISH_APPROVAL_BLOCKED', 'Episode cannot be approved for publishing until checklist items are complete.', {
+          blockedReasons: blockers,
+        });
+      }
+
       const approved = await productionStore.approveEpisodeForPublish(episode.id, {
         actor: body.actor,
         reason: body.reason ?? null,
@@ -818,10 +904,11 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
 
       const assets = await productionStore.listEpisodeAssets(episode.id);
       const maybeFeed = await maybeResolveFeed(productionStore, episode, body.feedId);
+      const researchPacket = await loadEpisodeResearchPacket(rawStore, episode);
       const blockers = publishBlockers(episode, assets, maybeFeed, {
         republish: body.republish,
         changelog: body.changelog ?? null,
-      });
+      }, researchPacket);
 
       if (blockers.length > 0) {
         throw new ApiError(409, 'PUBLISH_BLOCKED', 'Episode cannot be published until blocking issues are resolved.', {

--- a/packages/api/src/research/routes.ts
+++ b/packages/api/src/research/routes.ts
@@ -54,6 +54,11 @@ const overrideWarningSchema = z.object({
   path: ['warningId'],
 });
 
+const approveResearchSchema = z.object({
+  actor: z.string().trim().min(1).default('local-user'),
+  reason: z.string().trim().min(1).nullable().optional(),
+});
+
 function sendError(reply: FastifyReply, error: unknown) {
   if (error instanceof ZodError) {
     return reply.code(400).send({
@@ -83,6 +88,7 @@ function requireResearchStore(store: Partial<ResearchStore>): ResearchStore {
     'getResearchPacket',
     'listResearchPackets',
     'overrideResearchWarning',
+    'approveResearchPacket',
   ];
 
   for (const method of required) {
@@ -92,6 +98,19 @@ function requireResearchStore(store: Partial<ResearchStore>): ResearchStore {
   }
 
   return store as ResearchStore;
+}
+
+function readinessStatus(packet: { status: string; content: Record<string, unknown> }) {
+  const readiness = packet.content.readiness;
+  const contentStatus = readiness && typeof readiness === 'object' && !Array.isArray(readiness)
+    ? (readiness as Record<string, unknown>).status
+    : undefined;
+
+  return typeof contentStatus === 'string' ? contentStatus : packet.status;
+}
+
+function unresolvedWarnings(packet: { warnings: ResearchWarning[] }) {
+  return packet.warnings.filter((warning) => !warning.override);
 }
 
 function hasResearchJobStore(store: object): store is Pick<SearchJobStore, 'createJob' | 'updateJob'> {
@@ -501,6 +520,47 @@ export function registerResearchRoutes(app: FastifyInstance, options: ResearchRo
       }
 
       return { ok: true, researchPacket: packet };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.post<{ Params: { id: string } }>('/research-packets/:id/approve', async (request, reply) => {
+    try {
+      const store = requireResearchStore(options.getStore());
+      const body = approveResearchSchema.parse(request.body ?? {});
+      const packet = await store.getResearchPacket(request.params.id);
+
+      if (!packet) {
+        throw new ApiError(404, 'RESEARCH_PACKET_NOT_FOUND', `Research packet not found: ${request.params.id}`);
+      }
+
+      const status = readinessStatus(packet);
+      const unresolved = unresolvedWarnings(packet);
+
+      if (!['ready', 'approved', 'research-ready'].includes(status) || unresolved.length > 0) {
+        throw new ApiError(
+          409,
+          'RESEARCH_APPROVAL_BLOCKED',
+          'Research brief cannot be approved until it is ready and warnings are overridden.',
+        );
+      }
+
+      const approved = await store.approveResearchPacket(packet.id, {
+        actor: body.actor,
+        reason: body.reason ?? null,
+        metadata: {
+          previousStatus: packet.status,
+          readinessStatus: status,
+          warningCount: packet.warnings.length,
+        },
+      });
+
+      if (!approved) {
+        throw new ApiError(404, 'RESEARCH_PACKET_NOT_FOUND', `Research packet not found: ${request.params.id}`);
+      }
+
+      return reply.code(201).send({ ok: true, researchPacket: approved });
     } catch (error) {
       return sendError(reply, error);
     }

--- a/packages/api/src/research/store.ts
+++ b/packages/api/src/research/store.ts
@@ -101,6 +101,12 @@ export interface OverrideResearchWarningInput {
   reason: string;
 }
 
+export interface ApproveResearchPacketInput {
+  actor: string;
+  reason?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
 export interface ResearchPacketListFilter {
   showId?: string;
   showSlug?: string;
@@ -114,4 +120,5 @@ export interface ResearchStore {
   getResearchPacket(id: string): Promise<ResearchPacketRecord | undefined>;
   listResearchPackets(filter?: ResearchPacketListFilter): Promise<ResearchPacketRecord[]>;
   overrideResearchWarning(id: string, input: OverrideResearchWarningInput): Promise<ResearchPacketRecord | undefined>;
+  approveResearchPacket(id: string, input: ApproveResearchPacketInput): Promise<ResearchPacketRecord | undefined>;
 }

--- a/packages/api/src/sources/db-store.ts
+++ b/packages/api/src/sources/db-store.ts
@@ -1087,6 +1087,42 @@ export function createDbSourceStore(connectionString = process.env.DATABASE_URL)
       return row ? mapResearchPacket(row) : undefined;
     },
 
+    async approveResearchPacket(id: string, input) {
+      const current = await this.getResearchPacket(id);
+
+      if (!current) {
+        return undefined;
+      }
+
+      const approvedAt = new Date();
+      await db.insert(approvalEvents).values({
+        researchPacketId: id,
+        action: 'approve',
+        gate: 'research-brief',
+        actor: input.actor,
+        reason: input.reason ?? null,
+        metadata: input.metadata ?? {},
+      });
+
+      const [row] = await db.update(researchPackets)
+        .set({
+          approvedAt,
+          content: {
+            ...current.content,
+            reviewApproval: {
+              actor: input.actor,
+              reason: input.reason ?? null,
+              approvedAt: approvedAt.toISOString(),
+            },
+          },
+          updatedAt: approvedAt,
+        })
+        .where(eq(researchPackets.id, id))
+        .returning();
+
+      return row ? mapResearchPacket(row) : undefined;
+    },
+
     async createScriptWithRevision(input: CreateScriptWithRevisionInput) {
       return db.transaction(async (tx) => {
         const [scriptRow] = await tx.insert(scripts).values({

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -35,6 +35,7 @@ import type {
 } from '../production/store.js';
 import type { ResearchFetch } from '../research/fetch.js';
 import type {
+  ApproveResearchPacketInput,
   CreateResearchPacketInput,
   CreateSourceDocumentInput,
   OverrideResearchWarningInput,
@@ -160,6 +161,15 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
     updatedAt: new Date('2026-01-01T00:00:00Z'),
   }];
   publishEvents: PublishEventRecord[] = [];
+  approvalEvents: Array<{
+    artifactType: string;
+    artifactId: string;
+    action: string;
+    gate: string;
+    actor: string;
+    reason: string | null;
+    createdAt: Date;
+  }> = [];
 
   async listShows() {
     return this.shows;
@@ -435,6 +445,15 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
       },
       updatedAt: new Date('2026-01-08T00:00:00Z'),
     });
+    this.approvalEvents.push({
+      artifactType: 'episode',
+      artifactId: id,
+      action: 'approve',
+      gate: 'episode-publish',
+      actor: input.actor,
+      reason: input.reason ?? null,
+      createdAt: new Date('2026-01-08T00:00:00Z'),
+    });
     return episode;
   }
 
@@ -614,7 +633,45 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
       return undefined;
     }
 
+    this.approvalEvents.push({
+      artifactType: 'research-packet',
+      artifactId: id,
+      action: 'override',
+      gate: 'research-warning',
+      actor: input.actor,
+      reason: input.reason,
+      createdAt: new Date('2026-01-03T00:00:00Z'),
+    });
     packet.updatedAt = new Date('2026-01-03T00:00:00Z');
+    return packet;
+  }
+
+  async approveResearchPacket(id: string, input: ApproveResearchPacketInput) {
+    const packet = await this.getResearchPacket(id);
+
+    if (!packet) {
+      return undefined;
+    }
+
+    packet.approvedAt = new Date('2026-01-03T12:00:00Z');
+    packet.content = {
+      ...packet.content,
+      reviewApproval: {
+        actor: input.actor,
+        reason: input.reason ?? null,
+        approvedAt: packet.approvedAt.toISOString(),
+      },
+    };
+    packet.updatedAt = packet.approvedAt;
+    this.approvalEvents.push({
+      artifactType: 'research-packet',
+      artifactId: id,
+      action: 'approve',
+      gate: 'research-brief',
+      actor: input.actor,
+      reason: input.reason ?? null,
+      createdAt: packet.approvedAt,
+    });
     return packet;
   }
 
@@ -715,6 +772,15 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
         approvalReason: input.reason,
       },
       updatedAt: new Date('2026-01-06T00:00:00Z'),
+    });
+    this.approvalEvents.push({
+      artifactType: 'script-revision',
+      artifactId: revisionId,
+      action: 'approve',
+      gate: 'script-audio',
+      actor: input.actor,
+      reason: input.reason,
+      createdAt: new Date('2026-01-06T00:00:00Z'),
     });
     return script;
   }
@@ -1047,6 +1113,7 @@ describe('source profile routes', () => {
     store.episodeAssets = [];
     store.feeds = new FakeSourceStore().feeds;
     store.publishEvents = [];
+    store.approvalEvents = [];
     requestedUrls = [];
     requestedRssUrls = [];
     requestedResearchUrls = [];
@@ -1071,6 +1138,10 @@ describe('source profile routes', () => {
       citations: [],
       warnings: [],
       content: { summary: `A packet summary for ${title}.` },
+    });
+    await store.approveResearchPacket(packet.id, {
+      actor: 'research-editor@example.com',
+      reason: 'Research reviewed for publish testing.',
     });
     const scriptResponse = await app.inject({
       method: 'POST',
@@ -1448,6 +1519,76 @@ describe('source profile routes', () => {
     assert.equal(overrideResponse.statusCode, 200);
     assert.equal(overriddenWarning.override.actor, 'editor@example.com');
     assert.match(overriddenWarning.override.reason, /two independent sources/);
+  });
+
+  it('records durable research approval only after readiness and warnings are clear', async () => {
+    const blockedPacket = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Blocked Research Review',
+      status: 'needs_more_sources',
+      sourceDocumentIds: [],
+      claims: [],
+      citations: [],
+      warnings: [{
+        id: 'warning-1',
+        code: 'INSUFFICIENT_INDEPENDENT_SOURCES',
+        message: 'Needs another independent source.',
+        severity: 'warning',
+      }],
+      content: { readiness: { status: 'needs_more_sources' } },
+    });
+    const blockedResponse = await app.inject({
+      method: 'POST',
+      url: `/research-packets/${blockedPacket.id}/approve`,
+      payload: {
+        actor: 'editor@example.com',
+        reason: 'Attempted approval without enough sourcing.',
+      },
+    });
+
+    assert.equal(blockedResponse.statusCode, 409);
+    assert.equal(blockedResponse.json().code, 'RESEARCH_APPROVAL_BLOCKED');
+
+    const readyPacket = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Ready Research Review',
+      status: 'ready',
+      sourceDocumentIds: ['source-document-1', 'source-document-2'],
+      claims: [{
+        id: 'claim-1',
+        text: 'A verified claim is supported.',
+        sourceDocumentIds: ['source-document-1'],
+        citationUrls: ['https://example.com/source'],
+      }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/source',
+        title: 'Source',
+        fetchedAt: '2026-01-03T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { readiness: { status: 'ready', independentSourceCount: 2 } },
+    });
+    const approvalResponse = await app.inject({
+      method: 'POST',
+      url: `/research-packets/${readyPacket.id}/approve`,
+      payload: {
+        actor: 'editor@example.com',
+        reason: 'Sources and citations reviewed.',
+      },
+    });
+    const approved = approvalResponse.json().researchPacket as ResearchPacketRecord;
+
+    assert.equal(approvalResponse.statusCode, 201);
+    assert.ok(approved.approvedAt);
+    assert.equal((approved.content.reviewApproval as { actor: string }).actor, 'editor@example.com');
+    assert.deepEqual(
+      store.approvalEvents.map((event) => `${event.gate}:${event.action}`),
+      ['research-brief:approve'],
+    );
   });
 
   it('builds a research packet from multiple candidates with model warnings and readiness metadata', async () => {
@@ -2022,6 +2163,59 @@ describe('source profile routes', () => {
     assert.deepEqual(body.blockedReasons.map((reason: { code: string }) => reason.code), ['EPISODE_NOT_APPROVED_FOR_PUBLISH']);
     assert.equal(store.jobs.some((job) => job.type === 'publish.rss'), false);
     assert.equal(uploadedPublishAssets.length, 0);
+  });
+
+  it('blocks publish approval when the research brief has no recorded approval event', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Unreviewed Research Publish Story',
+      status: 'ready',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{ id: 'claim-1', text: 'A sourced claim exists.', sourceDocumentIds: ['source-document-1'], citationUrls: ['https://example.com/research'] }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/research',
+        title: 'Research Source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary.', readiness: { status: 'ready' } },
+    });
+    const scriptResponse = await app.inject({ method: 'POST', url: `/research-packets/${packet.id}/script` });
+    const initial = scriptResponse.json();
+
+    await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/approve-for-audio`,
+      payload: { actor: 'producer@example.com' },
+    });
+    await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/production/audio-preview`,
+      payload: { actor: 'producer@example.com' },
+    });
+    const artResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/production/cover-art`,
+      payload: { actor: 'producer@example.com' },
+    });
+    const episode = artResponse.json().episode as EpisodeRecord;
+    const approvalResponse = await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/approve-for-publish`,
+      payload: { actor: 'editor@example.com' },
+    });
+    const body = approvalResponse.json();
+
+    assert.equal(approvalResponse.statusCode, 409);
+    assert.equal(body.code, 'PUBLISH_APPROVAL_BLOCKED');
+    assert.equal(
+      body.blockedReasons.some((reason: { code: string }) => reason.code === 'RESEARCH_BRIEF_NOT_APPROVED'),
+      true,
+    );
+    assert.equal(store.approvalEvents.some((event) => event.gate === 'episode-publish'), false);
   });
 
   it('uses a provided cover prompt without invoking the prompt writer', async () => {


### PR DESCRIPTION
## Summary
- Adds Review Gates UI at `/ui` for research brief, script, production assets, and publishing readiness.
- Adds durable research approval support via `POST /research-packets/:id/approve`.
- Hardens publish approval/RSS publish blockers so publish cannot bypass required research/script/asset/feed approvals.
- Updates README and HANDOFF.

## Approval endpoints/events
- Added: `POST /research-packets/:id/approve`
  - Writes `approval_events` gate `research-brief`.
- Existing used:
  - `POST /research-packets/:id/override-warning`
  - `POST /scripts/:id/revisions/:revisionId/approve-for-audio`
  - `POST /episodes/:id/approve-for-publish`
  - `POST /episodes/:id/publish/rss`

## Publish checklist rules
- Research brief ready, approved, and warnings overridden.
- Script revision approved for audio.
- Valid audio asset exists.
- Cover art asset exists.
- Feed metadata configured.
- RSS/public target configured.
- No blocking research/production warnings.
- Episode has explicit publish approval before RSS publish.

## Known backend gaps
- Cover art is still always required; there is no configurable “cover not required” policy yet.
- Approval events are written durably, but there is no dedicated approval-event timeline/read endpoint yet.

## Verification
- `node --check packages/api/public/ui.js` passed in Codex run.
- `npm run check` passed in Codex run: root review tests, API TypeScript + 69 node tests, DB TypeScript.

Closes #24.