### PR TITLE
Harden publishing validation and scheduled-run status

### DIFF
--- a/packages/api/src/production/publishing.ts
+++ b/packages/api/src/production/publishing.ts
@@ -68,7 +68,7 @@ function configString(config: Record<string, unknown>, keys: string[]) {
   return null;
 }
 
-function extensionForMimeType(mimeType: string | null) {
+export function extensionForMimeType(mimeType: string | null) {
   switch (mimeType) {
     case 'audio/mpeg':
       return 'mp3';
@@ -81,7 +81,7 @@ function extensionForMimeType(mimeType: string | null) {
   }
 }
 
-function defaultObjectKey(episode: EpisodeRecord, asset: EpisodeAssetRecord) {
+export function defaultPublishObjectKey(episode: EpisodeRecord, asset: EpisodeAssetRecord) {
   return asset.objectKey ?? `episodes/${episode.slug}/${asset.type}.${extensionForMimeType(asset.mimeType)}`;
 }
 
@@ -126,7 +126,7 @@ export function createPublishStorageAdapter(feed: FeedRecord): PublishStorageAda
   if (feed.storageType === 'r2') {
     return {
       async uploadAsset({ asset, episode }) {
-        const objectKey = defaultObjectKey(episode, asset);
+        const objectKey = defaultPublishObjectKey(episode, asset);
         const url = assertPublicUrl(publicUrl(feed, objectKey, asset.publicUrl), `${asset.type} asset`);
 
         return {
@@ -146,7 +146,7 @@ export function createPublishStorageAdapter(feed: FeedRecord): PublishStorageAda
 
   return {
     async uploadAsset({ asset, episode }) {
-      const objectKey = defaultObjectKey(episode, asset);
+      const objectKey = defaultPublishObjectKey(episode, asset);
       const rootDir = configString(feed.storageConfig, ['localRoot', 'outputDir', 'publicDir']);
       const copiedTo = await maybeCopyLocalAsset(rootDir, objectKey, asset.localPath);
       const size = copiedTo ? (await stat(copiedTo)).size : asset.byteSize;

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -23,6 +23,7 @@ import {
 } from './providers.js';
 import {
   createPublishStorageAdapter,
+  defaultPublishObjectKey,
   localRssUpdateAdapter,
   op3Wrap,
   strictPublicUrlValidator,
@@ -700,23 +701,6 @@ function validOptionalHttpUrl(value: string | null) {
   return !value || normalizedHttpUrl(value) !== null;
 }
 
-function extensionForAsset(asset: EpisodeAssetRecord) {
-  switch (asset.mimeType) {
-    case 'audio/mpeg':
-      return 'mp3';
-    case 'image/png':
-      return 'png';
-    case 'image/jpeg':
-      return 'jpg';
-    default:
-      return 'bin';
-  }
-}
-
-function defaultPublishObjectKey(episode: EpisodeRecord, asset: EpisodeAssetRecord) {
-  return asset.objectKey ?? `episodes/${episode.slug}/${asset.type}.${extensionForAsset(asset)}`;
-}
-
 function resolvedAssetPublicUrl(feed: FeedRecord, episode: EpisodeRecord, asset: EpisodeAssetRecord) {
   if (asset.publicUrl) {
     return normalizedHttpUrl(asset.publicUrl);
@@ -1228,9 +1212,22 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           publishedAt,
         },
       });
-      if (!normalizedHttpUrl(rss.rssUrl)) {
+      const finalRssUrl = normalizedHttpUrl(rss.rssUrl);
+
+      if (!finalRssUrl) {
         throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `RSS adapter returned a non-public feed URL: ${rss.rssUrl}`);
       }
+
+      const finalRssValidations = finalRssUrl === expectedRssUrl
+        ? []
+        : await urlValidator.validate([finalRssUrl]);
+      const finalInvalidUrl = finalRssValidations.find((validation) => !validation.ok);
+
+      if (finalInvalidUrl) {
+        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `Published RSS URL failed validation: ${finalInvalidUrl.url}`);
+      }
+
+      const publishValidations = [...validations, ...finalRssValidations];
 
       const updatedEpisode = await productionStore.updateEpisodeProduction(episode.id, {
         feedId: feed.id,
@@ -1244,7 +1241,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
             feedGuid: guid,
             jobId: job.id,
             publishEventId: publishEvent.id,
-            rssUrl: rss.rssUrl,
+            rssUrl: finalRssUrl,
             audioUrl: rssAudioUrl,
             unwrappedAudioUrl: audioUpload.publicUrl,
             coverUrl: coverUpload.publicUrl,
@@ -1256,7 +1253,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
             },
             republished: body.republish,
             changelog: body.changelog ?? null,
-            validatedUrls: validations,
+            validatedUrls: publishValidations,
           },
         },
       }) ?? episode;
@@ -1265,7 +1262,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         feedGuid: guid,
         audioUrl: rssAudioUrl,
         coverUrl: coverUpload.publicUrl,
-        rssUrl: rss.rssUrl,
+        rssUrl: finalRssUrl,
         metadata: {
           ...publishEvent.metadata,
           jobId: job.id,
@@ -1278,13 +1275,13 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
             originalAudioUrl: audioUpload.publicUrl,
             wrappedAudioUrl: rssAudioUrl,
           },
-          validatedUrls: validations,
+          validatedUrls: publishValidations,
         },
       }) ?? publishEvent;
 
       logs.push(log('info', 'Completed publish.rss job.', {
         publishEventId: publishEvent.id,
-        rssUrl: rss.rssUrl,
+        rssUrl: finalRssUrl,
         inserted: rss.inserted,
       }));
       job = await updateJob(jobStore, job.id, {
@@ -1300,9 +1297,9 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           audioUrl: rssAudioUrl,
           unwrappedAudioUrl: audioUpload.publicUrl,
           coverUrl: coverUpload.publicUrl,
-          rssUrl: rss.rssUrl,
+          rssUrl: finalRssUrl,
           rssInserted: rss.inserted,
-          validatedUrls: validations,
+          validatedUrls: publishValidations,
         },
         finishedAt: new Date(),
       }) ?? job;

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -810,10 +810,10 @@ function publishBlockers(
       });
     }
 
-    if (audioAsset.byteSize === null || audioAsset.byteSize <= 0) {
+    if (audioAsset.byteSize !== null && audioAsset.byteSize <= 0) {
       blockers.push({
         code: 'AUDIO_ASSET_SIZE_INVALID',
-        message: 'Audio asset byte size must be known and positive before RSS publishing.',
+        message: 'Audio asset byte size must be positive when known before RSS publishing.',
         metadata: { assetId: audioAsset.id, byteSize: audioAsset.byteSize },
       });
     }
@@ -1039,7 +1039,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const audioAsset = selectAsset(assets, ['audio-final', 'audio-preview'], 'audio');
       const coverAsset = selectAsset(assets, ['cover-art'], 'cover art');
       const guid = feedGuid(episode, feed);
-      const expectedRssUrl = resolvedRssPublicUrl(feed);
+      const expectedRssUrl = resolvedRssPublicUrl(feed) ?? '';
 
       const storageAdapter = options.publishStorageAdapterFactory?.(feed) ?? createPublishStorageAdapter(feed);
 
@@ -1101,15 +1101,6 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         });
       }
 
-      if (!expectedRssUrl) {
-        throw new ApiError(409, 'PUBLISH_BLOCKED', 'Episode cannot be published until blocking issues are resolved.', {
-          blockedReasons: [{
-            code: 'PUBLISH_FEED_PUBLIC_URL_REQUIRED',
-            message: 'RSS publishing requires a public feed URL or a public base URL with an RSS feed path.',
-          }],
-        });
-      }
-
       logs.push(log('info', 'Starting publish.rss job.', {
         episodeId: episode.id,
         feedId: feed.id,
@@ -1165,6 +1156,16 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       ]);
       const audioUpload = assertUploadedAssetReady('Audio asset', rawAudioUpload);
       const coverUpload = assertUploadedAssetReady('Cover art asset', rawCoverUpload);
+      const audioByteSize = audioUpload.byteSize ?? audioAsset.byteSize;
+
+      if (audioByteSize === null || audioByteSize <= 0) {
+        throw new ApiError(502, 'PUBLISHED_ASSET_SIZE_INVALID', 'Audio upload did not provide a positive byte size.', {
+          assetId: audioAsset.id,
+          uploadByteSize: audioUpload.byteSize,
+          assetByteSize: audioAsset.byteSize,
+        });
+      }
+
       const rssAudioUrl = feed.op3Wrap ? op3Wrap(audioUpload.publicUrl) : audioUpload.publicUrl;
 
       stage = 'validating-public-urls';
@@ -1206,7 +1207,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           description: episode.description ?? episode.title,
           audioUrl: rssAudioUrl,
           audioMimeType: audioAsset.mimeType ?? 'audio/mpeg',
-          audioByteSize: audioUpload.byteSize ?? audioAsset.byteSize ?? 0,
+          audioByteSize,
           coverUrl: coverUpload.publicUrl,
           durationSeconds: audioAsset.durationSeconds ?? episode.durationSeconds,
           publishedAt,

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -814,7 +814,11 @@ function publishBlockers(
       blockers.push({
         code: 'PUBLISH_FEED_PUBLIC_URL_REQUIRED',
         message: 'RSS publishing requires a public feed URL or a public base URL with an RSS feed path.',
-        metadata: { publicFeedUrl: feed.publicFeedUrl, publicBaseUrl: feed.publicBaseUrl, rssFeedPath: feed.rssFeedPath },
+        metadata: {
+          publicFeedUrl: sanitizedUrlForDiagnostics(feed.publicFeedUrl),
+          publicBaseUrl: sanitizedUrlForDiagnostics(feed.publicBaseUrl),
+          hasRssFeedPath: Boolean(feed.rssFeedPath),
+        },
       });
     }
   }

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -1278,8 +1278,8 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           ...publishEvent.metadata,
           jobId: job.id,
           actor: body.actor,
-          audioUpload,
-          coverUpload,
+          audioUpload: sanitizedUploadDetails(audioUpload),
+          coverUpload: sanitizedUploadDetails(coverUpload),
           rss,
           op3: {
             enabled: feed.op3Wrap,

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -731,12 +731,22 @@ function resolvedRssPublicUrl(feed: FeedRecord) {
   return normalizedHttpUrl(`${publicBaseUrl.replace(/\/$/, '')}/feed.xml`);
 }
 
+function sanitizedUploadDetails(upload: UploadedPublishAsset) {
+  return {
+    assetId: upload.assetId,
+    type: upload.type,
+    objectKey: upload.objectKey,
+    byteSize: upload.byteSize,
+    hasMetadata: Object.keys(upload.metadata).length > 0,
+  };
+}
+
 function assertUploadedAssetReady(label: string, upload: UploadedPublishAsset) {
   const publicUrl = normalizedHttpUrl(upload.publicUrl);
 
   if (!publicUrl) {
     throw new ApiError(502, 'PUBLISHED_ASSET_URL_INVALID', `${label} upload returned a non-public URL.`, {
-      upload,
+      upload: sanitizedUploadDetails(upload),
     });
   }
 

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -731,6 +731,19 @@ function resolvedRssPublicUrl(feed: FeedRecord) {
   return normalizedHttpUrl(`${publicBaseUrl.replace(/\/$/, '')}/feed.xml`);
 }
 
+function sanitizedUrlForDiagnostics(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return '[REDACTED]';
+  }
+}
+
 function sanitizedUploadDetails(upload: UploadedPublishAsset) {
   return {
     assetId: upload.assetId,
@@ -1180,9 +1193,9 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
 
       stage = 'validating-public-urls';
       logs.push(log('info', 'Validating publish URLs before RSS mutation.', {
-        audioUrl: rssAudioUrl,
-        coverUrl: coverUpload.publicUrl,
-        rssUrl: expectedRssUrl,
+        audioUrl: sanitizedUrlForDiagnostics(rssAudioUrl),
+        coverUrl: sanitizedUrlForDiagnostics(coverUpload.publicUrl),
+        rssUrl: sanitizedUrlForDiagnostics(expectedRssUrl),
       }));
       job = await updateJob(jobStore, job.id, {
         progress: 65,
@@ -1193,7 +1206,9 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const invalidUrl = validations.find((validation) => !validation.ok);
 
       if (invalidUrl) {
-        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `Published URL failed validation: ${invalidUrl.url}`);
+        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', 'Published URL failed validation.', {
+          url: sanitizedUrlForDiagnostics(invalidUrl.url),
+        });
       }
 
       stage = 'updating-rss';
@@ -1226,7 +1241,9 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const finalRssUrl = normalizedHttpUrl(rss.rssUrl);
 
       if (!finalRssUrl) {
-        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `RSS adapter returned a non-public feed URL: ${rss.rssUrl}`);
+        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', 'RSS adapter returned a non-public feed URL.', {
+          rssUrl: sanitizedUrlForDiagnostics(rss.rssUrl),
+        });
       }
 
       const finalRssValidations = finalRssUrl === expectedRssUrl
@@ -1235,7 +1252,9 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const finalInvalidUrl = finalRssValidations.find((validation) => !validation.ok);
 
       if (finalInvalidUrl) {
-        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `Published RSS URL failed validation: ${finalInvalidUrl.url}`);
+        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', 'Published RSS URL failed validation.', {
+          url: sanitizedUrlForDiagnostics(finalInvalidUrl.url),
+        });
       }
 
       const publishValidations = [...validations, ...finalRssValidations];

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -683,12 +683,12 @@ function researchBlockers(episode: EpisodeRecord, researchPacket: ResearchPacket
 }
 
 function normalizedHttpUrl(value: string | null) {
-  if (!value) {
+  if (!value || value !== value.trim()) {
     return null;
   }
 
   try {
-    const parsed = new URL(value.trim());
+    const parsed = new URL(value);
     return parsed.protocol === 'http:' || parsed.protocol === 'https:'
       ? parsed.toString()
       : null;
@@ -1041,15 +1041,6 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const guid = feedGuid(episode, feed);
       const expectedRssUrl = resolvedRssPublicUrl(feed);
 
-      if (!expectedRssUrl) {
-        throw new ApiError(409, 'PUBLISH_BLOCKED', 'Episode cannot be published until blocking issues are resolved.', {
-          blockedReasons: [{
-            code: 'PUBLISH_FEED_PUBLIC_URL_REQUIRED',
-            message: 'RSS publishing requires a public feed URL or a public base URL with an RSS feed path.',
-          }],
-        });
-      }
-
       const storageAdapter = options.publishStorageAdapterFactory?.(feed) ?? createPublishStorageAdapter(feed);
 
       if (episode.status === 'published' && episode.feedGuid && !body.republish) {
@@ -1107,6 +1098,15 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           job,
           episode,
           publishEvent: null,
+        });
+      }
+
+      if (!expectedRssUrl) {
+        throw new ApiError(409, 'PUBLISH_BLOCKED', 'Episode cannot be published until blocking issues are resolved.', {
+          blockedReasons: [{
+            code: 'PUBLISH_FEED_PUBLIC_URL_REQUIRED',
+            message: 'RSS publishing requires a public feed URL or a public base URL with an RSS feed path.',
+          }],
         });
       }
 

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -29,6 +29,7 @@ import {
   type PublishStorageAdapter,
   type PublishUrlValidator,
   type RssUpdateAdapter,
+  type UploadedPublishAsset,
 } from './publishing.js';
 import type {
   CreateEpisodeAssetInput,
@@ -680,17 +681,82 @@ function researchBlockers(episode: EpisodeRecord, researchPacket: ResearchPacket
   return blockers;
 }
 
-function validHttpUrl(value: string | null) {
+function normalizedHttpUrl(value: string | null) {
   if (!value) {
-    return true;
+    return null;
   }
 
   try {
-    const parsed = new URL(value);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.toString()
+      : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+function validOptionalHttpUrl(value: string | null) {
+  return !value || normalizedHttpUrl(value) !== null;
+}
+
+function extensionForAsset(asset: EpisodeAssetRecord) {
+  switch (asset.mimeType) {
+    case 'audio/mpeg':
+      return 'mp3';
+    case 'image/png':
+      return 'png';
+    case 'image/jpeg':
+      return 'jpg';
+    default:
+      return 'bin';
+  }
+}
+
+function defaultPublishObjectKey(episode: EpisodeRecord, asset: EpisodeAssetRecord) {
+  return asset.objectKey ?? `episodes/${episode.slug}/${asset.type}.${extensionForAsset(asset)}`;
+}
+
+function resolvedAssetPublicUrl(feed: FeedRecord, episode: EpisodeRecord, asset: EpisodeAssetRecord) {
+  if (asset.publicUrl) {
+    return normalizedHttpUrl(asset.publicUrl);
+  }
+
+  const publicBaseUrl = normalizedHttpUrl(feed.publicBaseUrl);
+
+  if (!publicBaseUrl) {
+    return null;
+  }
+
+  return normalizedHttpUrl(`${publicBaseUrl.replace(/\/$/, '')}/${defaultPublishObjectKey(episode, asset).replace(/^\//, '')}`);
+}
+
+function resolvedRssPublicUrl(feed: FeedRecord) {
+  const publicFeedUrl = normalizedHttpUrl(feed.publicFeedUrl);
+
+  if (publicFeedUrl) {
+    return publicFeedUrl;
+  }
+
+  const publicBaseUrl = normalizedHttpUrl(feed.publicBaseUrl);
+
+  if (!publicBaseUrl || !feed.rssFeedPath) {
+    return null;
+  }
+
+  return normalizedHttpUrl(`${publicBaseUrl.replace(/\/$/, '')}/feed.xml`);
+}
+
+function assertUploadedAssetReady(label: string, upload: UploadedPublishAsset) {
+  const publicUrl = normalizedHttpUrl(upload.publicUrl);
+
+  if (!publicUrl) {
+    throw new ApiError(502, 'PUBLISHED_ASSET_URL_INVALID', `${label} upload returned a non-public URL.`, {
+      upload,
+    });
+  }
+
+  return { ...upload, publicUrl };
 }
 
 function publishBlockers(
@@ -729,11 +795,19 @@ function publishBlockers(
       message: 'Show has no configured RSS feed.',
     });
   } else {
-    if (!validHttpUrl(feed.publicFeedUrl) || !validHttpUrl(feed.publicBaseUrl)) {
+    if (!validOptionalHttpUrl(feed.publicFeedUrl) || !validOptionalHttpUrl(feed.publicBaseUrl)) {
       blockers.push({
         code: 'PUBLISH_FEED_PUBLIC_URL_INVALID',
         message: 'Feed public URLs must be valid http(s) URLs when configured.',
         metadata: { publicFeedUrl: feed.publicFeedUrl, publicBaseUrl: feed.publicBaseUrl },
+      });
+    }
+
+    if (!resolvedRssPublicUrl(feed)) {
+      blockers.push({
+        code: 'PUBLISH_FEED_PUBLIC_URL_REQUIRED',
+        message: 'RSS publishing requires a public feed URL or a public base URL with an RSS feed path.',
+        metadata: { publicFeedUrl: feed.publicFeedUrl, publicBaseUrl: feed.publicBaseUrl, rssFeedPath: feed.rssFeedPath },
       });
     }
   }
@@ -752,11 +826,25 @@ function publishBlockers(
       });
     }
 
-    if (audioAsset.byteSize !== null && audioAsset.byteSize <= 0) {
+    if (audioAsset.byteSize === null || audioAsset.byteSize <= 0) {
       blockers.push({
         code: 'AUDIO_ASSET_SIZE_INVALID',
-        message: 'Audio asset byte size must be positive when known.',
+        message: 'Audio asset byte size must be known and positive before RSS publishing.',
         metadata: { assetId: audioAsset.id, byteSize: audioAsset.byteSize },
+      });
+    }
+
+    if (audioAsset.publicUrl && !normalizedHttpUrl(audioAsset.publicUrl)) {
+      blockers.push({
+        code: 'AUDIO_ASSET_PUBLIC_URL_INVALID',
+        message: 'Audio asset public URL must be a valid http(s) URL when configured.',
+        metadata: { assetId: audioAsset.id, publicUrl: audioAsset.publicUrl },
+      });
+    } else if (feed && !resolvedAssetPublicUrl(feed, episode, audioAsset)) {
+      blockers.push({
+        code: 'AUDIO_ASSET_PUBLIC_URL_REQUIRED',
+        message: 'Audio asset needs a public URL or a feed public base URL before RSS publishing.',
+        metadata: { assetId: audioAsset.id, objectKey: audioAsset.objectKey, publicBaseUrl: feed.publicBaseUrl },
       });
     }
   }
@@ -771,6 +859,18 @@ function publishBlockers(
       code: 'COVER_ART_ASSET_MIME_INVALID',
       message: 'Cover art asset must have an image MIME type.',
       metadata: { assetId: coverAsset.id, mimeType: coverAsset.mimeType },
+    });
+  } else if (coverAsset.publicUrl && !normalizedHttpUrl(coverAsset.publicUrl)) {
+    blockers.push({
+      code: 'COVER_ART_ASSET_PUBLIC_URL_INVALID',
+      message: 'Cover art asset public URL must be a valid http(s) URL when configured.',
+      metadata: { assetId: coverAsset.id, publicUrl: coverAsset.publicUrl },
+    });
+  } else if (feed && !resolvedAssetPublicUrl(feed, episode, coverAsset)) {
+    blockers.push({
+      code: 'COVER_ART_ASSET_PUBLIC_URL_REQUIRED',
+      message: 'Cover art asset needs a public URL or a feed public base URL before RSS publishing.',
+      metadata: { assetId: coverAsset.id, objectKey: coverAsset.objectKey, publicBaseUrl: feed.publicBaseUrl },
     });
   }
 
@@ -955,6 +1055,17 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const audioAsset = selectAsset(assets, ['audio-final', 'audio-preview'], 'audio');
       const coverAsset = selectAsset(assets, ['cover-art'], 'cover art');
       const guid = feedGuid(episode, feed);
+      const expectedRssUrl = resolvedRssPublicUrl(feed);
+
+      if (!expectedRssUrl) {
+        throw new ApiError(409, 'PUBLISH_BLOCKED', 'Episode cannot be published until blocking issues are resolved.', {
+          blockedReasons: [{
+            code: 'PUBLISH_FEED_PUBLIC_URL_REQUIRED',
+            message: 'RSS publishing requires a public feed URL or a public base URL with an RSS feed path.',
+          }],
+        });
+      }
+
       const storageAdapter = options.publishStorageAdapterFactory?.(feed) ?? createPublishStorageAdapter(feed);
 
       if (episode.status === 'published' && episode.feedGuid && !body.republish) {
@@ -1064,11 +1175,31 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         logs,
         output: { stage },
       }) ?? job;
-      const [audioUpload, coverUpload] = await Promise.all([
+      const [rawAudioUpload, rawCoverUpload] = await Promise.all([
         storageAdapter.uploadAsset({ feed, episode, asset: audioAsset }),
         storageAdapter.uploadAsset({ feed, episode, asset: coverAsset }),
       ]);
+      const audioUpload = assertUploadedAssetReady('Audio asset', rawAudioUpload);
+      const coverUpload = assertUploadedAssetReady('Cover art asset', rawCoverUpload);
       const rssAudioUrl = feed.op3Wrap ? op3Wrap(audioUpload.publicUrl) : audioUpload.publicUrl;
+
+      stage = 'validating-public-urls';
+      logs.push(log('info', 'Validating publish URLs before RSS mutation.', {
+        audioUrl: rssAudioUrl,
+        coverUrl: coverUpload.publicUrl,
+        rssUrl: expectedRssUrl,
+      }));
+      job = await updateJob(jobStore, job.id, {
+        progress: 65,
+        logs,
+        output: { stage },
+      }) ?? job;
+      const validations = await urlValidator.validate([rssAudioUrl, coverUpload.publicUrl, expectedRssUrl]);
+      const invalidUrl = validations.find((validation) => !validation.ok);
+
+      if (invalidUrl) {
+        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `Published URL failed validation: ${invalidUrl.url}`);
+      }
 
       stage = 'updating-rss';
       logs.push(log('info', 'Updating RSS feed.', {
@@ -1097,12 +1228,8 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
           publishedAt,
         },
       });
-      stage = 'validating-public-urls';
-      const validations = await urlValidator.validate([rssAudioUrl, coverUpload.publicUrl, rss.rssUrl]);
-      const invalidUrl = validations.find((validation) => !validation.ok);
-
-      if (invalidUrl) {
-        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `Published URL failed validation: ${invalidUrl.url}`);
+      if (!normalizedHttpUrl(rss.rssUrl)) {
+        throw new ApiError(502, 'PUBLISHED_URL_VALIDATION_FAILED', `RSS adapter returned a non-public feed URL: ${rss.rssUrl}`);
       }
 
       const updatedEpisode = await productionStore.updateEpisodeProduction(episode.id, {

--- a/packages/api/src/scheduler/routes.test.ts
+++ b/packages/api/src/scheduler/routes.test.ts
@@ -392,6 +392,7 @@ describe('scheduler routes', () => {
       ['source.ingest', 'research.packet', 'script.generate', 'audio.preview', 'publish.rss'],
     );
     assert.equal(body.stageJobs[0].status, 'succeeded');
+    assert.equal(body.job.output.stageStatuses[0].stage, null);
     assert.equal(body.stageJobs[4].status, 'queued');
     assert.equal(body.stageJobs[4].input.waitCategory, 'blocked');
     assert.match(body.stageJobs[4].logs[0].message, /approval/i);

--- a/packages/api/src/scheduler/routes.test.ts
+++ b/packages/api/src/scheduler/routes.test.ts
@@ -384,7 +384,8 @@ describe('scheduler routes', () => {
     assert.equal(runResponse.statusCode, 201);
     const body = runResponse.json();
     assert.equal(body.job.type, 'pipeline.scheduled');
-    assert.equal(body.job.status, 'succeeded');
+    assert.equal(body.job.status, 'running');
+    assert.equal(body.job.output.semanticStatus, 'blocked');
     assert.equal(body.job.input.triggeredBy, 'dashboard-user');
     assert.deepEqual(
       body.stageJobs.map((job: JobRecord) => job.type),
@@ -392,6 +393,7 @@ describe('scheduler routes', () => {
     );
     assert.equal(body.stageJobs[0].status, 'succeeded');
     assert.equal(body.stageJobs[4].status, 'queued');
+    assert.equal(body.stageJobs[4].input.waitCategory, 'blocked');
     assert.match(body.stageJobs[4].logs[0].message, /approval/i);
   });
 
@@ -441,6 +443,7 @@ describe('scheduler routes', () => {
 
     assert.equal(retryResponse.statusCode, 201);
     assert.equal(retryResponse.json().job.status, 'succeeded');
+    assert.equal(retryResponse.json().job.output.semanticStatus, 'succeeded');
     assert.equal(retryResponse.json().job.input.retryOfJobId, failedJob.id);
   });
 });

--- a/packages/api/src/scheduler/runner.ts
+++ b/packages/api/src/scheduler/runner.ts
@@ -390,14 +390,17 @@ export async function runScheduledPipeline(options: RunScheduledPipelineOptions)
       stageJobs.push(legacyJob);
     }
 
-    logs.push(log('info', 'Completed scheduled pipeline run.', {
-      stageJobCount: stageJobs.length,
-      waitingStageJobCount: stageOutput(stageJobs).waitingStageJobIds.length,
-    }));
     const output = stageOutput(stageJobs);
     const hasWaitingStages = output.waitingStageJobIds.length > 0;
     const status = hasWaitingStages ? 'running' : 'succeeded';
     const progress = hasWaitingStages ? 90 : 100;
+
+    logs.push(log('info', hasWaitingStages ? 'Scheduled pipeline run recorded; downstream stages pending.' : 'Completed scheduled pipeline run.', {
+      status,
+      semanticStatus: output.semanticStatus,
+      stageJobCount: stageJobs.length,
+      waitingStageJobCount: output.waitingStageJobIds.length,
+    }));
 
     if (hasWaitingStages) {
       logs.push(log(output.blockedStageJobIds.length > 0 ? 'warn' : 'info', 'Scheduled pipeline has downstream stages that are not complete.', {

--- a/packages/api/src/scheduler/runner.ts
+++ b/packages/api/src/scheduler/runner.ts
@@ -420,12 +420,13 @@ export async function runScheduledPipeline(options: RunScheduledPipelineOptions)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Scheduled pipeline run failed.';
     logs.push(log('error', message));
+    const output = { ...stageOutput(stageJobs), semanticStatus: 'failed' };
     parentJob = await updateJob(options.store, parentJob.id, {
       status: 'failed',
       progress: parentJob.progress,
       logs,
       error: message,
-      output: stageOutput(stageJobs),
+      output,
       finishedAt: new Date(),
     }) ?? parentJob;
   }

--- a/packages/api/src/scheduler/runner.ts
+++ b/packages/api/src/scheduler/runner.ts
@@ -148,7 +148,7 @@ function stageOutput(stageJobs: JobRecord[]) {
       id: job.id,
       type: job.type,
       status: job.status,
-      stage: job.input.stage,
+      stage: job.input.stage ?? null,
       waitCategory: job.input.waitCategory ?? null,
       waitReason: job.input.waitReason ?? null,
       error: job.error,

--- a/packages/api/src/scheduler/runner.ts
+++ b/packages/api/src/scheduler/runner.ts
@@ -9,6 +9,7 @@ import { nextCronRun } from './cron.js';
 import type { ScheduledPipelineRecord, ScheduledPipelineStage, SchedulerStore } from './store.js';
 
 type JsonObject = Record<string, unknown>;
+type WaitingStageCategory = 'queued' | 'blocked';
 
 export interface RunScheduledPipelineOptions {
   pipeline: ScheduledPipelineRecord;
@@ -89,13 +90,16 @@ async function createWaitingStageJob(options: {
   stage: ScheduledPipelineStage;
   type: string;
   reason: string;
+  category?: WaitingStageCategory;
   status?: JobRecord['status'];
 }) {
+  const category = options.category ?? 'queued';
   const logs = [
     log(options.status === 'failed' ? 'error' : 'info', options.reason, {
       scheduledPipelineId: options.pipeline.id,
       parentJobId: options.parentJob.id,
       stage: options.stage,
+      waitCategory: category,
     }),
   ];
 
@@ -112,9 +116,44 @@ async function createWaitingStageJob(options: {
       feedId: options.pipeline.feedId,
       sourceProfileId: options.pipeline.sourceProfileId,
       autopublish: options.pipeline.autopublish,
+      waitReason: options.reason,
+      waitCategory: category,
     },
     logs,
   });
+}
+
+function stageOutput(stageJobs: JobRecord[]) {
+  const failedStageJobs = stageJobs.filter((job) => job.status === 'failed');
+  const waitingStageJobs = stageJobs.filter((job) => job.status === 'queued' || job.status === 'running');
+  const blockedStageJobs = waitingStageJobs.filter((job) => job.input.waitCategory === 'blocked');
+  const completedStageJobs = stageJobs.filter((job) => job.status === 'succeeded');
+  const semanticStatus = failedStageJobs.length > 0
+    ? 'failed'
+    : blockedStageJobs.length > 0
+      ? 'blocked'
+      : waitingStageJobs.length > 0
+        ? completedStageJobs.length > 0
+          ? 'partial'
+          : 'queued'
+        : 'succeeded';
+
+  return {
+    semanticStatus,
+    stageJobIds: stageJobs.map((job) => job.id),
+    failedStageJobIds: failedStageJobs.map((job) => job.id),
+    waitingStageJobIds: waitingStageJobs.map((job) => job.id),
+    blockedStageJobIds: blockedStageJobs.map((job) => job.id),
+    stageStatuses: stageJobs.map((job) => ({
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      stage: job.input.stage,
+      waitCategory: job.input.waitCategory ?? null,
+      waitReason: job.input.waitReason ?? null,
+      error: job.error,
+    })),
+  };
 }
 
 async function runIngestStage(options: RunScheduledPipelineOptions, parentJob: JobRecord) {
@@ -238,6 +277,7 @@ async function runStage(options: RunScheduledPipelineOptions, parentJob: JobReco
       parentJob,
       stage,
       type,
+      category: 'blocked',
       reason: 'Publishing is waiting for explicit approval; autopublish is disabled for this scheduled pipeline.',
     });
   }
@@ -257,6 +297,7 @@ async function runStage(options: RunScheduledPipelineOptions, parentJob: JobReco
       parentJob,
       stage,
       type,
+      category: 'blocked',
       reason: `Scheduled ${stage} stage is waiting for config.stageInputs.${stage}.${requiredId}.`,
     });
   }
@@ -327,11 +368,7 @@ export async function runScheduledPipeline(options: RunScheduledPipelineOptions)
       parentJob = await updateJob(options.store, parentJob.id, {
         progress: Math.round(((index + 1) / options.pipeline.workflow.length) * 90),
         logs,
-        output: {
-          stageJobIds: stageJobs.map((job) => job.id),
-          failedStageJobIds: stageJobs.filter((job) => job.status === 'failed').map((job) => job.id),
-          waitingStageJobIds: stageJobs.filter((job) => job.status === 'queued').map((job) => job.id),
-        },
+        output: stageOutput(stageJobs),
       }) ?? parentJob;
 
       if (failed) {
@@ -355,18 +392,27 @@ export async function runScheduledPipeline(options: RunScheduledPipelineOptions)
 
     logs.push(log('info', 'Completed scheduled pipeline run.', {
       stageJobCount: stageJobs.length,
-      waitingStageJobCount: stageJobs.filter((job) => job.status === 'queued').length,
+      waitingStageJobCount: stageOutput(stageJobs).waitingStageJobIds.length,
     }));
+    const output = stageOutput(stageJobs);
+    const hasWaitingStages = output.waitingStageJobIds.length > 0;
+    const status = hasWaitingStages ? 'running' : 'succeeded';
+    const progress = hasWaitingStages ? 90 : 100;
+
+    if (hasWaitingStages) {
+      logs.push(log(output.blockedStageJobIds.length > 0 ? 'warn' : 'info', 'Scheduled pipeline has downstream stages that are not complete.', {
+        semanticStatus: output.semanticStatus,
+        waitingStageJobIds: output.waitingStageJobIds,
+        blockedStageJobIds: output.blockedStageJobIds,
+      }));
+    }
+
     parentJob = await updateJob(options.store, parentJob.id, {
-      status: 'succeeded',
-      progress: 100,
+      status,
+      progress,
       logs,
-      output: {
-        stageJobIds: stageJobs.map((job) => job.id),
-        failedStageJobIds: [],
-        waitingStageJobIds: stageJobs.filter((job) => job.status === 'queued').map((job) => job.id),
-      },
-      finishedAt: new Date(),
+      output,
+      finishedAt: hasWaitingStages ? null : new Date(),
     }) ?? parentJob;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Scheduled pipeline run failed.';
@@ -376,11 +422,7 @@ export async function runScheduledPipeline(options: RunScheduledPipelineOptions)
       progress: parentJob.progress,
       logs,
       error: message,
-      output: {
-        stageJobIds: stageJobs.map((job) => job.id),
-        failedStageJobIds: stageJobs.filter((job) => job.status === 'failed').map((job) => job.id),
-        waitingStageJobIds: stageJobs.filter((job) => job.status === 'queued').map((job) => job.id),
-      },
+      output: stageOutput(stageJobs),
       finishedAt: new Date(),
     }) ?? parentJob;
   }

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -3051,6 +3051,9 @@ describe('source profile routes', () => {
       url: `/episodes/${episode.id}/publish/rss`,
       payload: { actor: 'publisher@example.com' },
     });
+    store.feeds[0].publicFeedUrl = null;
+    store.feeds[0].publicBaseUrl = null;
+    store.feeds[0].rssFeedPath = null;
     const secondResponse = await app.inject({
       method: 'POST',
       url: `/episodes/${episode.id}/publish/rss`,

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -2978,6 +2978,66 @@ describe('source profile routes', () => {
     }
   });
 
+  it('records failed publish state when the RSS adapter returns a different invalid final URL', async () => {
+    const { episode } = await createProducedEpisode('Failed Final RSS URL Story');
+
+    await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/approve-for-publish`,
+      payload: { actor: 'editor@example.com' },
+    });
+
+    let rssMutationCount = 0;
+    const finalUrlApp = buildApp({
+      sourceStore: store,
+      braveApiKey: 'test-brave-key',
+      fetchImpl: braveFetch,
+      rssFetchImpl: rssFetch,
+      researchFetchImpl: researchFetch,
+      researchModelServices,
+      llmRuntime,
+      publishStorageAdapterFactory,
+      rssUpdateAdapter: {
+        async upsertEpisode() {
+          rssMutationCount += 1;
+          return {
+            rssUrl: 'https://podcast.example.com/rebuilt-feed.xml',
+            inserted: true,
+            itemCount: 1,
+          };
+        },
+      },
+      publishUrlValidator: {
+        async validate(urls) {
+          validatedPublishUrls.push(...urls);
+          return urls.map((url) => ({ url, ok: !url.includes('rebuilt-feed.xml') }));
+        },
+      },
+      sleep: async () => {},
+    });
+
+    try {
+      const response = await finalUrlApp.inject({
+        method: 'POST',
+        url: `/episodes/${episode.id}/publish/rss`,
+        payload: { actor: 'publisher@example.com' },
+      });
+      const body = response.json();
+
+      assert.equal(response.statusCode, 502);
+      assert.equal(body.code, 'PUBLISHED_URL_VALIDATION_FAILED');
+      assert.equal(body.job.status, 'failed');
+      assert.equal(body.job.output.stage, 'updating-rss');
+      assert.equal(rssMutationCount, 1);
+      assert.equal(validatedPublishUrls.includes('https://podcast.example.com/rebuilt-feed.xml'), true);
+      assert.equal(store.episodes.find((candidate) => candidate.id === episode.id)?.status, 'approved-for-publish');
+      assert.equal(store.publishEvents.filter((event) => event.status === 'succeeded').length, 0);
+      assert.equal(store.publishEvents.filter((event) => event.status === 'failed').length, 1);
+    } finally {
+      await finalUrlApp.close();
+    }
+  });
+
   it('keeps RSS publishing idempotent by episode feed GUID', async () => {
     const { episode } = await createProducedEpisode('Idempotent Publish Story');
 

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -2749,6 +2749,40 @@ describe('source profile routes', () => {
     assert.equal(uploadedPublishAssets.length, 0);
   });
 
+  it('blocks RSS publishing before mutations when feed public URLs are unusable', async () => {
+    const { episode } = await createProducedEpisode('Missing Feed URL Story');
+
+    const approvalResponse = await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/approve-for-publish`,
+      payload: { actor: 'editor@example.com' },
+    });
+
+    assert.equal(approvalResponse.statusCode, 201);
+    store.feeds[0].publicFeedUrl = null;
+    store.feeds[0].publicBaseUrl = null;
+    store.feeds[0].rssFeedPath = null;
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/publish/rss`,
+      payload: { actor: 'publisher@example.com' },
+    });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 409);
+    assert.equal(body.code, 'PUBLISH_BLOCKED');
+    assert.equal(
+      body.blockedReasons.some((reason: { code: string }) => reason.code === 'PUBLISH_FEED_PUBLIC_URL_REQUIRED'),
+      true,
+    );
+    assert.equal(store.jobs.some((job) => job.type === 'publish.rss'), false);
+    assert.equal(store.publishEvents.length, 0);
+    assert.equal(uploadedPublishAssets.length, 0);
+    assert.equal(rssEntries.size, 0);
+    assert.equal(store.episodes.find((candidate) => candidate.id === episode.id)?.status, 'approved-for-publish');
+  });
+
   it('blocks publish approval when the research brief has no recorded approval event', async () => {
     const packet = await store.createResearchPacket({
       showId: store.shows[0].id,
@@ -2882,6 +2916,66 @@ describe('source profile routes', () => {
     assert.equal(validatedPublishUrls.includes(publishBody.publishEvent.rssUrl), true);
     assert.equal(rssEntries.size, 1);
     assert.equal(Array.from(rssEntries.values())[0]?.guid, publishBody.episode.feedGuid);
+  });
+
+  it('records failed publish state without mutating RSS or marking the episode published when URL validation fails', async () => {
+    const { episode } = await createProducedEpisode('Failed Publish Validation Story');
+
+    await app.inject({
+      method: 'POST',
+      url: `/episodes/${episode.id}/approve-for-publish`,
+      payload: { actor: 'editor@example.com' },
+    });
+
+    let rssMutationCount = 0;
+    const validationApp = buildApp({
+      sourceStore: store,
+      braveApiKey: 'test-brave-key',
+      fetchImpl: braveFetch,
+      rssFetchImpl: rssFetch,
+      researchFetchImpl: researchFetch,
+      researchModelServices,
+      llmRuntime,
+      publishStorageAdapterFactory,
+      rssUpdateAdapter: {
+        async upsertEpisode({ feed, entry }) {
+          rssMutationCount += 1;
+          return {
+            rssUrl: feed.publicFeedUrl ?? 'https://podcast.example.com/feed.xml',
+            inserted: !rssEntries.has(entry.guid),
+            itemCount: rssEntries.size,
+          };
+        },
+      },
+      publishUrlValidator: {
+        async validate(urls) {
+          validatedPublishUrls.push(...urls);
+          return urls.map((url) => ({ url, ok: !url.includes('/cover-art') }));
+        },
+      },
+      sleep: async () => {},
+    });
+
+    try {
+      const response = await validationApp.inject({
+        method: 'POST',
+        url: `/episodes/${episode.id}/publish/rss`,
+        payload: { actor: 'publisher@example.com' },
+      });
+      const body = response.json();
+
+      assert.equal(response.statusCode, 502);
+      assert.equal(body.code, 'PUBLISHED_URL_VALIDATION_FAILED');
+      assert.equal(body.job.status, 'failed');
+      assert.equal(body.job.output.stage, 'validating-public-urls');
+      assert.equal(rssMutationCount, 0);
+      assert.equal(rssEntries.size, 0);
+      assert.equal(store.episodes.find((candidate) => candidate.id === episode.id)?.status, 'approved-for-publish');
+      assert.equal(store.publishEvents.filter((event) => event.status === 'succeeded').length, 0);
+      assert.equal(store.publishEvents.filter((event) => event.status === 'failed').length, 1);
+    } finally {
+      await validationApp.close();
+    }
   });
 
   it('keeps RSS publishing idempotent by episode feed GUID', async () => {


### PR DESCRIPTION
Closes #52

## Summary
- validate RSS feed/asset public URLs before publishing mutates RSS or episode state
- record failed publish attempts without marking episodes published when public URL validation fails
- keep scheduled parent jobs truthful by surfacing queued/blocked/partial/failed semantic stage status
- add regression coverage for publish validation failure and blocked scheduled stages

## Verification
- npm run check

## Notes
Recovered the finished issue #52 diff from `/home/steven/clawd/worktrees/podcast-forge-issue-52`, applied it on current `origin/main`, and re-ran the full check locally.