### PR TITLE
Add AI episode planning assistant

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -408,7 +408,7 @@ Recommended order:
 5. #51 — PF2-08 Fix script edit provenance and citation-map invalidation ✅ merged (#60)
 6. #50 — PF2-07 Enforce source query domain/freshness controls or remove dead UI fields ✅ merged (#61)
 7. #52 — PF2-09 Harden publishing validation and scheduled-run status semantics ✅ merged (#62)
-8. #47 — PF2-04 Add AI story brief / episode plan assistant 🚧 active on `issue-47-ai-story-brief` in `/home/steven/clawd/worktrees/podcast-forge-issue-47`
+8. #47 — PF2-04 Add AI story brief / episode plan assistant 🚧 active on branch `issue-47-ai-story-brief`
 9. #48 — PF2-05 Add AI source-gap and claim-coverage surfacing in review UI
 10. #49 — PF2-06 Add AI rewrite/coaching actions for scripts without bypassing approval
 11. #53 — PF2-10 Split UI state/render helpers into testable modules or sections

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -401,14 +401,14 @@ Current frontend stack remains static HTML + vanilla JS + plain CSS served by Fa
 Run one issue per coding agent, preferably branch/PR per issue because the static UI files are conflict-prone.
 
 Recommended order:
-1. #38 — Add Integrity Reviewer — AI quality gate between script writing and production
-2. #44 — PF2-01 Make the guided workflow the primary UI
-3. #45 — PF2-02 Add always-visible next-best-action and blocker explanations
-4. #46 — PF2-03 Move admin/settings/debug surfaces out of the production flow
-5. #51 — PF2-08 Fix script edit provenance and citation-map invalidation
+1. #38 — Add Integrity Reviewer — AI quality gate between script writing and production ✅ merged (#56)
+2. #44 — PF2-01 Make the guided workflow the primary UI ✅ merged (#57)
+3. #45 — PF2-02 Add always-visible next-best-action and blocker explanations ✅ merged (#58)
+4. #46 — PF2-03 Move admin/settings/debug surfaces out of the production flow ✅ merged (#59)
+5. #51 — PF2-08 Fix script edit provenance and citation-map invalidation ✅ merged (#60)
 6. #50 — PF2-07 Enforce source query domain/freshness controls or remove dead UI fields ✅ merged (#61)
-7. #52 — PF2-09 Harden publishing validation and scheduled-run status semantics 🚧 active on `issue-52-publishing-scheduler-status` in `/home/steven/clawd/worktrees/podcast-forge-issue-52`
-8. #47 — PF2-04 Add AI story brief / episode plan assistant
+7. #52 — PF2-09 Harden publishing validation and scheduled-run status semantics ✅ merged (#62)
+8. #47 — PF2-04 Add AI story brief / episode plan assistant 🚧 active on `issue-47-ai-story-brief` in `/home/steven/clawd/worktrees/podcast-forge-issue-47`
 9. #48 — PF2-05 Add AI source-gap and claim-coverage surfacing in review UI
 10. #49 — PF2-06 Add AI rewrite/coaching actions for scripts without bypassing approval
 11. #53 — PF2-10 Split UI state/render helpers into testable modules or sections

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,7 @@ user-facing labels in the app.
 
 - `source.search`
 - `source.fetch`
+- `episode.plan`
 - `story.score`
 - `episode.cluster`
 - `research.packet`
@@ -54,6 +55,7 @@ user-facing labels in the app.
 Each agent role is an adapter over model providers:
 
 - `query_expander`
+- `episode_planner`
 - `candidate_scorer`
 - `source_summarizer`
 - `claim_extractor`

--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -325,8 +325,10 @@
               </label>
             </div>
             <div class="actions">
+              <button id="requestEpisodePlan" class="secondary" type="button">AI Episode Plan</button>
               <button id="launchClusterBrief" type="submit">Build Research Brief</button>
             </div>
+            <article id="episodePlanResult" class="episode-plan-result" aria-live="polite"></article>
           </form>
           <div id="candidateList" class="record-list"></div>
         </section>

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -619,6 +619,64 @@ textarea {
   color: #1f4d7a;
 }
 
+.episode-plan-result {
+  background: white;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.85rem;
+}
+
+.episode-plan-result:empty {
+  display: none;
+}
+
+.episode-plan-result h3,
+.episode-plan-result h4,
+.episode-plan-result p {
+  margin: 0;
+}
+
+.episode-plan-result h3 {
+  font-size: 1rem;
+}
+
+.episode-plan-result h4 {
+  color: #3f4b5a;
+  font-size: 0.9rem;
+}
+
+.episode-plan-banner {
+  background: #fff9d9;
+  border: 1px solid #d8cf73;
+  border-radius: 6px;
+  color: #3f4b5a;
+  padding: 0.55rem 0.65rem;
+}
+
+.episode-plan-grid {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.episode-plan-section {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.episode-plan-section.wide {
+  grid-column: 1 / -1;
+}
+
+.episode-plan-list {
+  color: #3f4b5a;
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
 .new-query {
   display: grid;
   gap: 0.75rem;
@@ -1224,6 +1282,7 @@ textarea {
   .next-action-panel,
   .pipeline-grid,
   .model-grid,
+  .episode-plan-grid,
   .cluster-grid,
   .manual-form,
   .script-generate,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -12,6 +12,7 @@ const state = {
   recentJobs: [],
   selectedJobId: '',
   storyCandidates: [],
+  episodePlan: null,
   episodes: [],
   selectedScriptId: '',
   selectedScript: null,
@@ -112,7 +113,9 @@ const els = {
   clusterNotes: document.querySelector('#clusterNotes'),
   clusterFormat: document.querySelector('#clusterFormat'),
   clusterRuntime: document.querySelector('#clusterRuntime'),
+  requestEpisodePlan: document.querySelector('#requestEpisodePlan'),
   launchClusterBrief: document.querySelector('#launchClusterBrief'),
+  episodePlanResult: document.querySelector('#episodePlanResult'),
   candidateList: document.querySelector('#candidateList'),
   researchBriefMeta: document.querySelector('#researchBriefMeta'),
   researchBriefList: document.querySelector('#researchBriefList'),
@@ -155,6 +158,10 @@ const els = {
 };
 
 const MODEL_ROLE_LABELS = {
+  episode_planner: {
+    title: 'Episode planner',
+    description: 'Drafts advisory story briefs and episode plans before research begins.',
+  },
   candidate_scorer: {
     title: 'Candidate scorer',
     description: 'Ranks possible stories for editorial fit, significance, novelty, source quality, and urgency.',
@@ -255,6 +262,10 @@ function friendlyApiMessage(body, status) {
     STORY_CANDIDATE_NOT_FOUND: 'That candidate story could not be found. Refresh and try again.',
     STORY_CANDIDATE_IGNORED: 'Ignored candidate stories cannot be used for research briefs.',
     CANDIDATE_SHOW_MISMATCH: 'All selected candidate stories must belong to the same show.',
+    EPISODE_PLANNER_RUNTIME_REQUIRED: 'AI episode planning is unavailable because the local LLM runtime is not configured.',
+    EPISODE_PLANNER_MODEL_PROFILE_REQUIRED: 'Configure the episode planner AI role before requesting a plan.',
+    EPISODE_PLAN_MODEL_OUTPUT_INVALID: 'The AI episode planner returned an unreadable plan. No research or approval state changed.',
+    EPISODE_PLAN_MODEL_FAILED: 'The AI episode planner failed. No research or approval state changed.',
     RESEARCH_PACKET_NOT_FOUND: 'That research brief could not be found. Check the ID and try again.',
     RESEARCH_PACKET_OR_WARNING_NOT_FOUND: 'That research brief or warning could not be found.',
     RESEARCH_APPROVAL_BLOCKED: 'Research approval is blocked until the brief is ready and warnings have override reasons.',
@@ -973,6 +984,7 @@ function savePipelineState() {
 
 function clearPipelineSelections() {
   state.selectedCandidateIds = [];
+  state.episodePlan = null;
   state.clusterForm = { angle: '', notes: '', targetFormat: '', targetRuntime: '' };
   state.selectedResearchPacketId = '';
   state.selectedScriptId = '';
@@ -1003,6 +1015,7 @@ function toggleCandidateSelection(candidateId) {
     state.selectedCandidateIds = [...state.selectedCandidateIds, candidateId];
   }
 
+  state.episodePlan = null;
   savePipelineState();
   render();
 }
@@ -1134,6 +1147,7 @@ function taskLabel(type) {
   const labels = {
     'source.search': 'Source search',
     'source.ingest': 'RSS import',
+    'episode.plan': 'AI episode plan',
     'research.packet': 'Research brief',
     'script.generate': 'Script draft',
     'script.integrity_review': 'Integrity review',
@@ -1919,11 +1933,103 @@ function renderQueries() {
   }
 }
 
+function appendPlanText(section, title, text) {
+  const block = document.createElement('section');
+  block.className = 'episode-plan-section';
+  const heading = document.createElement('h4');
+  heading.textContent = title;
+  const body = document.createElement('p');
+  body.textContent = text || 'Not provided.';
+  block.append(heading, body);
+  section.append(block);
+}
+
+function appendPlanList(section, title, items, mapper = (item) => String(item)) {
+  const block = document.createElement('section');
+  block.className = 'episode-plan-section wide';
+  const heading = document.createElement('h4');
+  heading.textContent = title;
+  block.append(heading);
+
+  if (!items.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Not provided.';
+    block.append(empty);
+  } else {
+    const list = document.createElement('ul');
+    list.className = 'episode-plan-list';
+    for (const item of items) {
+      const row = document.createElement('li');
+      row.textContent = mapper(item);
+      list.append(row);
+    }
+    block.append(list);
+  }
+
+  section.append(block);
+}
+
+function renderEpisodePlan() {
+  els.episodePlanResult.innerHTML = '';
+  const plan = state.episodePlan;
+
+  if (!plan) {
+    return;
+  }
+
+  const selected = new Set(state.selectedCandidateIds);
+  const planMatchesSelection = asArray(plan.candidateIds).every((id) => selected.has(id)) && selected.size === asArray(plan.candidateIds).length;
+
+  const title = document.createElement('h3');
+  title.textContent = plan.proposedAngle || 'AI episode plan';
+  const banner = document.createElement('p');
+  banner.className = 'episode-plan-banner';
+  banner.textContent = planMatchesSelection
+    ? 'AI-generated editorial assistance only. This is not verified evidence and does not approve research, scripts, or publishing.'
+    : 'This AI plan was generated for a previous selection. Select the same candidate stories or request a fresh plan.';
+
+  const grid = document.createElement('div');
+  grid.className = 'episode-plan-grid';
+  appendPlanText(grid, 'Why now', plan.whyNow);
+  appendPlanText(grid, 'Audience relevance', plan.audienceRelevance);
+  appendPlanList(grid, 'Known from candidate records', asArray(plan.knownFacts));
+  appendPlanList(grid, 'Unknowns and source gaps', asArray(plan.unknownsSourceGaps));
+  appendPlanList(grid, 'Questions to answer', asArray(plan.questionsToAnswer));
+  appendPlanList(grid, 'Recommended sources to fetch next', asArray(plan.recommendedSources), (source) => {
+    const priority = source.priority ? `${source.priority} priority` : 'medium priority';
+    const query = source.suggestedQuery ? ` | query: ${source.suggestedQuery}` : '';
+    const url = source.url ? ` | ${source.url}` : '';
+    return `${source.sourceType || 'source'} (${priority}): ${source.rationale || 'No rationale recorded.'}${query}${url}`;
+  });
+
+  if (asArray(plan.warnings).length > 0) {
+    appendPlanList(grid, 'Planner warnings', asArray(plan.warnings), (warning) => `${warning.code || 'warning'}: ${warning.message || JSON.stringify(sanitizedDebug(warning))}`);
+  }
+
+  const details = document.createElement('details');
+  details.className = 'debug-details row-debug';
+  details.innerHTML = '<summary>Planning audit metadata</summary><pre></pre>';
+  details.querySelector('pre').textContent = JSON.stringify(sanitizedDebug({
+    id: plan.id,
+    candidateIds: plan.candidateIds,
+    generatedAt: plan.generatedAt,
+    aiGenerated: plan.aiGenerated,
+    advisoryOnly: plan.advisoryOnly,
+    evidenceStatus: plan.evidenceStatus,
+    gateStatus: plan.gateStatus,
+    modelProfile: plan.modelProfile,
+    promptTemplate: plan.promptTemplate,
+  }), null, 2);
+
+  els.episodePlanResult.append(title, banner, grid, details);
+}
+
 function renderCandidateSelectionPanel() {
   const analysis = selectedCandidateAnalysis();
   const { candidates } = analysis;
   const selectedCount = candidates.length;
   const researchRunning = isActionRunning('research');
+  const planningRunning = isActionRunning('planning');
 
   els.selectionCount.textContent = selectedCount === 0
     ? 'No candidate stories selected'
@@ -1983,6 +2089,9 @@ function renderCandidateSelectionPanel() {
 
   els.launchClusterBrief.disabled = researchRunning || !analysis.canLaunch;
   els.launchClusterBrief.textContent = researchRunning ? 'Building Research Brief...' : 'Build Research Brief';
+  els.requestEpisodePlan.disabled = planningRunning || selectedCount === 0;
+  els.requestEpisodePlan.textContent = planningRunning ? 'Planning...' : 'AI Episode Plan';
+  renderEpisodePlan();
 }
 
 function renderStoryCandidates() {
@@ -3909,6 +4018,7 @@ function selectTopCandidate() {
   }
 
   state.selectedCandidateIds = [candidate.id];
+  state.episodePlan = null;
   savePipelineState();
   render();
   setStatus('Top candidate story selected for the research brief.');
@@ -3916,6 +4026,7 @@ function selectTopCandidate() {
 
 function clearCandidateSelection() {
   state.selectedCandidateIds = [];
+  state.episodePlan = null;
   savePipelineState();
   render();
   setStatus('Candidate story selection cleared.');
@@ -3955,6 +4066,41 @@ async function runSelectedProfileDiscovery() {
     reportError(error);
   } finally {
     setActionRunning('discover', false);
+  }
+}
+
+async function requestEpisodePlanForSelected() {
+  syncClusterFormFromInputs();
+  const candidateIds = state.selectedCandidateIds.filter(Boolean);
+
+  if (candidateIds.length === 0) {
+    render();
+    return;
+  }
+
+  setActionRunning('planning', true);
+  setStatus('Requesting AI episode plan...');
+
+  try {
+    const body = await api('/story-candidates/episode-plan', {
+      method: 'POST',
+      body: JSON.stringify({
+        candidateIds,
+        notes: state.clusterForm.notes || null,
+        targetFormat: state.clusterForm.targetFormat || null,
+        targetRuntime: state.clusterForm.targetRuntime || null,
+      }),
+    });
+    state.episodePlan = body.episodePlan;
+    await loadJobs();
+    render();
+    setStatus('AI episode plan generated. It is advisory only and does not approve research or production.');
+  } catch (error) {
+    await loadJobs();
+    render();
+    reportError(error);
+  } finally {
+    setActionRunning('planning', false);
   }
 }
 
@@ -4493,6 +4639,7 @@ async function createShow(event) {
       queries: [els.showSourceQuery.value.trim() || `${els.showName.value.trim()} news`],
     },
     modelRoleDefaults: {
+      episode_planner: { provider, model, params: reasoningEffort ? { reasoningEffort } : {} },
       candidate_scorer: { provider, model, params: reasoningEffort ? { reasoningEffort } : {} },
       source_summarizer: { provider, model, params: reasoningEffort ? { reasoningEffort } : {} },
       claim_extractor: { provider, model, params: reasoningEffort ? { reasoningEffort } : {} },
@@ -5128,6 +5275,7 @@ els.candidateClusterForm.addEventListener('submit', async (event) => {
   await buildResearchBriefFromSelected();
 });
 els.clearCandidateSelection.addEventListener('click', clearCandidateSelection);
+els.requestEpisodePlan.addEventListener('click', requestEpisodePlanForSelected);
 for (const input of [els.clusterAngle, els.clusterNotes, els.clusterFormat, els.clusterRuntime]) {
   input.addEventListener('input', syncClusterFormFromInputs);
 }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -17,6 +17,7 @@ import { registerModelRoutes } from './models/routes.js';
 import type { ModelProfileStore } from './models/store.js';
 import { registerPromptRoutes } from './prompts/routes.js';
 import type { PromptTemplateStore } from './prompts/types.js';
+import { registerEpisodePlanningRoutes } from './planning/routes.js';
 import { registerResearchRoutes } from './research/routes.js';
 import type { ResearchFetch } from './research/fetch.js';
 import type { ResearchModelServices } from './research/models.js';
@@ -216,6 +217,14 @@ export function buildApp(options: BuildAppOptions = {}) {
     candidateScorer,
     llmRuntime,
     sleep,
+  });
+
+  registerEpisodePlanningRoutes(app, {
+    getStore() {
+      resolvedSourceStore ??= createDbSourceStore();
+      return resolvedSourceStore;
+    },
+    llmRuntime,
   });
 
   registerResearchRoutes(app, {

--- a/packages/api/src/jobs/summary.ts
+++ b/packages/api/src/jobs/summary.ts
@@ -101,6 +101,7 @@ function artifactRefs(job: JobRecord): JobArtifactRef[] {
     addArtifact(artifacts, 'scheduled pipeline', source.scheduledPipelineSlug);
     addArtifact(artifacts, 'candidate story', source.storyCandidateId);
     addArtifact(artifacts, 'candidate story', source.candidateIds);
+    addArtifact(artifacts, 'episode plan', source.episodePlanId);
     addArtifact(artifacts, 'research brief', source.researchPacketId);
     addArtifact(artifacts, 'source document', source.sourceDocumentIds);
     addArtifact(artifacts, 'failed source document', source.failedSourceDocumentIds);

--- a/packages/api/src/models/roles.ts
+++ b/packages/api/src/models/roles.ts
@@ -1,4 +1,5 @@
 export const MODEL_ROLES = [
+  'episode_planner',
   'candidate_scorer',
   'source_summarizer',
   'claim_extractor',

--- a/packages/api/src/planning/episode-plan.ts
+++ b/packages/api/src/planning/episode-plan.ts
@@ -1,0 +1,273 @@
+import { LlmJsonOutputError, LlmRuntimeError, type LlmInvocationMetadata, type LlmJsonResult, type LlmRuntime } from '../llm/types.js';
+import type { ResolvedModelProfile } from '../models/resolver.js';
+import { PROMPT_OUTPUT_SCHEMAS, type EpisodePlanResult } from '../prompts/schemas.js';
+import { PromptRenderError, renderPromptTemplate } from '../prompts/renderer.js';
+import type { PromptRegistry, RenderedPrompt } from '../prompts/types.js';
+import type { StoryCandidateRecord } from '../search/store.js';
+import type { ShowRecord, SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+
+export class EpisodePlanError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+export interface EpisodePlan {
+  id: string;
+  showId: string;
+  candidateIds: string[];
+  duplicateCandidateIds: string[];
+  aiGenerated: true;
+  advisoryOnly: true;
+  evidenceStatus: 'not_verified_evidence';
+  gateStatus: 'research_required';
+  generatedAt: string;
+  proposedAngle: string;
+  whyNow: string;
+  audienceRelevance: string;
+  knownFacts: string[];
+  unknownsSourceGaps: string[];
+  questionsToAnswer: string[];
+  recommendedSources: EpisodePlanResult['recommendedSources'];
+  warnings: EpisodePlanResult['warnings'];
+  modelProfile: Record<string, unknown>;
+  promptTemplate: {
+    key: string;
+    version: number;
+  };
+  invocation: LlmInvocationMetadata;
+  planningNotes: Record<string, unknown>;
+}
+
+export interface BuildEpisodePlanOptions {
+  show: ShowRecord;
+  candidates: StoryCandidateRecord[];
+  duplicateCandidateIds?: string[];
+  sourceProfiles?: Map<string, SourceProfileRecord>;
+  sourceQueries?: Map<string, SourceQueryRecord>;
+  modelProfile: ResolvedModelProfile;
+  runtime: LlmRuntime;
+  promptRegistry: PromptRegistry;
+  notes?: string | null;
+  targetFormat?: string | null;
+  targetRuntime?: string | null;
+  now?: () => Date;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+const secretKeyPattern = /(api[_-]?key|authorization|cookie|credential|password|secret|token)/i;
+const localPathPattern = /(^|_)(local|absolute)?(file|dir|directory|path)$/i;
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (depth > 4) {
+    return '[max-depth]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, depth + 1));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value instanceof Date ? value.toISOString() : value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !secretKeyPattern.test(key) && !localPathPattern.test(key))
+      .map(([key, item]) => [key, sanitizeValue(item, depth + 1)]),
+  );
+}
+
+function isoDate(value: Date | null): string | null {
+  return value ? value.toISOString() : null;
+}
+
+function hostnameFor(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function showContext(show: ShowRecord): Record<string, unknown> {
+  return sanitizeValue({
+    id: show.id,
+    slug: show.slug,
+    title: show.title,
+    description: show.description,
+    format: show.format,
+    defaultRuntimeMinutes: show.defaultRuntimeMinutes,
+    cast: show.cast.map((member) => ({ name: member.name, role: member.role })),
+    settings: show.settings,
+  }) as Record<string, unknown>;
+}
+
+function candidateContext(
+  candidate: StoryCandidateRecord,
+  sourceProfiles: Map<string, SourceProfileRecord>,
+  sourceQueries: Map<string, SourceQueryRecord>,
+): Record<string, unknown> {
+  const sourceProfile = candidate.sourceProfileId ? sourceProfiles.get(candidate.sourceProfileId) : undefined;
+  const sourceQuery = candidate.sourceQueryId ? sourceQueries.get(candidate.sourceQueryId) : undefined;
+  const url = candidate.canonicalUrl ?? candidate.url;
+
+  return sanitizeValue({
+    id: candidate.id,
+    title: candidate.title,
+    url,
+    canonicalUrl: candidate.canonicalUrl,
+    domain: hostnameFor(url),
+    sourceName: candidate.sourceName,
+    author: candidate.author,
+    summary: candidate.summary,
+    status: candidate.status,
+    publishedAt: isoDate(candidate.publishedAt),
+    discoveredAt: candidate.discoveredAt.toISOString(),
+    score: candidate.score,
+    scoreBreakdown: candidate.scoreBreakdown,
+    metadata: candidate.metadata,
+    sourceProfile: sourceProfile ? {
+      id: sourceProfile.id,
+      slug: sourceProfile.slug,
+      name: sourceProfile.name,
+      type: sourceProfile.type,
+      freshness: sourceProfile.freshness,
+      includeDomains: sourceProfile.includeDomains,
+      excludeDomains: sourceProfile.excludeDomains,
+    } : null,
+    sourceQuery: sourceQuery ? {
+      id: sourceQuery.id,
+      query: sourceQuery.query,
+      freshness: sourceQuery.freshness,
+      includeDomains: sourceQuery.includeDomains,
+      excludeDomains: sourceQuery.excludeDomains,
+    } : null,
+  }) as Record<string, unknown>;
+}
+
+function promptErrorMessage(error: unknown) {
+  if (error instanceof PromptRenderError) {
+    return error.message;
+  }
+
+  if (error instanceof LlmJsonOutputError) {
+    return 'Episode planner returned malformed JSON or did not match the required output schema.';
+  }
+
+  if (error instanceof LlmRuntimeError) {
+    return error.message;
+  }
+
+  return error instanceof Error ? error.message : 'Episode planning failed.';
+}
+
+function planningErrorFor(error: unknown): EpisodePlanError {
+  if (error instanceof EpisodePlanError) {
+    return error;
+  }
+
+  if (error instanceof PromptRenderError) {
+    return new EpisodePlanError(409, error.code, error.message, error.details);
+  }
+
+  if (error instanceof LlmJsonOutputError) {
+    return new EpisodePlanError(502, 'EPISODE_PLAN_MODEL_OUTPUT_INVALID', promptErrorMessage(error), error.details);
+  }
+
+  if (error instanceof LlmRuntimeError) {
+    return new EpisodePlanError(502, 'EPISODE_PLAN_MODEL_FAILED', error.message);
+  }
+
+  return new EpisodePlanError(500, 'EPISODE_PLAN_FAILED', promptErrorMessage(error));
+}
+
+export async function buildEpisodePlan(options: BuildEpisodePlanOptions): Promise<EpisodePlan> {
+  const sourceProfiles = options.sourceProfiles ?? new Map();
+  const sourceQueries = options.sourceQueries ?? new Map();
+  const generatedAt = (options.now?.() ?? new Date()).toISOString();
+  const schema = PROMPT_OUTPUT_SCHEMAS.episode_plan_result;
+  let result: LlmJsonResult<EpisodePlanResult>;
+  let rendered: RenderedPrompt;
+
+  try {
+    rendered = await renderPromptTemplate(options.promptRegistry, {
+      key: options.modelProfile.promptTemplateKey ?? undefined,
+      role: options.modelProfile.promptTemplateKey ? undefined : 'episode_planner',
+      showId: options.show.id,
+      variables: {
+        show_context: showContext(options.show),
+        candidate_selection: {
+          advisoryOnly: true,
+          evidenceStatus: 'not_verified_evidence',
+          gateStatus: 'research_required',
+          planningNotes: {
+            notes: options.notes ?? null,
+            targetFormat: options.targetFormat ?? null,
+            targetRuntime: options.targetRuntime ?? null,
+          },
+          candidates: options.candidates.map((candidate) => candidateContext(candidate, sourceProfiles, sourceQueries)),
+        },
+      },
+    });
+    result = await options.runtime.generateJson<EpisodePlanResult>({
+      profile: options.modelProfile,
+      messages: rendered.messages,
+      schemaName: rendered.responseFormat.schemaName ?? schema.name,
+      schemaHint: rendered.responseFormat.schemaHint ?? schema.schemaHint,
+      validate: (value) => schema.validate(value) as EpisodePlanResult,
+      requestMetadata: {
+        purpose: 'episode_planning',
+        candidateIds: options.candidates.map((candidate) => candidate.id),
+        promptTemplateKey: rendered.template.key,
+        promptTemplateVersion: rendered.template.version,
+        advisoryOnly: true,
+      },
+    });
+  } catch (error) {
+    throw planningErrorFor(error);
+  }
+
+  return {
+    id: `episode-plan:${result.metadata.startedAt}:${options.candidates.map((candidate) => candidate.id).join(',')}`,
+    showId: options.show.id,
+    candidateIds: options.candidates.map((candidate) => candidate.id),
+    duplicateCandidateIds: options.duplicateCandidateIds ?? [],
+    aiGenerated: true,
+    advisoryOnly: true,
+    evidenceStatus: 'not_verified_evidence',
+    gateStatus: 'research_required',
+    generatedAt,
+    proposedAngle: result.value.proposedAngle,
+    whyNow: result.value.whyNow,
+    audienceRelevance: result.value.audienceRelevance,
+    knownFacts: [...result.value.knownFacts],
+    unknownsSourceGaps: [...result.value.unknownsSourceGaps],
+    questionsToAnswer: [...result.value.questionsToAnswer],
+    recommendedSources: result.value.recommendedSources,
+    warnings: result.value.warnings,
+    modelProfile: sanitizeValue(options.modelProfile) as Record<string, unknown>,
+    promptTemplate: {
+      key: rendered.template.key,
+      version: rendered.template.version,
+    },
+    invocation: result.metadata,
+    planningNotes: asRecord(sanitizeValue({
+      notes: options.notes ?? null,
+      targetFormat: options.targetFormat ?? null,
+      targetRuntime: options.targetRuntime ?? null,
+    })),
+  };
+}

--- a/packages/api/src/planning/routes.test.ts
+++ b/packages/api/src/planning/routes.test.ts
@@ -1,0 +1,372 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import Fastify from 'fastify';
+
+import { createFakeLlmProvider } from '../llm/providers.js';
+import { createLlmRuntime } from '../llm/runtime.js';
+import type { LlmProviderRequest, LlmProviderResult } from '../llm/types.js';
+import type { ModelRole } from '../models/roles.js';
+import type { CreateModelProfileInput, ModelProfileListFilter, ModelProfileRecord, UpdateModelProfileInput } from '../models/store.js';
+import type { CreateJobInput, JobRecord, StoryCandidateRecord, UpdateJobInput } from '../search/store.js';
+import type { ShowRecord, SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+import { registerEpisodePlanningRoutes } from './routes.js';
+
+type PlannerMode = 'valid' | 'malformed';
+
+class FakePlanningStore {
+  shows: ShowRecord[] = [{
+    id: 'show-1',
+    slug: 'example-show',
+    title: 'Example Show',
+    description: 'Evidence-first technology news.',
+    setupStatus: 'active',
+    format: 'feature-analysis',
+    defaultRuntimeMinutes: 8,
+    cast: [{ name: 'HOST', role: 'host', voice: 'Nova' }],
+    defaultModelProfile: {},
+    settings: { editorial: { avoidSensationalism: true } },
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }, {
+    id: 'show-2',
+    slug: 'other-show',
+    title: 'Other Show',
+    description: null,
+    setupStatus: 'active',
+    format: null,
+    defaultRuntimeMinutes: null,
+    cast: [],
+    defaultModelProfile: {},
+    settings: {},
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }];
+  sourceProfiles: SourceProfileRecord[] = [{
+    id: 'profile-1',
+    showId: 'show-1',
+    slug: 'ai-news',
+    name: 'AI News',
+    type: 'brave',
+    enabled: true,
+    weight: 1,
+    freshness: 'pd',
+    includeDomains: ['example.com'],
+    excludeDomains: [],
+    rateLimit: {},
+    config: {},
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }];
+  sourceQueries: SourceQueryRecord[] = [{
+    id: 'query-1',
+    sourceProfileId: 'profile-1',
+    query: 'AI policy product news',
+    enabled: true,
+    weight: 1,
+    region: null,
+    language: null,
+    freshness: 'pd',
+    includeDomains: ['example.com'],
+    excludeDomains: [],
+    config: {},
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }];
+  candidates: StoryCandidateRecord[] = [
+    this.candidate('candidate-1', 'show-1', 'New AI policy changes model release planning'),
+    this.candidate('candidate-2', 'show-1', 'Developers respond to model release policy'),
+    this.candidate('candidate-other-show', 'show-2', 'Unrelated show candidate'),
+  ];
+  modelProfiles: ModelProfileRecord[] = [this.modelProfile('episode_planner')];
+  jobs: JobRecord[] = [];
+  researchPacketsCreated = 0;
+  approvalsCreated = 0;
+
+  candidate(id: string, showId: string, title: string): StoryCandidateRecord {
+    return {
+      id,
+      showId,
+      sourceProfileId: showId === 'show-1' ? 'profile-1' : null,
+      sourceQueryId: showId === 'show-1' ? 'query-1' : null,
+      title,
+      url: `https://example.com/${id}`,
+      canonicalUrl: `https://example.com/${id}`,
+      sourceName: 'Example News',
+      author: null,
+      summary: `${title} with enough candidate context for planning.`,
+      publishedAt: new Date('2026-01-02T12:00:00Z'),
+      discoveredAt: new Date('2026-01-02T13:00:00Z'),
+      score: 82,
+      scoreBreakdown: {
+        rationale: 'High relevance and good source quality.',
+        sourceQuality: 78,
+      },
+      status: 'new',
+      rawPayload: { provider: 'test' },
+      metadata: { query: { text: 'AI policy product news' } },
+      createdAt: new Date('2026-01-02T13:00:00Z'),
+      updatedAt: new Date('2026-01-02T13:00:00Z'),
+    };
+  }
+
+  modelProfile(role: ModelRole): ModelProfileRecord {
+    return {
+      id: `model-${role}`,
+      showId: 'show-1',
+      role,
+      provider: 'openai',
+      model: 'planner-model',
+      temperature: 0.2,
+      maxTokens: 1200,
+      budgetUsd: null,
+      fallbacks: [],
+      promptTemplateKey: null,
+      config: {},
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+  }
+
+  async listShows() {
+    return this.shows;
+  }
+
+  async getStoryCandidate(id: string) {
+    return this.candidates.find((candidate) => candidate.id === id);
+  }
+
+  async getSourceProfile(id: string) {
+    return this.sourceProfiles.find((profile) => profile.id === id);
+  }
+
+  async getSourceQuery(id: string) {
+    return this.sourceQueries.find((query) => query.id === id);
+  }
+
+  async listModelProfiles(filter: ModelProfileListFilter = {}) {
+    return this.modelProfiles.filter((profile) => {
+      const showMatches = !filter.showId || profile.showId === filter.showId || (filter.includeGlobal && profile.showId === null);
+      const roleMatches = !filter.role || profile.role === filter.role;
+      return showMatches && roleMatches;
+    });
+  }
+
+  async getModelProfile(id: string) {
+    return this.modelProfiles.find((profile) => profile.id === id);
+  }
+
+  async createModelProfile(input: CreateModelProfileInput) {
+    const profile = {
+      ...input,
+      id: `model-${this.modelProfiles.length + 1}`,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    this.modelProfiles.push(profile);
+    return profile;
+  }
+
+  async updateModelProfile(id: string, input: UpdateModelProfileInput) {
+    const profile = await this.getModelProfile(id);
+
+    if (!profile) {
+      return undefined;
+    }
+
+    Object.assign(profile, input, { updatedAt: new Date('2026-01-03T00:00:00Z') });
+    return profile;
+  }
+
+  async createJob(input: CreateJobInput) {
+    const job: JobRecord = {
+      id: `job-${this.jobs.length + 1}`,
+      showId: input.showId,
+      episodeId: input.episodeId ?? null,
+      type: input.type,
+      status: input.status,
+      progress: input.progress,
+      attempts: input.attempts ?? 0,
+      maxAttempts: input.maxAttempts ?? 1,
+      input: input.input,
+      output: {},
+      logs: input.logs ?? [],
+      error: null,
+      lockedBy: null,
+      lockedAt: null,
+      startedAt: input.startedAt ?? null,
+      finishedAt: null,
+      createdAt: new Date('2026-01-03T00:00:00Z'),
+      updatedAt: new Date('2026-01-03T00:00:00Z'),
+    };
+    this.jobs.push(job);
+    return job;
+  }
+
+  async updateJob(id: string, input: UpdateJobInput) {
+    const job = this.jobs.find((candidate) => candidate.id === id);
+
+    if (!job) {
+      return undefined;
+    }
+
+    Object.assign(job, input, { updatedAt: new Date('2026-01-03T00:00:00Z') });
+    return job;
+  }
+}
+
+function plannerResult(request: LlmProviderRequest, mode: PlannerMode): LlmProviderResult {
+  if (request.attempt.role !== 'episode_planner') {
+    const text = JSON.stringify({ ok: true });
+    return { text, rawOutput: text };
+  }
+
+  if (mode === 'malformed') {
+    return { text: '{"proposedAngle":"Incomplete"}', rawOutput: '{"proposedAngle":"Incomplete"}' };
+  }
+
+  const text = JSON.stringify({
+    proposedAngle: 'The product story behind new AI policy pressure',
+    whyNow: 'The selected candidate records point to fresh policy and developer reaction this week.',
+    audienceRelevance: 'Listeners need to know what is verified before relying on the story.',
+    knownFacts: ['Two candidate stories were selected from Example News records.'],
+    unknownsSourceGaps: ['No primary company post or filing has been fetched yet.'],
+    questionsToAnswer: ['What did the primary source actually announce?'],
+    recommendedSources: [{
+      sourceType: 'primary company post',
+      rationale: 'Start with the origin of the claim before summarizing reaction.',
+      suggestedQuery: 'AI policy announcement primary source',
+      priority: 'high',
+    }],
+    warnings: [{
+      code: 'ADVISORY_ONLY',
+      severity: 'info',
+      message: 'Use this as planning guidance, not evidence.',
+    }],
+  });
+
+  return {
+    text,
+    rawOutput: text,
+    metadata: { adapter: 'test-planner' },
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    cost: { usd: 0, currency: 'USD' },
+  };
+}
+
+function buildPlanningApp(store: FakePlanningStore, mode: PlannerMode = 'valid') {
+  const app = Fastify();
+  const llmRuntime = createLlmRuntime({
+    adapters: [
+      createFakeLlmProvider({
+        provider: 'openai',
+        handler: (request) => plannerResult(request, mode),
+      }),
+    ],
+  });
+
+  registerEpisodePlanningRoutes(app, {
+    getStore() {
+      return store;
+    },
+    llmRuntime,
+  });
+
+  return app;
+}
+
+describe('episode planning routes', () => {
+  let store: FakePlanningStore;
+
+  beforeEach(() => {
+    store = new FakePlanningStore();
+  });
+
+  it('generates an advisory episode plan from selected candidates', async () => {
+    const app = buildPlanningApp(store);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/episode-plan',
+      payload: {
+        candidateIds: ['candidate-1', 'candidate-2', 'candidate-1'],
+        notes: 'Plan this before building research.',
+        targetFormat: 'feature-analysis',
+      },
+    });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(body.ok, true);
+    assert.equal(body.episodePlan.aiGenerated, true);
+    assert.equal(body.episodePlan.advisoryOnly, true);
+    assert.equal(body.episodePlan.evidenceStatus, 'not_verified_evidence');
+    assert.deepEqual(body.episodePlan.candidateIds, ['candidate-1', 'candidate-2']);
+    assert.deepEqual(body.episodePlan.duplicateCandidateIds, ['candidate-1']);
+    assert.equal(body.episodePlan.proposedAngle, 'The product story behind new AI policy pressure');
+    assert.equal(body.episodePlan.unknownsSourceGaps.length, 1);
+    assert.equal(body.job.type, 'episode.plan');
+    assert.equal(body.job.status, 'succeeded');
+    assert.equal(store.jobs[0].output.advisoryOnly, true);
+    await app.close();
+  });
+
+  it('fails clearly and records a failed job for malformed model output', async () => {
+    const app = buildPlanningApp(store, 'malformed');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/episode-plan',
+      payload: { candidateIds: ['candidate-1'] },
+    });
+    const body = response.json();
+
+    assert.equal(response.statusCode, 502);
+    assert.equal(body.ok, false);
+    assert.equal(body.code, 'EPISODE_PLAN_MODEL_OUTPUT_INVALID');
+    assert.equal(store.jobs.length, 1);
+    assert.equal(store.jobs[0].type, 'episode.plan');
+    assert.equal(store.jobs[0].status, 'failed');
+    assert.equal((store.jobs[0].output.failure as { code: string }).code, 'EPISODE_PLAN_MODEL_OUTPUT_INVALID');
+    await app.close();
+  });
+
+  it('rejects missing candidate IDs', async () => {
+    const app = buildPlanningApp(store);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/episode-plan',
+      payload: { candidateIds: ['missing-candidate'] },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.equal(response.json().code, 'STORY_CANDIDATE_NOT_FOUND');
+    assert.equal(store.jobs.length, 0);
+    await app.close();
+  });
+
+  it('rejects cross-show candidate selections', async () => {
+    const app = buildPlanningApp(store);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/story-candidates/episode-plan',
+      payload: { candidateIds: ['candidate-1', 'candidate-other-show'] },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, 'CANDIDATE_SHOW_MISMATCH');
+    assert.equal(store.jobs.length, 0);
+    await app.close();
+  });
+
+  it('does not create or approve research artifacts', async () => {
+    const app = buildPlanningApp(store);
+    await app.inject({
+      method: 'POST',
+      url: '/story-candidates/episode-plan',
+      payload: { candidateIds: ['candidate-1'] },
+    });
+
+    assert.equal(store.researchPacketsCreated, 0);
+    assert.equal(store.approvalsCreated, 0);
+    assert.equal(store.candidates.find((candidate) => candidate.id === 'candidate-1')?.status, 'new');
+    await app.close();
+  });
+});

--- a/packages/api/src/planning/routes.test.ts
+++ b/packages/api/src/planning/routes.test.ts
@@ -325,6 +325,7 @@ describe('episode planning routes', () => {
     assert.equal(store.jobs[0].type, 'episode.plan');
     assert.equal(store.jobs[0].status, 'failed');
     assert.equal((store.jobs[0].output.failure as { code: string }).code, 'EPISODE_PLAN_MODEL_OUTPUT_INVALID');
+    assert.equal((store.jobs[0].output.failure as { retryable: boolean }).retryable, false);
     await app.close();
   });
 

--- a/packages/api/src/planning/routes.ts
+++ b/packages/api/src/planning/routes.ts
@@ -1,0 +1,323 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { z, ZodError } from 'zod';
+
+import type { LlmRuntime } from '../llm/types.js';
+import { hasModelProfileStore, resolveModelProfile } from '../models/resolver.js';
+import type { ModelProfileStore } from '../models/store.js';
+import { createPromptRegistry } from '../prompts/registry.js';
+import type { PromptTemplateStore } from '../prompts/types.js';
+import type { CreateJobInput, JobRecord, SearchJobStore, StoryCandidateRecord, UpdateJobInput } from '../search/store.js';
+import type { ShowRecord, SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+import { buildEpisodePlan, EpisodePlanError } from './episode-plan.js';
+
+class ApiError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+export interface EpisodePlanningRoutesOptions {
+  getStore(): Partial<EpisodePlanningStore> & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<PromptTemplateStore>;
+  llmRuntime?: LlmRuntime;
+}
+
+interface EpisodePlanningStore {
+  listShows(): Promise<ShowRecord[]>;
+  getStoryCandidate(id: string): Promise<StoryCandidateRecord | undefined>;
+  getSourceProfile(id: string): Promise<SourceProfileRecord | undefined>;
+  getSourceQuery(id: string): Promise<SourceQueryRecord | undefined>;
+}
+
+const createEpisodePlanSchema = z.object({
+  candidateIds: z.array(z.string().trim().min(1)).min(1).max(20),
+  notes: z.string().trim().min(1).max(2_000).nullable().optional(),
+  targetFormat: z.string().trim().min(1).max(120).nullable().optional(),
+  targetRuntime: z.string().trim().min(1).max(120).nullable().optional(),
+});
+
+function sendError(reply: FastifyReply, error: unknown) {
+  if (error instanceof ZodError) {
+    return reply.code(400).send({
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      error: 'Request validation failed.',
+      errors: error.issues,
+    });
+  }
+
+  if (error instanceof ApiError || error instanceof EpisodePlanError) {
+    return reply.code(error.statusCode).send({
+      ok: false,
+      code: error.code,
+      error: error.message,
+      details: error.details,
+    });
+  }
+
+  throw error;
+}
+
+function requirePlanningStore(store: Partial<EpisodePlanningStore>): Pick<EpisodePlanningStore, 'listShows' | 'getStoryCandidate'> {
+  for (const method of ['listShows', 'getStoryCandidate'] as const) {
+    if (typeof store[method] !== 'function') {
+      throw new ApiError(503, 'EPISODE_PLANNING_STORE_UNAVAILABLE', `Planning store method is unavailable: ${method}`);
+    }
+  }
+
+  return store as Pick<EpisodePlanningStore, 'listShows' | 'getStoryCandidate'>;
+}
+
+function hasJobStore(store: object): store is Pick<SearchJobStore, 'createJob' | 'updateJob'> {
+  return (
+    'createJob' in store
+    && typeof store.createJob === 'function'
+    && 'updateJob' in store
+    && typeof store.updateJob === 'function'
+  );
+}
+
+function duplicatedValues(values: string[]): string[] {
+  const seen = new Set<string>();
+  const duplicated = new Set<string>();
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicated.add(value);
+    }
+
+    seen.add(value);
+  }
+
+  return [...duplicated];
+}
+
+async function selectedCandidates(store: Pick<EpisodePlanningStore, 'getStoryCandidate'>, candidateIds: string[]) {
+  const duplicateIds = duplicatedValues(candidateIds);
+  const uniqueIds = [...new Set(candidateIds)];
+  const candidates = await Promise.all(uniqueIds.map(async (id) => {
+    const candidate = await store.getStoryCandidate(id);
+
+    if (!candidate) {
+      throw new ApiError(404, 'STORY_CANDIDATE_NOT_FOUND', `Story candidate not found: ${id}`);
+    }
+
+    if (candidate.status === 'ignored') {
+      throw new ApiError(400, 'STORY_CANDIDATE_IGNORED', `Ignored story candidate cannot be used for episode planning: ${id}`);
+    }
+
+    return candidate;
+  }));
+  const showIds = new Set(candidates.map((candidate) => candidate.showId));
+
+  if (showIds.size > 1) {
+    throw new ApiError(400, 'CANDIDATE_SHOW_MISMATCH', 'All story candidates in an episode plan must belong to the same show.');
+  }
+
+  return { candidates, duplicateIds };
+}
+
+async function showForCandidates(store: Pick<EpisodePlanningStore, 'listShows'>, candidates: StoryCandidateRecord[]) {
+  const showId = candidates[0]?.showId;
+  const show = (await store.listShows()).find((candidate) => candidate.id === showId);
+
+  if (!show) {
+    throw new ApiError(404, 'SHOW_NOT_FOUND', `Show not found for selected candidates: ${showId}`);
+  }
+
+  return show;
+}
+
+async function sourceProfilesFor(
+  store: Partial<EpisodePlanningStore>,
+  candidates: StoryCandidateRecord[],
+): Promise<Map<string, SourceProfileRecord>> {
+  const profiles = new Map<string, SourceProfileRecord>();
+
+  if (typeof store.getSourceProfile !== 'function') {
+    return profiles;
+  }
+
+  for (const id of new Set(candidates.map((candidate) => candidate.sourceProfileId).filter((id): id is string => Boolean(id)))) {
+    const profile = await store.getSourceProfile(id);
+    if (profile) {
+      profiles.set(id, profile);
+    }
+  }
+
+  return profiles;
+}
+
+async function sourceQueriesFor(
+  store: Partial<EpisodePlanningStore>,
+  candidates: StoryCandidateRecord[],
+): Promise<Map<string, SourceQueryRecord>> {
+  const queries = new Map<string, SourceQueryRecord>();
+
+  if (typeof store.getSourceQuery !== 'function') {
+    return queries;
+  }
+
+  for (const id of new Set(candidates.map((candidate) => candidate.sourceQueryId).filter((id): id is string => Boolean(id)))) {
+    const query = await store.getSourceQuery(id);
+    if (query) {
+      queries.set(id, query);
+    }
+  }
+
+  return queries;
+}
+
+function log(level: 'info' | 'warn' | 'error', message: string, metadata: Record<string, unknown> = {}) {
+  return {
+    at: new Date().toISOString(),
+    level,
+    message,
+    ...metadata,
+  };
+}
+
+async function createPlanningJob(
+  store: Pick<SearchJobStore, 'createJob'>,
+  input: CreateJobInput,
+): Promise<JobRecord> {
+  return store.createJob(input);
+}
+
+async function updatePlanningJob(
+  store: Pick<SearchJobStore, 'updateJob'>,
+  id: string,
+  input: UpdateJobInput,
+): Promise<JobRecord | undefined> {
+  return store.updateJob(id, input);
+}
+
+function failurePayload(error: unknown): Record<string, unknown> {
+  const code = error instanceof ApiError || error instanceof EpisodePlanError ? error.code : 'EPISODE_PLAN_FAILED';
+
+  return {
+    failure: {
+      code,
+      message: error instanceof Error ? error.message : 'Episode planning failed.',
+      retryable: code !== 'STORY_CANDIDATE_NOT_FOUND' && code !== 'CANDIDATE_SHOW_MISMATCH',
+    },
+  };
+}
+
+export function registerEpisodePlanningRoutes(app: FastifyInstance, options: EpisodePlanningRoutesOptions) {
+  app.post('/story-candidates/episode-plan', async (request, reply) => {
+    let job: JobRecord | undefined;
+    let jobStore: Pick<SearchJobStore, 'createJob' | 'updateJob'> | undefined;
+    const logs: Array<Record<string, unknown>> = [];
+
+    try {
+      const body = createEpisodePlanSchema.parse(request.body ?? {});
+      const rawStore = options.getStore();
+      const store = requirePlanningStore(rawStore);
+      const selection = await selectedCandidates(store, body.candidateIds);
+      const candidates = selection.candidates;
+      const show = await showForCandidates(store, candidates);
+
+      if (!options.llmRuntime) {
+        throw new ApiError(409, 'EPISODE_PLANNER_RUNTIME_REQUIRED', 'Episode planning requires an LLM runtime.');
+      }
+
+      if (!hasModelProfileStore(rawStore)) {
+        throw new ApiError(409, 'EPISODE_PLANNER_MODEL_PROFILE_REQUIRED', 'No episode_planner model profile store is configured.');
+      }
+
+      const modelProfile = await resolveModelProfile(rawStore, { showId: show.id, role: 'episode_planner' });
+
+      if (!modelProfile) {
+        throw new ApiError(409, 'EPISODE_PLANNER_MODEL_PROFILE_REQUIRED', 'No episode_planner model profile is configured for this show.');
+      }
+
+      logs.push(log('info', 'Starting episode.plan job.', {
+        candidateIds: candidates.map((candidate) => candidate.id),
+        duplicateCandidateIds: selection.duplicateIds,
+        modelRole: modelProfile.role,
+      }));
+
+      if (hasJobStore(rawStore)) {
+        jobStore = rawStore;
+        job = await createPlanningJob(rawStore, {
+          showId: show.id,
+          type: 'episode.plan',
+          status: 'running',
+          progress: 0,
+          attempts: 1,
+          input: {
+            candidateIds: body.candidateIds,
+            selectedCandidateIds: candidates.map((candidate) => candidate.id),
+            duplicateCandidateIds: selection.duplicateIds,
+            notes: body.notes ?? null,
+            targetFormat: body.targetFormat ?? null,
+            targetRuntime: body.targetRuntime ?? null,
+            modelProfiles: { episode_planner: modelProfile },
+            advisoryOnly: true,
+          },
+          logs,
+          startedAt: new Date(),
+        });
+      }
+
+      const episodePlan = await buildEpisodePlan({
+        show,
+        candidates,
+        duplicateCandidateIds: selection.duplicateIds,
+        sourceProfiles: await sourceProfilesFor(rawStore as unknown as Partial<EpisodePlanningStore>, candidates),
+        sourceQueries: await sourceQueriesFor(rawStore as unknown as Partial<EpisodePlanningStore>, candidates),
+        modelProfile,
+        runtime: options.llmRuntime,
+        promptRegistry: createPromptRegistry({ store: rawStore as unknown as Partial<PromptTemplateStore> }),
+        notes: body.notes,
+        targetFormat: body.targetFormat,
+        targetRuntime: body.targetRuntime,
+      });
+
+      logs.push(log('info', 'Completed episode.plan job.', {
+        candidateIds: episodePlan.candidateIds,
+        warningCount: episodePlan.warnings.length,
+        advisoryOnly: true,
+      }));
+
+      if (jobStore && job) {
+        job = await updatePlanningJob(jobStore, job.id, {
+          status: 'succeeded',
+          progress: 100,
+          logs,
+          output: {
+            episodePlanId: episodePlan.id,
+            candidateIds: episodePlan.candidateIds,
+            duplicateCandidateIds: episodePlan.duplicateCandidateIds,
+            episodePlan,
+            warnings: episodePlan.warnings,
+            modelProfiles: { episode_planner: modelProfile },
+            advisoryOnly: true,
+          },
+          finishedAt: new Date(),
+        }) ?? job;
+      }
+
+      return reply.code(201).send({ ok: true, episodePlan, job });
+    } catch (error) {
+      if (jobStore && job) {
+        logs.push(log('error', error instanceof Error ? error.message : 'Episode planning failed.'));
+        job = await updatePlanningJob(jobStore, job.id, {
+          status: 'failed',
+          progress: job.progress,
+          logs,
+          error: error instanceof Error ? error.message : 'Episode planning failed.',
+          output: failurePayload(error),
+          finishedAt: new Date(),
+        }) ?? job;
+      }
+
+      return sendError(reply, error);
+    }
+  });
+}

--- a/packages/api/src/planning/routes.ts
+++ b/packages/api/src/planning/routes.ts
@@ -123,7 +123,7 @@ async function selectedCandidates(store: Pick<EpisodePlanningStore, 'getStoryCan
 
 async function showForCandidates(store: Pick<EpisodePlanningStore, 'listShows'>, candidates: StoryCandidateRecord[]) {
   const showId = candidates[0]?.showId;
-  const show = (await store.listShows()).find((candidate) => candidate.id === showId);
+  const show = (await store.listShows()).find((listedShow) => listedShow.id === showId);
 
   if (!show) {
     throw new ApiError(404, 'SHOW_NOT_FOUND', `Show not found for selected candidates: ${showId}`);
@@ -198,12 +198,14 @@ async function updatePlanningJob(
 
 function failurePayload(error: unknown): Record<string, unknown> {
   const code = error instanceof ApiError || error instanceof EpisodePlanError ? error.code : 'EPISODE_PLAN_FAILED';
+  const statusCode = error instanceof ApiError || error instanceof EpisodePlanError ? error.statusCode : 500;
+  const retryable = code !== 'EPISODE_PLAN_MODEL_OUTPUT_INVALID' && (statusCode < 400 || statusCode >= 500);
 
   return {
     failure: {
       code,
       message: error instanceof Error ? error.message : 'Episode planning failed.',
-      retryable: code !== 'STORY_CANDIDATE_NOT_FOUND' && code !== 'CANDIDATE_SHOW_MISMATCH',
+      retryable,
     },
   };
 }

--- a/packages/api/src/prompts/defaults.ts
+++ b/packages/api/src/prompts/defaults.ts
@@ -6,6 +6,7 @@ const baseVariables = {
   show_context: 'Show title, audience, format, voice/cast, runtime target, and editorial constraints.',
   source_profile: 'Source profile/query metadata that led to the candidate or packet.',
   candidate_json: 'Serialized story candidate with title, URL, source, summary, timestamps, and raw provider metadata.',
+  candidate_selection: 'Serialized selected candidate stories, source provenance, scoring signals, and optional editorial planning notes.',
   story_context: 'Serialized story/candidate context for the source being summarized.',
   source_document: 'Serialized fetched source document including id, URL, title, fetchedAt, and text content.',
   source_summary: 'Previously generated source summary for one document.',
@@ -57,6 +58,26 @@ function template(
 }
 
 export const DEFAULT_PROMPT_TEMPLATES: PromptTemplate[] = [
+  template(
+    'episode_planner',
+    'Default episode planner',
+    'Creates an advisory story brief and episode plan before research packet generation.',
+    [variable('show_context'), variable('candidate_selection')],
+    'episode_plan_result',
+    [
+      'You are an AI editorial planning assistant for an evidence-first podcast/news workflow.',
+      'Use only the selected candidate metadata and source provenance provided below. This is planning help, not verified evidence.',
+      'Do not claim that facts are confirmed unless the input already includes that source-backed status. Make uncertainty and source gaps explicit.',
+      'Recommend primary sources, independent corroboration, and concrete questions the research step should answer next.',
+      'Avoid sensationalism, invented citations, or instructions that bypass research, source approval, script review, integrity review, or publishing gates.',
+      '',
+      'Show context:',
+      '{{show_context}}',
+      '',
+      'Selected candidate stories and planning notes:',
+      '{{candidate_selection}}',
+    ].join('\n'),
+  ),
   template(
     'candidate_scorer',
     'Default candidate scorer',

--- a/packages/api/src/prompts/prompts.test.ts
+++ b/packages/api/src/prompts/prompts.test.ts
@@ -10,6 +10,7 @@ import { PromptRenderError, renderPromptTemplate } from './renderer.js';
 import { registerPromptRoutes } from './routes.js';
 import {
   candidateScoreResultSchema,
+  episodePlanResultSchema,
   extractedClaimsSchema,
   integrityReviewResultSchema,
 } from './schemas.js';
@@ -32,6 +33,14 @@ describe('prompt registry defaults', () => {
 
     assert.equal(template?.role, 'script_writer');
     assert.equal(template?.outputSchemaName, 'script_generation_result');
+  });
+
+  it('provides the default episode planner template', async () => {
+    const registry = createPromptRegistry();
+    const template = await registry.getTemplateByRole('episode_planner');
+
+    assert.equal(template?.key, 'episode_planner.default');
+    assert.equal(template?.outputSchemaName, 'episode_plan_result');
   });
 });
 
@@ -77,6 +86,35 @@ describe('prompt rendering', () => {
 });
 
 describe('prompt output schemas', () => {
+  it('validates episode plan output', () => {
+    const result = episodePlanResultSchema.parse({
+      proposedAngle: 'Why open model policy is becoming a product decision.',
+      whyNow: 'The candidate records indicate new policy and product activity this week.',
+      audienceRelevance: 'Listeners need to understand what to verify before treating the claim as settled.',
+      knownFacts: ['A candidate story was discovered from an AI policy source.'],
+      unknownsSourceGaps: ['No primary source has been fetched yet.'],
+      questionsToAnswer: ['Which organization made the announcement?'],
+      recommendedSources: [{
+        sourceType: 'primary company post',
+        rationale: 'The research brief should start with the source of the claim.',
+        suggestedQuery: 'company announcement model policy',
+        priority: 'high',
+      }],
+      warnings: [],
+    });
+
+    assert.equal(result.recommendedSources[0].priority, 'high');
+    assert.throws(() => episodePlanResultSchema.parse({
+      proposedAngle: 'Missing fields',
+      whyNow: 'Now',
+      audienceRelevance: 'Audience',
+      knownFacts: [],
+      unknownsSourceGaps: ['gap'],
+      questionsToAnswer: ['question'],
+      recommendedSources: [],
+    }), ZodError);
+  });
+
   it('validates candidate score output', () => {
     const result = candidateScoreResultSchema.parse({
       score: 82,

--- a/packages/api/src/prompts/prompts.test.ts
+++ b/packages/api/src/prompts/prompts.test.ts
@@ -104,14 +104,19 @@ describe('prompt output schemas', () => {
     });
 
     assert.equal(result.recommendedSources[0].priority, 'high');
+    const sparseResult = episodePlanResultSchema.parse({
+      proposedAngle: 'Sparse but valid advisory plan',
+      whyNow: 'Candidate metadata may still be incomplete.',
+      audienceRelevance: 'The planner should surface uncertainty without fabricating lists.',
+    });
+
+    assert.deepEqual(sparseResult.knownFacts, []);
+    assert.deepEqual(sparseResult.recommendedSources, []);
     assert.throws(() => episodePlanResultSchema.parse({
-      proposedAngle: 'Missing fields',
+      proposedAngle: 'Bad source',
       whyNow: 'Now',
       audienceRelevance: 'Audience',
-      knownFacts: [],
-      unknownsSourceGaps: ['gap'],
-      questionsToAnswer: ['question'],
-      recommendedSources: [],
+      recommendedSources: [{ sourceType: '', rationale: 'Missing source type' }],
     }), ZodError);
   });
 

--- a/packages/api/src/prompts/schemas.ts
+++ b/packages/api/src/prompts/schemas.ts
@@ -41,10 +41,10 @@ export const episodePlanResultSchema = z.object({
   proposedAngle: z.string().min(1),
   whyNow: z.string().min(1),
   audienceRelevance: z.string().min(1),
-  knownFacts: z.array(z.string().min(1)).min(1),
-  unknownsSourceGaps: z.array(z.string().min(1)).min(1),
-  questionsToAnswer: z.array(z.string().min(1)).min(1),
-  recommendedSources: z.array(recommendedSourceSchema).min(1),
+  knownFacts: z.array(z.string().min(1)).default([]),
+  unknownsSourceGaps: z.array(z.string().min(1)).default([]),
+  questionsToAnswer: z.array(z.string().min(1)).default([]),
+  recommendedSources: z.array(recommendedSourceSchema).default([]),
   warnings: z.array(warningSchema).default([]),
 }).strict();
 

--- a/packages/api/src/prompts/schemas.ts
+++ b/packages/api/src/prompts/schemas.ts
@@ -29,6 +29,25 @@ const scoreDimensionsSchema = z.object({
   urgency: z.number().min(0).max(100),
 }).strict();
 
+const recommendedSourceSchema = z.object({
+  sourceType: z.string().min(1),
+  rationale: z.string().min(1),
+  suggestedQuery: z.string().min(1).optional(),
+  url: z.string().url().optional(),
+  priority: z.enum(['low', 'medium', 'high']).default('medium'),
+}).strict();
+
+export const episodePlanResultSchema = z.object({
+  proposedAngle: z.string().min(1),
+  whyNow: z.string().min(1),
+  audienceRelevance: z.string().min(1),
+  knownFacts: z.array(z.string().min(1)).min(1),
+  unknownsSourceGaps: z.array(z.string().min(1)).min(1),
+  questionsToAnswer: z.array(z.string().min(1)).min(1),
+  recommendedSources: z.array(recommendedSourceSchema).min(1),
+  warnings: z.array(warningSchema).default([]),
+}).strict();
+
 export const candidateScoreResultSchema = z.object({
   score: z.number().min(0).max(100),
   verdict: z.enum(['ignore', 'watch', 'shortlist']),
@@ -163,6 +182,7 @@ export const coverPromptResultSchema = z.object({
 }).strict();
 
 export type CandidateScoreResult = z.infer<typeof candidateScoreResultSchema>;
+export type EpisodePlanResult = z.infer<typeof episodePlanResultSchema>;
 export type SourceSummaryResult = z.infer<typeof sourceSummarySchema>;
 export type ExtractedClaimsResult = z.infer<typeof extractedClaimsSchema>;
 export type ResearchSynthesisResult = z.infer<typeof researchSynthesisSchema>;
@@ -183,6 +203,21 @@ function jsonSchemaHint(name: PromptOutputSchemaName, properties: Record<string,
 }
 
 export const PROMPT_OUTPUT_SCHEMAS: Record<PromptOutputSchemaName, PromptOutputSchemaDefinition> = {
+  episode_plan_result: {
+    name: 'episode_plan_result',
+    description: 'Advisory AI episode/story plan for selected candidate stories before research.',
+    schemaHint: jsonSchemaHint('episode_plan_result', {
+      proposedAngle: { type: 'string' },
+      whyNow: { type: 'string' },
+      audienceRelevance: { type: 'string' },
+      knownFacts: { type: 'array', items: { type: 'string' } },
+      unknownsSourceGaps: { type: 'array', items: { type: 'string' } },
+      questionsToAnswer: { type: 'array', items: { type: 'string' } },
+      recommendedSources: { type: 'array' },
+      warnings: { type: 'array' },
+    }, ['proposedAngle', 'whyNow', 'audienceRelevance', 'knownFacts', 'unknownsSourceGaps', 'questionsToAnswer', 'recommendedSources']),
+    validate: episodePlanResultSchema.parse,
+  },
   candidate_score_result: {
     name: 'candidate_score_result',
     description: 'Scores one story candidate for editorial fit and source quality.',

--- a/packages/api/src/prompts/types.ts
+++ b/packages/api/src/prompts/types.ts
@@ -52,6 +52,7 @@ export interface PromptRegistry {
 }
 
 export type PromptOutputSchemaName =
+  | 'episode_plan_result'
   | 'candidate_score_result'
   | 'source_summary'
   | 'extracted_claims'

--- a/packages/api/src/shows/routes.test.ts
+++ b/packages/api/src/shows/routes.test.ts
@@ -281,7 +281,7 @@ describe('show onboarding routes', () => {
     assert.equal(body.feed.publicFeedUrl, 'https://podcast.example.com/future-signals/feed.xml');
     assert.equal(body.sourceProfile.type, 'brave');
     assert.equal(body.sourceQueries[0].query, 'technology policy news');
-    assert.equal(body.modelProfiles.length, 9);
+    assert.equal(body.modelProfiles.length, 10);
     assert.ok(body.show.defaultModelProfile.script_writer);
 
     const showsResponse = await app.inject({ method: 'GET', url: '/shows' });
@@ -293,6 +293,7 @@ describe('show onboarding routes', () => {
     const modelsResponse = await app.inject({ method: 'GET', url: '/model-profiles?showSlug=future-signals' });
     const roles = modelsResponse.json().modelProfiles.map((profile: { role: ModelRole }) => profile.role);
     assert.ok(roles.includes('script_writer'));
+    assert.ok(roles.includes('episode_planner'));
     assert.ok(roles.includes('integrity_reviewer'));
     assert.ok(roles.includes('candidate_scorer'));
   });

--- a/packages/api/src/shows/routes.test.ts
+++ b/packages/api/src/shows/routes.test.ts
@@ -281,7 +281,6 @@ describe('show onboarding routes', () => {
     assert.equal(body.feed.publicFeedUrl, 'https://podcast.example.com/future-signals/feed.xml');
     assert.equal(body.sourceProfile.type, 'brave');
     assert.equal(body.sourceQueries[0].query, 'technology policy news');
-    assert.equal(body.modelProfiles.length, 10);
     assert.ok(body.show.defaultModelProfile.script_writer);
 
     const showsResponse = await app.inject({ method: 'GET', url: '/shows' });

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -135,6 +135,7 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
   scripts: ScriptRecord[] = [];
   scriptRevisions: ScriptRevisionRecord[] = [];
   modelProfiles: ModelProfileRecord[] = [
+    this.modelProfileRecord('episode_planner', 'openai', 'gpt-5.5'),
     this.modelProfileRecord('candidate_scorer', 'google-vertex', 'gemini-2.5-flash'),
     this.modelProfileRecord('source_summarizer', 'google-vertex', 'gemini-2.5-flash'),
     this.modelProfileRecord('claim_extractor', 'google-vertex', 'gemini-2.5-flash'),


### PR DESCRIPTION
Closes #47

## Summary
- add an episode_planner role, default prompt, and structured episode_plan_result schema
- add POST /story-candidates/episode-plan with fake-runtime test coverage for success, validation, malformed model output, cross-show rejection, and non-bypass behavior
- surface advisory episode plan output in the static guided workflow UI without creating research/approval artifacts
- update HANDOFF sprint status for merged PF2 tickets and active #47

## Verification
- npm run check

## Notes
- Static HTML/vanilla JS/plain CSS only; no frontend framework/build pipeline added.
- The plan is explicitly advisory AI assistance and does not bypass research, approval, integrity review, or publishing gates.