### PR TITLE
Make guided workflow primary UI

### DIFF
--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -51,7 +51,7 @@
           </div>
           <div id="workflowContext" class="workflow-context" aria-live="polite"></div>
           <div id="pipelineStages" class="pipeline-grid"></div>
-          <details class="debug-details pipeline-debug" hidden>
+          <details class="debug-details pipeline-debug">
             <summary>Technical IDs</summary>
             <pre id="pipelineDebug"></pre>
           </details>

--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -41,17 +41,18 @@
       </aside>
 
       <section class="workspace">
-        <section class="panel pipeline-panel" aria-labelledby="pipelineTitle">
+        <section id="workflowPanel" class="panel pipeline-panel" aria-labelledby="pipelineTitle">
           <div class="panel-heading">
             <div>
-              <h2 id="pipelineTitle">Guided Episode Pipeline</h2>
+              <h2 id="pipelineTitle">Editorial Production Workflow</h2>
               <p id="pipelineMeta">Choose a show to start an evidence-first episode workflow.</p>
-              <p class="help">Work from story sources to candidate stories, research briefs, script drafts, integrity review, audio/cover preview, review decisions, and RSS publishing.</p>
+              <p class="help">Follow the 8-stage journey from show selection through sourced evidence, script, integrity review, production assets, approval, and publishing.</p>
             </div>
           </div>
+          <div id="workflowContext" class="workflow-context" aria-live="polite"></div>
           <div id="pipelineStages" class="pipeline-grid"></div>
-          <details class="debug-details pipeline-debug">
-            <summary>Selected IDs and technical details</summary>
+          <details class="debug-details pipeline-debug" hidden>
+            <summary>Technical IDs</summary>
             <pre id="pipelineDebug"></pre>
           </details>
         </section>
@@ -241,7 +242,7 @@
           </div>
         </form>
 
-        <section class="panel">
+        <section id="manualStoryPanel" class="panel">
           <div class="panel-heading">
             <div>
               <h2>Add Manual Story</h2>
@@ -271,7 +272,7 @@
           </form>
         </section>
 
-        <section class="panel">
+        <section id="modelRolesPanel" class="panel">
           <div class="panel-heading">
             <div>
               <h2>AI Role Settings</h2>
@@ -282,7 +283,7 @@
           <div id="modelProfileList" class="model-grid"></div>
         </section>
 
-        <section class="panel">
+        <section id="candidatePanel" class="panel">
           <div class="panel-heading">
             <div>
               <h2>Candidate Stories</h2>
@@ -324,7 +325,7 @@
           <div id="candidateList" class="record-list"></div>
         </section>
 
-        <section class="panel">
+        <section id="researchPanel" class="panel">
           <div class="panel-heading">
             <div>
               <h2>Research Briefs</h2>
@@ -335,7 +336,7 @@
           <div id="researchBriefList" class="record-list"></div>
         </section>
 
-        <section class="panel">
+        <section id="schedulerPanel" class="panel">
           <div class="panel-heading">
             <div>
               <h2>Scheduled Pipelines</h2>
@@ -364,7 +365,7 @@
           </div>
         </section>
 
-        <section class="panel">
+        <section id="episodePanel" class="panel">
           <div class="panel-heading">
             <div>
               <h2>Episodes</h2>
@@ -375,7 +376,7 @@
           <div id="episodeList" class="record-list"></div>
         </section>
 
-        <section class="panel review-panel" aria-labelledby="reviewTitle">
+        <section id="reviewPanel" class="panel review-panel" aria-labelledby="reviewTitle">
           <div class="panel-heading">
             <div>
               <h2 id="reviewTitle">Review Gates</h2>
@@ -406,7 +407,7 @@
           <div id="queryList" class="query-list"></div>
         </section>
 
-        <section class="panel">
+        <section id="scriptPanel" class="panel">
           <div class="panel-heading">
             <div>
               <h2>Scripts</h2>

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -160,7 +160,7 @@ button:disabled {
   min-width: 0;
 }
 
-.pipeline-panel {
+.panel.pipeline-panel {
   border-color: #b8c7d9;
   box-shadow: 0 10px 30px rgba(31, 91, 149, 0.08);
   padding: 1.15rem;

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -162,12 +162,45 @@ button:disabled {
 
 .pipeline-panel {
   border-color: #b8c7d9;
+  box-shadow: 0 10px 30px rgba(31, 91, 149, 0.08);
+  padding: 1.15rem;
+}
+
+.workflow-context {
+  background: #f8fafc;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0 0 1rem;
+  padding: 0.85rem;
+}
+
+.workflow-context-item {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.workflow-context-item span {
+  color: #687486;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.workflow-context-item strong {
+  color: #20242c;
+  font-size: 0.95rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .pipeline-grid {
   display: grid;
   gap: 0.75rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
 }
 
 .pipeline-card {
@@ -310,10 +343,17 @@ button:disabled {
 
 .pipeline-card button {
   justify-self: start;
+  min-height: 2.4rem;
 }
 
 .pipeline-debug {
   margin-top: 0.85rem;
+}
+
+.panel-focus {
+  outline: 3px solid rgba(36, 104, 168, 0.28);
+  outline-offset: 3px;
+  transition: outline-color 0.2s ease;
 }
 
 .panel {
@@ -1060,6 +1100,7 @@ textarea {
   .layout,
   .grid,
   .grid.two,
+  .workflow-context,
   .pipeline-grid,
   .model-grid,
   .cluster-grid,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1411,9 +1411,9 @@ function buildPipelineStages() {
       action: !state.selectedScript || !state.selectedRevision
         ? () => scrollToPanel('scriptPanel')
         : integrity.blocking ? runSelectedIntegrityReview : scriptApproved ? () => scrollToPanel('reviewPanel') : approveSelectedScript,
-      disabled: integrityRunning || approvalsRunning || (!state.selectedScript || !state.selectedRevision),
+      disabled: integrityRunning || approvalsRunning,
       active: Boolean(state.selectedRevision && !integrity.blocking),
-      targetId: 'reviewPanel',
+      targetId: !state.selectedScript || !state.selectedRevision ? 'scriptPanel' : 'reviewPanel',
     },
     {
       number: 7,
@@ -1427,7 +1427,7 @@ function buildPipelineStages() {
       action: audioAsset && coverAsset ? refreshProductionUntilSettled : createMissingProductionAssets,
       disabled: productionActionRunning || (!scriptReadyForProduction && !(audioAsset && coverAsset)),
       active: Boolean(audioAsset || coverAsset),
-      targetId: 'scriptPanel',
+      targetId: 'productionPanel',
       jobTypes: ['audio.preview', 'art.generate'],
     },
     {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1363,7 +1363,7 @@ function buildPipelineStages() {
     {
       number: 2,
       title: 'Find story candidates',
-      status: discoverRunning ? 'running' : !profile ? 'blocked' : state.storyCandidates.length > 0 ? 'done' : 'ready',
+      status: discoverRunning ? 'running' : !profile ? 'blocked' : state.storyCandidates.length > 0 ? 'done' : (profileSupportsDiscovery || profile.type === 'manual') ? 'ready' : 'blocked',
       artifact: state.storyCandidates.length > 0
         ? `${state.storyCandidates.length} candidate stor${state.storyCandidates.length === 1 ? 'y' : 'ies'} loaded. Latest: ${state.storyCandidates[0].title}`
         : 'No candidate stories loaded yet.',
@@ -1374,9 +1374,9 @@ function buildPipelineStages() {
           : profileSupportsDiscovery
             ? `Run ${profile.type === 'rss' ? 'RSS import' : 'source search'} for the selected story source.`
             : 'This source type is not wired for browser-triggered discovery yet.',
-      actionLabel: !profile ? 'Choose Story Source' : profile.type === 'rss' ? 'Import RSS Items' : profile.type === 'brave' ? 'Run Source Search' : 'Add Manual Story',
-      action: !profile ? undefined : profileSupportsDiscovery ? runSelectedProfileDiscovery : focusManualStoryForm,
-      disabled: discoverRunning || !profile || (!profileSupportsDiscovery && profile.type !== 'manual'),
+      actionLabel: !profile ? 'Choose Story Source' : profile.type === 'rss' ? 'Import RSS Items' : profile.type === 'brave' ? 'Run Source Search' : profile.type === 'manual' ? 'Add Manual Story' : 'Open Source Settings',
+      action: !profile ? () => scrollToPanel('settingsPanel') : profileSupportsDiscovery ? runSelectedProfileDiscovery : profile.type === 'manual' ? focusManualStoryForm : () => scrollToPanel('settingsPanel'),
+      disabled: discoverRunning,
       active: state.storyCandidates.length > 0,
       targetId: profile?.type === 'manual' ? 'manualStoryPanel' : 'settingsPanel',
       jobTypes: ['source.search', 'source.ingest'],

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1127,21 +1127,28 @@ function scrollToPanel(id) {
   }
 
   const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-  const hadTabIndex = target.hasAttribute('tabindex');
-  const previousTabIndex = target.getAttribute('tabindex');
+  if (!target.dataset.originalTabindex) {
+    target.dataset.originalTabindex = target.hasAttribute('tabindex') ? target.getAttribute('tabindex') || '' : '__none__';
+  }
+  if (target.dataset.panelFocusTimeout) {
+    window.clearTimeout(Number(target.dataset.panelFocusTimeout));
+  }
 
   target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
   target.setAttribute('tabindex', '-1');
   target.focus({ preventScroll: true });
   target.classList.add('panel-focus');
-  window.setTimeout(() => {
+  target.dataset.panelFocusTimeout = String(window.setTimeout(() => {
     target.classList.remove('panel-focus');
-    if (hadTabIndex && previousTabIndex !== null) {
-      target.setAttribute('tabindex', previousTabIndex);
+    const originalTabindex = target.dataset.originalTabindex;
+    if (originalTabindex && originalTabindex !== '__none__') {
+      target.setAttribute('tabindex', originalTabindex);
     } else {
       target.removeAttribute('tabindex');
     }
-  }, 1200);
+    delete target.dataset.originalTabindex;
+    delete target.dataset.panelFocusTimeout;
+  }, 1200));
 }
 
 function stageCard(stage) {
@@ -1349,7 +1356,7 @@ function buildPipelineStages() {
     {
       number: 2,
       title: 'Find story candidates',
-      status: discoverRunning ? 'running' : !profile ? 'blocked' : state.storyCandidates.length > 0 ? 'done' : profileSupportsDiscovery ? 'ready' : 'ready',
+      status: discoverRunning ? 'running' : !profile ? 'blocked' : state.storyCandidates.length > 0 ? 'done' : 'ready',
       artifact: state.storyCandidates.length > 0
         ? `${state.storyCandidates.length} candidate stor${state.storyCandidates.length === 1 ? 'y' : 'ies'} loaded. Latest: ${state.storyCandidates[0].title}`
         : 'No candidate stories loaded yet.',

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -77,6 +77,7 @@ const els = {
   settingsPublishing: document.querySelector('#settingsPublishing'),
   settingsSchedules: document.querySelector('#settingsSchedules'),
   pipelineMeta: document.querySelector('#pipelineMeta'),
+  workflowContext: document.querySelector('#workflowContext'),
   pipelineStages: document.querySelector('#pipelineStages'),
   pipelineDebug: document.querySelector('#pipelineDebug'),
   profileList: document.querySelector('#profileList'),
@@ -1070,6 +1071,7 @@ function taskLabel(type) {
     'source.ingest': 'RSS import',
     'research.packet': 'Research brief',
     'script.generate': 'Script draft',
+    'script.integrity_review': 'Integrity review',
     'audio.preview': 'Preview audio',
     'art.generate': 'Cover art',
     'publish.rss': 'RSS publishing',
@@ -1112,9 +1114,24 @@ function latestStageJob(types) {
   return job ? `${taskLabel(job.type)} ${job.status}, ${job.progress}%` : 'No recorded task run yet.';
 }
 
+function scrollToPanel(id) {
+  const target = document.getElementById(id);
+
+  if (!target) {
+    return;
+  }
+
+  target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  target.classList.add('panel-focus');
+  window.setTimeout(() => {
+    target.classList.remove('panel-focus');
+  }, 1200);
+}
+
 function stageCard(stage) {
   const card = document.createElement('article');
   card.className = `pipeline-card ${statusClass(stage.status)}${stage.active ? ' active' : ''}`;
+  card.dataset.stage = String(stage.number);
 
   const top = document.createElement('div');
   top.className = 'pipeline-top';
@@ -1158,6 +1175,15 @@ function stageCard(stage) {
   }
 
   card.append(top, artifacts, next, button);
+
+  if (stage.targetId) {
+    const panelButton = document.createElement('button');
+    panelButton.type = 'button';
+    panelButton.className = 'secondary';
+    panelButton.textContent = 'Open Stage Panel';
+    panelButton.addEventListener('click', () => scrollToPanel(stage.targetId));
+    card.append(panelButton);
+  }
 
   if (stage.jobTypes?.length) {
     const jobButton = document.createElement('button');
@@ -1212,6 +1238,44 @@ function latestProductionText() {
   return `${episode.title} (${episode.status}) | audio ${audio ? 'ready' : 'missing'} | cover ${art ? 'ready' : 'missing'}`;
 }
 
+function workflowStoryContext() {
+  const candidates = selectedCandidates();
+
+  if (candidates.length > 0) {
+    return candidates.length === 1 ? candidates[0].title : `${candidates.length} candidate stories selected`;
+  }
+
+  const packet = selectedResearchPacket();
+  if (packet) {
+    return packet.title;
+  }
+
+  if (state.storyCandidates.length > 0) {
+    return `${state.storyCandidates.length} candidate stories loaded`;
+  }
+
+  return 'No story selected yet';
+}
+
+function workflowRevisionContext() {
+  const episode = selectedEpisode();
+
+  if (episode) {
+    return `${episode.title} (${episode.status})`;
+  }
+
+  if (state.selectedScript && state.selectedRevision) {
+    return `${state.selectedScript.title} | revision ${state.selectedRevision.version}`;
+  }
+
+  const packet = selectedResearchPacket();
+  if (packet) {
+    return `${packet.title} | research brief`;
+  }
+
+  return 'No active run or revision';
+}
+
 function buildPipelineStages() {
   const show = selectedShow();
   const profile = selectedProfile();
@@ -1231,6 +1295,7 @@ function buildPipelineStages() {
   const discoverRunning = isActionRunning('discover');
   const researchRunning = isActionRunning('research');
   const scriptRunning = isActionRunning('script');
+  const integrityRunning = isActionRunning('integrity');
   const approvalsRunning = isActionRunning('approval');
   const publishRunning = isActionRunning('publish');
   const productionActionRunning = productionRunning || isActionRunning('production');
@@ -1245,7 +1310,7 @@ function buildPipelineStages() {
   return [
     {
       number: 1,
-      title: 'Choose show and story source',
+      title: 'Choose show',
       status: show && profile ? 'done' : show ? 'blocked' : 'not started',
       artifact: show ? `${show.title}${profile ? ` | ${profile.name}` : ''}` : 'No show selected.',
       next: show
@@ -1255,13 +1320,15 @@ function buildPipelineStages() {
       action: () => {
         state.showSetupOpen = true;
         render();
+        scrollToPanel('showSetupForm');
       },
       disabled: false,
       active: Boolean(show && profile),
+      targetId: show ? 'settingsPanel' : 'showSetupForm',
     },
     {
       number: 2,
-      title: 'Find or ingest candidate stories',
+      title: 'Find story candidates',
       status: discoverRunning ? 'running' : !profile ? 'blocked' : state.storyCandidates.length > 0 ? 'done' : profileSupportsDiscovery ? 'ready' : 'ready',
       artifact: state.storyCandidates.length > 0
         ? `${state.storyCandidates.length} candidate stor${state.storyCandidates.length === 1 ? 'y' : 'ies'} loaded. Latest: ${state.storyCandidates[0].title}`
@@ -1277,11 +1344,12 @@ function buildPipelineStages() {
       action: !profile ? undefined : profileSupportsDiscovery ? runSelectedProfileDiscovery : focusManualStoryForm,
       disabled: discoverRunning || !profile || (!profileSupportsDiscovery && profile.type !== 'manual'),
       active: state.storyCandidates.length > 0,
+      targetId: profile?.type === 'manual' ? 'manualStoryPanel' : 'settingsPanel',
       jobTypes: ['source.search', 'source.ingest'],
     },
     {
       number: 3,
-      title: 'Select or cluster candidate stories',
+      title: 'Pick / cluster story',
       status: state.storyCandidates.length === 0 ? 'blocked' : candidates.length > 0 ? 'done' : 'ready',
       artifact: latestCandidateText(),
       next: candidates.length > 0
@@ -1293,10 +1361,11 @@ function buildPipelineStages() {
       action: candidates.length > 0 ? clearCandidateSelection : selectTopCandidate,
       disabled: state.storyCandidates.length === 0,
       active: candidates.length > 0,
+      targetId: 'candidatePanel',
     },
     {
       number: 4,
-      title: 'Build research brief',
+      title: 'Build evidence brief',
       status: researchRunning ? 'running' : packetBlocked ? 'blocked' : packet && packetWarningCount > 0 ? 'needs review' : packet ? 'done' : state.researchPackets.length > 0 || candidates.length > 0 ? 'ready' : 'blocked',
       artifact: latestResearchText(latestPacket),
       next: packet
@@ -1306,62 +1375,77 @@ function buildPipelineStages() {
       action: packet ? () => selectResearchPacket(packet) : state.researchPackets.length > 0 ? () => selectResearchPacket(state.researchPackets[0]) : buildResearchBriefFromSelected,
       disabled: researchRunning || (!packet && state.researchPackets.length === 0 && !candidateAnalysis.canLaunch),
       active: Boolean(packet),
+      targetId: 'researchPanel',
       jobTypes: ['research.packet'],
     },
     {
       number: 5,
-      title: 'Generate or revise script draft',
-      status: scriptRunning ? 'running' : state.selectedScript && scriptReadyForProduction ? 'done' : state.selectedScript ? 'needs review' : packet && !packetBlocked ? 'ready' : 'blocked',
+      title: 'Generate script',
+      status: scriptRunning ? 'running' : state.selectedScript ? 'done' : packet && !packetBlocked ? 'ready' : 'blocked',
       artifact: latestScriptText(),
       next: state.selectedScript
-        ? (scriptReadyForProduction ? 'Approved script draft passed integrity review and can move into production.' : integrity.blocking ? 'Run the integrity reviewer or record an override before production.' : 'Review and approve the selected script revision before audio.')
+        ? 'Review the draft and continue to integrity review before production.'
         : packet && !packetBlocked ? 'Generate an episode draft from the selected research brief.' : 'Select a ready research brief first.',
       actionLabel: state.selectedScript ? 'Review Draft' : 'Generate Script Draft',
       action: state.selectedScript ? focusScriptEditor : generateScriptFromSelectedResearch,
       disabled: scriptRunning || (!state.selectedScript && (!packet || packetBlocked)),
       active: Boolean(state.selectedScript),
+      targetId: 'scriptPanel',
       jobTypes: ['script.generate'],
     },
     {
       number: 6,
-      title: 'Generate audio and cover preview',
+      title: 'Integrity review',
+      status: integrityRunning || approvalsRunning ? 'running' : scriptReadyForProduction ? 'done' : state.selectedScript && state.selectedRevision ? 'ready' : 'blocked',
+      artifact: state.selectedRevision
+        ? `Integrity review ${integrityReviewLabel(integrity.status)}${scriptApproved ? ' | script approved for audio' : ''}`
+        : 'No script revision selected yet.',
+      next: !state.selectedScript || !state.selectedRevision
+        ? 'Generate or select a script draft first.'
+        : integrity.blocking
+          ? 'Run the integrity reviewer or record an explicit override before production.'
+          : scriptApproved ? 'Integrity and script approval gates are complete.' : 'Approve the reviewed script revision for audio.',
+      actionLabel: !state.selectedScript || !state.selectedRevision
+        ? 'Open Scripts'
+        : integrity.blocking ? 'Run Integrity Review' : scriptApproved ? 'Open Review Gates' : 'Approve Script for Audio',
+      action: !state.selectedScript || !state.selectedRevision
+        ? () => scrollToPanel('scriptPanel')
+        : integrity.blocking ? runSelectedIntegrityReview : scriptApproved ? () => scrollToPanel('reviewPanel') : approveSelectedScript,
+      disabled: integrityRunning || approvalsRunning || (!state.selectedScript || !state.selectedRevision),
+      active: Boolean(state.selectedRevision && !integrity.blocking),
+      targetId: 'reviewPanel',
+    },
+    {
+      number: 7,
+      title: 'Produce audio / cover',
       status: productionActionRunning ? 'running' : audioAsset && coverAsset ? 'done' : scriptReadyForProduction ? 'ready' : 'blocked',
       artifact: latestProductionText(),
       next: audioAsset && coverAsset
-        ? 'Preview audio and cover art are ready for publish review.'
-        : scriptReadyForProduction ? 'Create the missing preview audio and cover art assets.' : integrity.blocking ? 'Complete the integrity review gate before production.' : 'Approve a script revision for audio first.',
+        ? 'Preview audio and cover art are ready for approval and publishing review.'
+        : scriptReadyForProduction ? 'Create the missing preview audio and cover art assets.' : integrity.blocking ? 'Complete the integrity review gate before production.' : 'Approve the reviewed script revision for audio first.',
       actionLabel: audioAsset && coverAsset ? 'Refresh Assets' : 'Create Missing Assets',
       action: audioAsset && coverAsset ? refreshProductionUntilSettled : createMissingProductionAssets,
       disabled: productionActionRunning || (!scriptReadyForProduction && !(audioAsset && coverAsset)),
       active: Boolean(audioAsset || coverAsset),
+      targetId: 'scriptPanel',
       jobTypes: ['audio.preview', 'art.generate'],
     },
     {
-      number: 7,
-      title: 'Review approvals',
-      status: approvalsRunning ? 'running' : episode?.status === 'approved-for-publish' || episode?.status === 'published' ? 'done' : episode?.status === 'audio-ready' && publishPreApprovalReady ? 'ready' : state.selectedScript && !scriptReadyForProduction ? 'needs review' : 'blocked',
-      artifact: episode ? `${episode.title} (${episode.status})` : latestScriptText(),
-      next: episode?.status === 'audio-ready'
-        ? (publishPreApprovalReady ? 'Approve the episode for publishing after reviewing assets.' : firstChecklistBlocker || 'Complete the publish checklist before approval.')
-        : state.selectedScript && !scriptReadyForProduction ? 'Finish script approval and integrity review before production can run.' : 'Finish script approval and production assets first.',
-      actionLabel: episode?.status === 'audio-ready' ? 'Approve for Publishing' : 'Approve Script for Audio',
-      action: episode?.status === 'audio-ready' ? approveEpisodeForPublishing : approveSelectedScript,
-      disabled: approvalsRunning || !(episode?.status === 'audio-ready' ? publishPreApprovalReady : (state.selectedScript && state.selectedRevision && !scriptApproved)),
-      active: Boolean(episode?.status === 'approved-for-publish' || episode?.status === 'published'),
-    },
-    {
       number: 8,
-      title: 'Publish',
-      status: publishRunning ? 'running' : episode?.status === 'published' ? 'done' : episode?.status === 'approved-for-publish' && publishChecklistReady ? 'ready' : 'blocked',
+      title: 'Approve and publish',
+      status: publishRunning || approvalsRunning ? 'running' : episode?.status === 'published' ? 'done' : episode?.status === 'approved-for-publish' && publishChecklistReady ? 'ready' : episode?.status === 'audio-ready' && publishPreApprovalReady ? 'ready' : 'blocked',
       artifact: episode?.feedGuid || episode?.metadata?.publish?.rssUrl || 'No publishing record yet.',
       next: episode?.status === 'published'
         ? 'RSS publishing has a recorded feed GUID or publish result.'
-        : episode?.status === 'approved-for-publish' ? (publishChecklistReady ? 'Publish to the configured RSS feed.' : firstChecklistBlocker || 'Complete the publish checklist first.') : 'Approval for publishing is required before RSS output.',
-      actionLabel: episode?.status === 'published' ? 'Already Published' : 'Publish to RSS',
-      action: publishSelectedEpisode,
-      disabled: publishRunning || episode?.status !== 'approved-for-publish' || !publishChecklistReady,
+        : episode?.status === 'approved-for-publish' ? (publishChecklistReady ? 'Publish to the configured RSS feed.' : firstChecklistBlocker || 'Complete the publish checklist first.')
+          : episode?.status === 'audio-ready' ? (publishPreApprovalReady ? 'Approve the episode for publishing after reviewing assets.' : firstChecklistBlocker || 'Complete the publish checklist before approval.')
+            : 'Production assets and explicit publish approval are required before RSS output.',
+      actionLabel: episode?.status === 'published' ? 'Already Published' : episode?.status === 'approved-for-publish' ? 'Publish to RSS' : 'Approve for Publishing',
+      action: episode?.status === 'approved-for-publish' ? publishSelectedEpisode : approveEpisodeForPublishing,
+      disabled: publishRunning || approvalsRunning || !(episode?.status === 'approved-for-publish' ? publishChecklistReady : (episode?.status === 'audio-ready' && publishPreApprovalReady)),
       active: episode?.status === 'published',
       primary: true,
+      targetId: 'reviewPanel',
       jobTypes: ['publish.rss'],
     },
   ];
@@ -1373,6 +1457,26 @@ function renderPipeline() {
   els.pipelineMeta.textContent = show
     ? `${show.title}${profile ? ` | Story source: ${profile.name}` : ' | Choose a story source/search recipe'}`
     : 'Choose a show to start an evidence-first episode workflow.';
+  els.workflowContext.innerHTML = '';
+
+  const contextItems = [
+    ['Selected show', show ? show.title : 'No show selected'],
+    ['Story source', profile ? profile.name : 'Choose a source/search recipe'],
+    ['Episode/story', workflowStoryContext()],
+    ['Active run/revision', workflowRevisionContext()],
+  ];
+
+  for (const [label, value] of contextItems) {
+    const item = document.createElement('div');
+    item.className = 'workflow-context-item';
+    const itemLabel = document.createElement('span');
+    itemLabel.textContent = label;
+    const itemValue = document.createElement('strong');
+    itemValue.textContent = value;
+    item.append(itemLabel, itemValue);
+    els.workflowContext.append(item);
+  }
+
   els.pipelineStages.innerHTML = '';
 
   for (const stage of buildPipelineStages()) {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1127,11 +1127,17 @@ function scrollToPanel(id) {
   }
 
   const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-  if (!target.dataset.originalTabindex) {
-    target.dataset.originalTabindex = target.hasAttribute('tabindex') ? target.getAttribute('tabindex') || '' : '__none__';
-  }
   if (target.dataset.panelFocusTimeout) {
     window.clearTimeout(Number(target.dataset.panelFocusTimeout));
+  }
+  if (!target.dataset.panelFocusTracking) {
+    target.dataset.panelFocusTracking = 'true';
+    target.dataset.panelFocusHadTabindex = target.hasAttribute('tabindex') ? 'true' : 'false';
+    if (target.hasAttribute('tabindex')) {
+      target.dataset.panelFocusPreviousTabindex = target.getAttribute('tabindex') || '';
+    } else {
+      delete target.dataset.panelFocusPreviousTabindex;
+    }
   }
 
   target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
@@ -1140,14 +1146,15 @@ function scrollToPanel(id) {
   target.classList.add('panel-focus');
   target.dataset.panelFocusTimeout = String(window.setTimeout(() => {
     target.classList.remove('panel-focus');
-    const originalTabindex = target.dataset.originalTabindex;
-    if (originalTabindex && originalTabindex !== '__none__') {
-      target.setAttribute('tabindex', originalTabindex);
+    if (target.dataset.panelFocusHadTabindex === 'true') {
+      target.setAttribute('tabindex', target.dataset.panelFocusPreviousTabindex || '');
     } else {
       target.removeAttribute('tabindex');
     }
-    delete target.dataset.originalTabindex;
     delete target.dataset.panelFocusTimeout;
+    delete target.dataset.panelFocusTracking;
+    delete target.dataset.panelFocusHadTabindex;
+    delete target.dataset.panelFocusPreviousTabindex;
   }, 1200));
 }
 

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1114,17 +1114,33 @@ function latestStageJob(types) {
   return job ? `${taskLabel(job.type)} ${job.status}, ${job.progress}%` : 'No recorded task run yet.';
 }
 
+function panelIsAvailable(id) {
+  const target = document.getElementById(id);
+  return Boolean(target && !target.closest('[hidden]'));
+}
+
 function scrollToPanel(id) {
   const target = document.getElementById(id);
 
-  if (!target) {
+  if (!target || target.closest('[hidden]')) {
     return;
   }
 
-  target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+  const hadTabIndex = target.hasAttribute('tabindex');
+  const previousTabIndex = target.getAttribute('tabindex');
+
+  target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+  target.setAttribute('tabindex', '-1');
+  target.focus({ preventScroll: true });
   target.classList.add('panel-focus');
   window.setTimeout(() => {
     target.classList.remove('panel-focus');
+    if (hadTabIndex && previousTabIndex !== null) {
+      target.setAttribute('tabindex', previousTabIndex);
+    } else {
+      target.removeAttribute('tabindex');
+    }
   }, 1200);
 }
 
@@ -1176,7 +1192,7 @@ function stageCard(stage) {
 
   card.append(top, artifacts, next, button);
 
-  if (stage.targetId) {
+  if (stage.targetId && panelIsAvailable(stage.targetId)) {
     const panelButton = document.createElement('button');
     panelButton.type = 'button';
     panelButton.className = 'secondary';
@@ -1316,8 +1332,12 @@ function buildPipelineStages() {
       next: show
         ? (profile ? 'Use this show and source recipe for the next discovery run.' : 'Add or seed a story source/search recipe for this show.')
         : 'Create or select a show before building an episode.',
-      actionLabel: show ? 'Open Show Setup' : 'New Show',
+      actionLabel: show ? 'Open Settings' : 'New Show',
       action: () => {
+        if (show) {
+          scrollToPanel('settingsPanel');
+          return;
+        }
         state.showSetupOpen = true;
         render();
         scrollToPanel('showSetupForm');

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -25,8 +25,8 @@ describe('api config endpoints', () => {
     assert.match(response.body, /Settings/);
     assert.match(response.body, /Shows &amp; Feeds/);
     assert.match(response.body, /Prompt Templates/);
-    assert.match(response.body, /Guided Episode Pipeline/);
-    assert.match(response.body, /story sources to candidate stories, research briefs, script drafts, integrity review/);
+    assert.match(response.body, /Editorial Production Workflow/);
+    assert.match(response.body, /8-stage journey from show selection through sourced evidence, script, integrity review, production assets, approval, and publishing/);
   });
 
   it('serves guided pipeline client state helpers', async () => {
@@ -39,6 +39,8 @@ describe('api config endpoints', () => {
     assert.match(response.body, /saveModelProfile/);
     assert.match(response.body, /renderPipeline/);
     assert.match(response.body, /runSelectedIntegrityReview/);
+    assert.match(response.body, /workflowStoryContext/);
+    assert.match(response.body, /scrollToPanel/);
   });
 
   it('returns the bundled example config', async () => {


### PR DESCRIPTION
## Summary
- Reframe `/ui` around the 8-stage editorial production workflow
- Add selected show/story/revision context near the top of the workflow
- Link stage cards to existing panels while keeping current actions reachable
- Update static UI assertions for the new workflow shell

Closes #44

## Verification
- npm run check
- git diff --check
- node --check packages/api/public/ui.js

## Notes
- No frontend framework or build pipeline added
- Debug IDs moved out of the primary workflow presentation
- Admin/settings separation remains for follow-up ticket #46