### PR TITLE
Separate admin and debug surfaces from production flow

### DIFF
--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -16,8 +16,13 @@
           <pre id="errorDetailsBody"></pre>
         </details>
       </div>
+      <nav class="surface-nav" aria-label="Workspace sections">
+        <button class="surface-tab active" data-surface-tab="workflow" type="button" aria-pressed="true">Produce Episode</button>
+        <button class="surface-tab" data-surface-tab="settings" type="button" aria-pressed="false">Settings / Admin</button>
+        <button class="surface-tab" data-surface-tab="debug" type="button" aria-pressed="false">Jobs / Debug</button>
+      </nav>
       <div class="actions inline">
-        <button id="importLegacy" class="secondary" type="button">Import Legacy</button>
+        <button id="importLegacy" class="secondary surface-hidden" data-surface="debug" type="button">Import Legacy</button>
         <button id="refresh" type="button">Refresh</button>
       </div>
     </header>
@@ -41,7 +46,7 @@
       </aside>
 
       <section class="workspace">
-        <section id="workflowPanel" class="panel pipeline-panel" aria-labelledby="pipelineTitle">
+        <section id="workflowPanel" class="panel pipeline-panel" data-surface="workflow" aria-labelledby="pipelineTitle">
           <div class="panel-heading">
             <div>
               <h2 id="pipelineTitle">Editorial Production Workflow</h2>
@@ -58,7 +63,7 @@
           </details>
         </section>
 
-        <form id="showSetupForm" class="panel setup-form" hidden>
+        <form id="showSetupForm" class="panel setup-form surface-hidden" data-surface="settings" hidden>
           <div class="panel-heading">
             <div>
               <h2>New Show Setup</h2>
@@ -159,7 +164,7 @@
           </div>
         </form>
 
-        <section id="settingsPanel" class="panel admin-panel" aria-labelledby="settingsTitle">
+        <section id="settingsPanel" class="panel admin-panel surface-hidden" data-surface="settings" aria-labelledby="settingsTitle">
           <div class="panel-heading">
             <div>
               <h2 id="settingsTitle">Settings</h2>
@@ -184,7 +189,7 @@
           <div id="settingsSchedules" class="settings-section" hidden></div>
         </section>
 
-        <form id="profileForm" class="panel" hidden>
+        <form id="profileForm" class="panel admin-panel surface-hidden" data-surface="settings" hidden>
           <div class="panel-heading">
             <div>
               <h2 id="profileTitle">Story Source</h2>
@@ -243,7 +248,7 @@
           </div>
         </form>
 
-        <section id="manualStoryPanel" class="panel">
+        <section id="manualStoryPanel" class="panel" data-surface="workflow">
           <div class="panel-heading">
             <div>
               <h2>Add Manual Story</h2>
@@ -273,7 +278,7 @@
           </form>
         </section>
 
-        <section id="modelRolesPanel" class="panel">
+        <section id="modelRolesPanel" class="panel admin-panel surface-hidden" data-surface="settings">
           <div class="panel-heading">
             <div>
               <h2>AI Role Settings</h2>
@@ -284,7 +289,7 @@
           <div id="modelProfileList" class="model-grid"></div>
         </section>
 
-        <section id="candidatePanel" class="panel">
+        <section id="candidatePanel" class="panel" data-surface="workflow">
           <div class="panel-heading">
             <div>
               <h2>Candidate Stories</h2>
@@ -326,7 +331,7 @@
           <div id="candidateList" class="record-list"></div>
         </section>
 
-        <section id="researchPanel" class="panel">
+        <section id="researchPanel" class="panel" data-surface="workflow">
           <div class="panel-heading">
             <div>
               <h2>Research Briefs</h2>
@@ -337,7 +342,7 @@
           <div id="researchBriefList" class="record-list"></div>
         </section>
 
-        <section id="schedulerPanel" class="panel">
+        <section id="schedulerPanel" class="panel admin-panel surface-hidden" data-surface="settings">
           <div class="panel-heading">
             <div>
               <h2>Scheduled Pipelines</h2>
@@ -349,7 +354,7 @@
           <div id="failedScheduleRuns" class="scheduler-failures"></div>
         </section>
 
-        <section class="panel job-panel" aria-labelledby="jobRunsTitle">
+        <section id="jobsPanel" class="panel job-panel surface-hidden" data-surface="debug" aria-labelledby="jobRunsTitle">
           <div class="panel-heading">
             <div>
               <h2 id="jobRunsTitle">Task Runs</h2>
@@ -366,7 +371,7 @@
           </div>
         </section>
 
-        <section id="episodePanel" class="panel">
+        <section id="episodePanel" class="panel" data-surface="workflow">
           <div class="panel-heading">
             <div>
               <h2>Episodes</h2>
@@ -377,7 +382,7 @@
           <div id="episodeList" class="record-list"></div>
         </section>
 
-        <section id="reviewPanel" class="panel review-panel" aria-labelledby="reviewTitle">
+        <section id="reviewPanel" class="panel review-panel" data-surface="workflow" aria-labelledby="reviewTitle">
           <div class="panel-heading">
             <div>
               <h2 id="reviewTitle">Review Gates</h2>
@@ -393,7 +398,7 @@
           </div>
         </section>
 
-        <section id="queriesPanel" class="panel" hidden>
+        <section id="queriesPanel" class="panel admin-panel surface-hidden" data-surface="settings" hidden>
           <div class="panel-heading">
             <div>
               <h2>Search Queries</h2>
@@ -408,7 +413,7 @@
           <div id="queryList" class="query-list"></div>
         </section>
 
-        <section id="scriptPanel" class="panel">
+        <section id="scriptPanel" class="panel" data-surface="workflow">
           <div class="panel-heading">
             <div>
               <h2>Scripts</h2>

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -50,6 +50,7 @@ button:disabled {
   background: #ffffff;
   border-bottom: 1px solid #d8dde5;
   display: flex;
+  gap: 1rem;
   justify-content: space-between;
   min-height: 78px;
   padding: 1rem 1.5rem;
@@ -100,6 +101,34 @@ button:disabled {
   overflow: auto;
   padding: 0.75rem;
   white-space: pre-wrap;
+}
+
+.surface-nav {
+  background: #eef1f5;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: center;
+  padding: 0.3rem;
+}
+
+.surface-tab {
+  background: transparent;
+  border-color: transparent;
+  color: #27303b;
+  min-height: 2.4rem;
+}
+
+.surface-tab.active {
+  background: #2468a8;
+  border-color: #1f5b95;
+  color: white;
+}
+
+.surface-hidden {
+  display: none !important;
 }
 
 .layout {
@@ -1176,6 +1205,18 @@ textarea {
 }
 
 @media (max-width: 820px) {
+  .topbar {
+    align-items: stretch;
+    display: grid;
+  }
+
+  .surface-nav,
+  .surface-tab,
+  .topbar .actions,
+  .topbar .actions button {
+    width: 100%;
+  }
+
   .layout,
   .grid,
   .grid.two,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -4980,6 +4980,7 @@ for (const button of els.surfaceTabs) {
 els.newShowToggle.addEventListener('click', () => {
   state.showSetupOpen = true;
   setActiveSurface('settings');
+  renderShowSetup();
   scrollToPanel('showSetupForm');
 });
 els.cancelShowSetup.addEventListener('click', () => {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -36,6 +36,7 @@ const state = {
   selectedAssetIds: [],
   selectedShowSlug: '',
   selectedProfileId: '',
+  activeSurface: 'workflow',
   activeSettingsTab: 'shows',
   showSetupOpen: false,
   runningActions: {},
@@ -47,6 +48,7 @@ const els = {
   errorDetailsBody: document.querySelector('#errorDetailsBody'),
   refresh: document.querySelector('#refresh'),
   importLegacy: document.querySelector('#importLegacy'),
+  surfaceTabs: document.querySelectorAll('.surface-tab'),
   showSelect: document.querySelector('#showSelect'),
   newShowToggle: document.querySelector('#newShowToggle'),
   showSetupForm: document.querySelector('#showSetupForm'),
@@ -199,6 +201,8 @@ const SETTINGS_SECTIONS = {
   publishing: 'Publishing/storage',
   schedules: 'Scheduled pipelines',
 };
+
+const SURFACES = new Set(['workflow', 'settings', 'debug']);
 
 class ApiRequestError extends Error {
   constructor(message, debugDetails) {
@@ -1107,7 +1111,9 @@ function viewLatestJob(types) {
     return;
   }
 
+  setActiveSurface('debug');
   selectJob(job.id);
+  scrollToPanel('jobsPanel');
 }
 
 function latestStageJob(types) {
@@ -1115,15 +1121,55 @@ function latestStageJob(types) {
   return job ? `${taskLabel(job.type)} ${job.status}, ${job.progress}%` : 'No recorded task run yet.';
 }
 
+function targetSurface(target) {
+  return target?.closest('[data-surface]')?.dataset.surface || '';
+}
+
+function isHiddenForNavigation(target) {
+  return Boolean(target?.closest('[hidden]'));
+}
+
+function renderSurfaceVisibility() {
+  for (const button of els.surfaceTabs) {
+    const active = button.dataset.surfaceTab === state.activeSurface;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+  }
+
+  for (const node of document.querySelectorAll('[data-surface]')) {
+    const active = node.dataset.surface === state.activeSurface;
+    node.classList.toggle('surface-hidden', !active);
+    node.setAttribute('aria-hidden', active && !node.closest('[hidden]') ? 'false' : 'true');
+  }
+}
+
+function setActiveSurface(surface) {
+  if (!SURFACES.has(surface)) {
+    return;
+  }
+
+  state.activeSurface = surface;
+  renderSurfaceVisibility();
+}
+
 function panelIsAvailable(id) {
   const target = document.getElementById(id);
-  return Boolean(target && !target.closest('[hidden]'));
+  return Boolean(target && !isHiddenForNavigation(target));
 }
 
 function scrollToPanel(id) {
   const target = document.getElementById(id);
 
-  if (!target || target.closest('[hidden]')) {
+  if (!target) {
+    return;
+  }
+
+  const surface = targetSurface(target);
+  if (surface && surface !== state.activeSurface) {
+    setActiveSurface(surface);
+  }
+
+  if (isHiddenForNavigation(target)) {
     return;
   }
 
@@ -3460,6 +3506,7 @@ function render() {
   renderModelProfiles();
   renderQueries();
   renderScripts();
+  renderSurfaceVisibility();
 }
 
 async function loadShows() {
@@ -3757,12 +3804,16 @@ async function loadProduction() {
 }
 
 function focusManualStoryForm() {
+  setActiveSurface('workflow');
+  scrollToPanel('manualStoryPanel');
   els.manualUrl.focus();
   setStatus('Paste a source URL in Add Manual Story to create a candidate story.');
 }
 
 function focusScriptEditor() {
   if (state.selectedScript && state.selectedRevision) {
+    setActiveSurface('workflow');
+    scrollToPanel('scriptPanel');
     els.scriptTitle.focus();
     setStatus('Review the selected script draft and save a revision or approve it for audio.');
   }
@@ -4921,9 +4972,16 @@ els.refreshJobs.addEventListener('click', async () => {
   }
 });
 els.importLegacy.addEventListener('click', importLegacyData);
+for (const button of els.surfaceTabs) {
+  button.addEventListener('click', () => {
+    setActiveSurface(button.dataset.surfaceTab);
+  });
+}
 els.newShowToggle.addEventListener('click', () => {
   state.showSetupOpen = true;
+  state.activeSurface = 'settings';
   render();
+  scrollToPanel('showSetupForm');
 });
 els.cancelShowSetup.addEventListener('click', () => {
   state.showSetupOpen = false;

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -4979,8 +4979,7 @@ for (const button of els.surfaceTabs) {
 }
 els.newShowToggle.addEventListener('click', () => {
   state.showSetupOpen = true;
-  state.activeSurface = 'settings';
-  render();
+  setActiveSurface('settings');
   scrollToPanel('showSetupForm');
 });
 els.cancelShowSetup.addEventListener('click', () => {

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -22,10 +22,15 @@ describe('api config endpoints', () => {
 
     assert.equal(response.statusCode, 200);
     assert.match(response.body, /Podcast Forge Command Center/);
-    assert.match(response.body, /Settings/);
+    assert.match(response.body, /Produce Episode/);
+    assert.match(response.body, /Settings \/ Admin/);
+    assert.match(response.body, /Jobs \/ Debug/);
     assert.match(response.body, /Shows &amp; Feeds/);
     assert.match(response.body, /Prompt Templates/);
     assert.match(response.body, /Editorial Production Workflow/);
+    assert.match(response.body, /data-surface="workflow"/);
+    assert.match(response.body, /data-surface="settings"/);
+    assert.match(response.body, /data-surface="debug"/);
     assert.match(response.body, /nextActionPanel/);
     assert.match(response.body, /8-stage journey from show selection through sourced evidence, script, integrity review, production assets, approval, and publishing/);
   });
@@ -39,6 +44,9 @@ describe('api config endpoints', () => {
     assert.match(response.body, /renderSettings/);
     assert.match(response.body, /saveModelProfile/);
     assert.match(response.body, /renderPipeline/);
+    assert.match(response.body, /activeSurface: 'workflow'/);
+    assert.match(response.body, /setActiveSurface/);
+    assert.match(response.body, /renderSurfaceVisibility/);
     assert.match(response.body, /runSelectedIntegrityReview/);
     assert.match(response.body, /workflowStoryContext/);
     assert.match(response.body, /renderNextAction/);


### PR DESCRIPTION
Closes #46

## Summary
- Adds top-level Produce Episode, Settings / Admin, and Jobs / Debug surfaces so the production workflow stays primary by default.
- Tags settings/admin/debug panels and hides them from the creator flow unless intentionally selected.
- Preserves current selected show/story state while navigating between surfaces.
- Updates static UI assertions for the new navigation/surface helpers.

## Verification
- npm run check