### PR TITLE
Fix script edit provenance invalidation

### DIFF
--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -3320,7 +3320,7 @@ function renderScriptReview() {
       ['Integrity issues', `${integrityCounts.total ?? integrityIssues.length} issue(s), ${integrityCounts.critical ?? 0} critical`],
       ['Speaker validation', speakerValidation.valid === false ? 'failed' : 'passed or not recorded'],
       ['Citation/provenance status', provenanceState.stale ? 'stale after human edit' : 'current or not flagged'],
-      ['Provenance validation', provenanceValidation.valid === false ? 'failed' : `${provenanceValidation.warningCount ?? warningItems.length} warning(s)`],
+      ['Provenance validation', provenanceValidation.valid === false ? 'failed' : `${warningItems.length} warning(s)`],
       ['Revision history', `${state.selectedRevisions.length || 1} revision${(state.selectedRevisions.length || 1) === 1 ? '' : 's'}`],
     ]),
     ...(provenanceState.stale ? [actionBlockerNote(provenanceState.message, true)] : []),

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -3323,7 +3323,7 @@ function renderScriptReview() {
       ['Citation/provenance warning items', provenanceValidation.valid === false ? 'failed' : `${warningItems.length} warning(s)`],
       ['Revision history', `${state.selectedRevisions.length || 1} revision${(state.selectedRevisions.length || 1) === 1 ? '' : 's'}`],
     ]),
-    ...(provenanceState.stale ? [actionBlockerNote(provenanceState.message, true)] : []),
+    ...(provenanceState.stale ? [actionBlockerNote(provenanceState.message, false)] : []),
     reviewList('Integrity review issues', integrityIssues, integrity.status === 'missing' ? 'Run the integrity reviewer before production.' : 'No unresolved integrity issues recorded.', integrityIssueText),
     integrity.override ? reviewList('Integrity override', [integrity.override], 'No override recorded.', (item) => `${item.actor || 'editor'} | ${item.reason} | ${formatTime(item.overriddenAt)}`) : settingsEmpty('No integrity override recorded.'),
     reviewList('Revision history', state.selectedRevisions, 'Only the selected revision is loaded.', (item) => `v${item.version} by ${item.author} | ${formatTime(item.createdAt)}${item.changeSummary ? ` | ${item.changeSummary}` : ''}`),

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -748,6 +748,22 @@ function integrityReviewLabel(status) {
   return labels[status] || status || 'not run';
 }
 
+function provenanceReviewState(revision = state.selectedRevision) {
+  const status = asObject(revision?.metadata?.provenanceStatus);
+  const stale = status.status === 'stale' || status.verified === false;
+  const message = typeof status.message === 'string' && status.message.trim()
+    ? status.message.trim()
+    : 'This human-edited revision needs fresh citation mapping and provenance review before production.';
+
+  return {
+    stale,
+    status: stale ? 'stale' : status.status || 'current',
+    message,
+    previousRevisionId: status.previousRevisionId || revision?.metadata?.previousRevisionId || null,
+    previousApprovedRevisionId: status.previousApprovedRevisionId || revision?.metadata?.previousApprovedRevisionId || null,
+  };
+}
+
 function integrityIssueItems(review) {
   const result = asObject(review?.result);
   return [
@@ -3280,7 +3296,12 @@ function renderScriptReview() {
   const validation = asObject(revision.metadata?.validation);
   const speakerValidation = asObject(validation.speakerLabels);
   const provenanceValidation = asObject(validation.provenance);
+  const provenanceState = provenanceReviewState(revision);
   const warningItems = [
+    ...(provenanceState.stale ? [{
+      code: 'STALE_SCRIPT_PROVENANCE',
+      message: provenanceState.message,
+    }] : []),
     ...asArray(revision.metadata?.warnings),
     ...asArray(revision.metadata?.provenance?.warnings),
     ...asArray(provenanceValidation.warnings),
@@ -3298,9 +3319,11 @@ function renderScriptReview() {
       ['Integrity review', integrity.status === 'missing' ? 'not run' : `${integrityReviewLabel(integrity.status)}${integrityReview?.reviewedAt ? ` ${formatTime(integrityReview.reviewedAt)}` : ''}`],
       ['Integrity issues', `${integrityCounts.total ?? integrityIssues.length} issue(s), ${integrityCounts.critical ?? 0} critical`],
       ['Speaker validation', speakerValidation.valid === false ? 'failed' : 'passed or not recorded'],
+      ['Citation/provenance status', provenanceState.stale ? 'stale after human edit' : 'current or not flagged'],
       ['Provenance validation', provenanceValidation.valid === false ? 'failed' : `${provenanceValidation.warningCount ?? warningItems.length} warning(s)`],
       ['Revision history', `${state.selectedRevisions.length || 1} revision${(state.selectedRevisions.length || 1) === 1 ? '' : 's'}`],
     ]),
+    ...(provenanceState.stale ? [actionBlockerNote(provenanceState.message, true)] : []),
     reviewList('Integrity review issues', integrityIssues, integrity.status === 'missing' ? 'Run the integrity reviewer before production.' : 'No unresolved integrity issues recorded.', integrityIssueText),
     integrity.override ? reviewList('Integrity override', [integrity.override], 'No override recorded.', (item) => `${item.actor || 'editor'} | ${item.reason} | ${formatTime(item.overriddenAt)}`) : settingsEmpty('No integrity override recorded.'),
     reviewList('Revision history', state.selectedRevisions, 'Only the selected revision is loaded.', (item) => `v${item.version} by ${item.author} | ${formatTime(item.createdAt)}${item.changeSummary ? ` | ${item.changeSummary}` : ''}`),
@@ -3336,7 +3359,9 @@ function renderScriptReview() {
     : isActionRunning('approval')
       ? 'Approval is already running.'
       : integrity.blocking
-        ? (integrity.status === 'missing' ? 'Blocked: run the integrity reviewer before production.' : 'Blocked: resolve the failed integrity review or record an explicit override reason.')
+        ? (integrity.status === 'missing'
+          ? (provenanceState.stale ? 'Blocked: human edit invalidated citation/provenance coverage; run the integrity reviewer before production.' : 'Blocked: run the integrity reviewer before production.')
+          : 'Blocked: resolve the failed integrity review or record an explicit override reason.')
         : approved ? 'Script and integrity gates are complete for production.' : 'Ready: approve the reviewed script revision for audio.';
   els.reviewScript.append(body, actions, actionBlockerNote(scriptGateReason, integrity.blocking || (!approved && approve.disabled)));
 }

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -3320,7 +3320,7 @@ function renderScriptReview() {
       ['Integrity issues', `${integrityCounts.total ?? integrityIssues.length} issue(s), ${integrityCounts.critical ?? 0} critical`],
       ['Speaker validation', speakerValidation.valid === false ? 'failed' : 'passed or not recorded'],
       ['Citation/provenance status', provenanceState.stale ? 'stale after human edit' : 'current or not flagged'],
-      ['Provenance validation', provenanceValidation.valid === false ? 'failed' : `${warningItems.length} warning(s)`],
+      ['Citation/provenance warning items', provenanceValidation.valid === false ? 'failed' : `${warningItems.length} warning(s)`],
       ['Revision history', `${state.selectedRevisions.length || 1} revision${(state.selectedRevisions.length || 1) === 1 ? '' : 's'}`],
     ]),
     ...(provenanceState.stale ? [actionBlockerNote(provenanceState.message, true)] : []),

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -246,14 +246,43 @@ function validationMetadata(body: string, show: ShowRecord, packet: { id: string
   };
 }
 
-function inheritedRevisionMetadata(previous: Record<string, unknown> | undefined, body: string, show: ShowRecord, packet: Parameters<typeof validationMetadata>[2]) {
+function historicalMetadataValue(value: unknown): unknown {
+  return value === undefined ? null : value;
+}
+
+function inheritedRevisionMetadata(
+  previousRevision: { id: string; metadata: Record<string, unknown> } | undefined,
+  previousApprovedRevisionId: string | null,
+  body: string,
+  show: ShowRecord,
+  packet: Parameters<typeof validationMetadata>[2],
+) {
+  const previous = previousRevision?.metadata;
+  const inheritedCitationMap = previous?.citationMap !== undefined;
+  const inheritedProvenance = previous?.provenance !== undefined;
+  const inheritedIntegrityReview = previous?.integrityReview !== undefined;
+
   return {
     source: 'human-edit',
-    previousSource: previous?.source,
-    previousApprovedRevisionId: null,
-    citationMap: previous?.citationMap,
-    provenance: previous?.provenance,
-    inheritedProvenance: Boolean(previous?.provenance || previous?.citationMap),
+    previousSource: previous?.source ?? null,
+    previousRevisionId: previousRevision?.id ?? null,
+    previousApprovedRevisionId,
+    provenanceStatus: {
+      status: 'stale',
+      verified: false,
+      reason: 'human_edit',
+      message: 'Script text changed in a human edit; citation mapping and provenance must be reviewed or rebuilt for this revision.',
+      previousRevisionId: previousRevision?.id ?? null,
+      previousApprovedRevisionId,
+      previousSource: previous?.source ?? null,
+      staleCitationMap: inheritedCitationMap,
+      staleProvenance: inheritedProvenance,
+      staleIntegrityReview: inheritedIntegrityReview,
+    },
+    staleCitationMap: historicalMetadataValue(previous?.citationMap),
+    previousProvenanceSnapshot: historicalMetadataValue(previous?.provenance),
+    previousIntegrityReviewSnapshot: historicalMetadataValue(previous?.integrityReview),
+    inheritedProvenance: inheritedCitationMap || inheritedProvenance,
     validation: validationMetadata(body, show, packet),
   };
 }
@@ -452,8 +481,7 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         changeSummary: body.changeSummary ?? 'Human edit.',
         modelProfile: {},
         metadata: {
-          ...inheritedRevisionMetadata(latestRevision?.metadata, body.body, show, packet),
-          previousApprovedRevisionId: script.approvedRevisionId,
+          ...inheritedRevisionMetadata(latestRevision, script.approvedRevisionId, body.body, show, packet),
         },
       });
 

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -2171,7 +2171,15 @@ describe('source profile routes', () => {
     assert.match(store.scriptRevisions[0].body, /This is The Synthetic Lens/);
     assert.equal(edited.revision.metadata.source, 'human-edit');
     assert.equal(edited.revision.metadata.inheritedProvenance, true);
-    assert.deepEqual(edited.revision.metadata.citationMap, initial.revision.metadata.citationMap);
+    assert.equal(edited.revision.metadata.citationMap, undefined);
+    assert.equal(edited.revision.metadata.provenance, undefined);
+    assert.deepEqual(edited.revision.metadata.staleCitationMap, initial.revision.metadata.citationMap);
+    assert.deepEqual(edited.revision.metadata.previousProvenanceSnapshot, initial.revision.metadata.provenance);
+    assert.equal(edited.revision.metadata.previousRevisionId, initial.revision.id);
+    assert.equal(edited.revision.metadata.previousApprovedRevisionId, null);
+    assert.equal((edited.revision.metadata.provenanceStatus as { status: string }).status, 'stale');
+    assert.equal((edited.revision.metadata.provenanceStatus as { verified: boolean }).verified, false);
+    assert.equal((edited.revision.metadata.provenanceStatus as { reason: string }).reason, 'human_edit');
     assert.equal(edited.revision.metadata.validation.speakerLabels.valid, true);
 
     const approveResponse = await app.inject({
@@ -2188,6 +2196,76 @@ describe('source profile routes', () => {
     assert.equal(approved.status, 'approved-for-audio');
     assert.equal(approved.approvedRevisionId, edited.revision.id);
     assert.ok(approved.approvedAt);
+  });
+
+  it('does not carry prior approval or integrity review forward after a human script edit', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Approved Revision Edit Story',
+      status: 'approved',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{ id: 'claim-1', text: 'An approved revision claim exists.', sourceDocumentIds: ['source-document-1'], citationUrls: ['https://example.com/approved-edit'] }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/approved-edit',
+        title: 'Approved Edit Source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary for approved revision edit testing.' },
+    });
+    const scriptResponse = await app.inject({ method: 'POST', url: `/research-packets/${packet.id}/script` });
+    const initial = scriptResponse.json();
+    const integrityResponse = await runIntegrityReview(initial.script.id, initial.revision.id);
+
+    assert.equal(integrityResponse.statusCode, 201);
+    assert.equal(integrityResponse.json().integrityReview.status, 'pass');
+
+    const initialApproval = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/approve-for-audio`,
+      payload: { actor: 'producer@example.com', reason: 'Initial revision reviewed.' },
+    });
+    assert.equal(initialApproval.statusCode, 200);
+    assert.equal(initialApproval.json().script.approvedRevisionId, initial.revision.id);
+
+    const editResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions`,
+      payload: {
+        body: 'DAVID: A human editor changed the sourced line.\nINGRID: This replacement needs a fresh integrity pass before assets.',
+        actor: 'editor@example.com',
+        changeSummary: 'Changed the sourced line.',
+      },
+    });
+    const edited = editResponse.json();
+
+    assert.equal(editResponse.statusCode, 201);
+    assert.equal(edited.script.status, 'draft');
+    assert.equal(edited.script.approvedRevisionId, null);
+    assert.equal(edited.script.approvedAt, null);
+    assert.equal(edited.revision.metadata.integrityReview, undefined);
+    assert.equal((edited.revision.metadata.provenanceStatus as { status: string }).status, 'stale');
+    assert.equal((edited.revision.metadata.provenanceStatus as { previousApprovedRevisionId: string }).previousApprovedRevisionId, initial.revision.id);
+    assert.equal(edited.revision.metadata.previousApprovedRevisionId, initial.revision.id);
+    assert.deepEqual(edited.revision.metadata.previousIntegrityReviewSnapshot, integrityResponse.json().integrityReview);
+    assert.deepEqual(edited.revision.metadata.staleCitationMap, initial.revision.metadata.citationMap);
+
+    await app.inject({
+      method: 'POST',
+      url: `/scripts/${edited.script.id}/revisions/${edited.revision.id}/approve-for-audio`,
+      payload: { actor: 'producer@example.com', reason: 'Explicitly approving edited revision.' },
+    });
+    const audioResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${edited.script.id}/production/audio-preview`,
+      payload: { actor: 'producer@example.com' },
+    });
+
+    assert.equal(audioResponse.statusCode, 409);
+    assert.equal(audioResponse.json().code, 'INTEGRITY_REVIEW_REQUIRED');
   });
 
   it('runs and persists a passing integrity review for a script revision', async () => {

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -2253,11 +2253,13 @@ describe('source profile routes', () => {
     assert.deepEqual(edited.revision.metadata.previousIntegrityReviewSnapshot, integrityResponse.json().integrityReview);
     assert.deepEqual(edited.revision.metadata.staleCitationMap, initial.revision.metadata.citationMap);
 
-    await app.inject({
+    const editedApprovalResponse = await app.inject({
       method: 'POST',
       url: `/scripts/${edited.script.id}/revisions/${edited.revision.id}/approve-for-audio`,
       payload: { actor: 'producer@example.com', reason: 'Explicitly approving edited revision.' },
     });
+    assert.equal(editedApprovalResponse.statusCode, 200);
+    assert.equal(editedApprovalResponse.json().script.approvedRevisionId, edited.revision.id);
     const audioResponse = await app.inject({
       method: 'POST',
       url: `/scripts/${edited.script.id}/production/audio-preview`,


### PR DESCRIPTION
## Summary
- mark human-edited script revisions as stale/unverified for citation and provenance coverage instead of copying current citation maps
- preserve previous revision, approval, provenance, citation, and integrity-review snapshots as historical metadata only
- surface stale provenance warnings in the script review UI and add route coverage for approval/integrity non-inheritance

Closes #51

## Verification
- npm run check