### PR TITLE
Add claim coverage review surfacing

### DIFF
--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -781,6 +781,39 @@ textarea {
   gap: 0.5rem;
 }
 
+.coverage-panel {
+  background: white;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.75rem;
+}
+
+.coverage-panel.blocking {
+  border-color: #e2c391;
+}
+
+.coverage-panel.needs_attention {
+  border-color: #d8cf73;
+}
+
+.coverage-panel.covered {
+  border-color: #9ac8aa;
+}
+
+.coverage-panel-heading {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.coverage-panel-heading h4,
+.coverage-panel p {
+  margin: 0;
+}
+
 .review-list-item,
 .checklist-item,
 .asset-preview {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -894,8 +894,8 @@ function renderCoverageSummary(summary) {
 
   section.append(
     reviewList('Blocking coverage findings', asArray(summary.blockers), 'No blocking coverage findings recorded.', coverageFindingText),
-    reviewList('Needs attention', asArray(summary.needsAttention).slice(0, 8), 'No weak, stale, single-source, missing-primary, or uncertain coverage warnings recorded.', coverageFindingText),
-    reviewList('Covered claims', asArray(summary.coveredClaims).slice(0, 6), 'No claims are marked fully covered by current metadata.', coverageClaimText),
+    reviewList('Needs attention', asArray(summary.needsAttention), 'No weak, stale, single-source, missing-primary, or uncertain coverage warnings recorded.', coverageFindingText),
+    reviewList('Covered claims', asArray(summary.coveredClaims), 'No claims are marked fully covered by current metadata.', coverageClaimText),
   );
 
   if (asArray(summary.unknowns).length > 0) {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -898,8 +898,9 @@ function renderCoverageSummary(summary) {
     reviewList('Covered claims', asArray(summary.coveredClaims), 'No claims are marked fully covered by current metadata.', coverageClaimText),
   );
 
-  if (asArray(summary.unknowns).length > 0) {
-    section.append(reviewList('Coverage unknowns', summary.unknowns, 'Coverage can be derived from current metadata.', coverageFindingText));
+  const unknowns = asArray(summary.unknowns);
+  if (unknowns.length > 0) {
+    section.append(reviewList('Coverage unknowns', unknowns, 'No unknown coverage gaps recorded.', coverageFindingText));
   }
 
   return section;

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -18,6 +18,7 @@ const state = {
   selectedScript: null,
   selectedRevision: null,
   selectedRevisions: [],
+  selectedCoverageSummary: null,
   production: {
     episode: null,
     assets: [],
@@ -837,6 +838,73 @@ function integrityIssueText(item) {
   return `${excerpt}${severity}${item.issue || item.message || item.code || JSON.stringify(sanitizedDebug(item))}${fix}`;
 }
 
+function coverageStatusLabel(status) {
+  const labels = {
+    blocking: 'Blocking',
+    needs_attention: 'Needs attention',
+    covered: 'Covered',
+    unknown: 'Coverage unknown',
+  };
+  return labels[status] || 'Coverage unknown';
+}
+
+function coverageFindingText(item) {
+  const claim = item.claimId ? `Claim ${item.claimId}: ` : '';
+  const context = item.context || item.line ? ` | Context: ${item.context || item.line}` : '';
+  const next = item.nextAction ? ` | Next: ${item.nextAction}` : '';
+  return `${claim}${item.message || item.code || 'Coverage finding requires review.'}${context}${next}`;
+}
+
+function coverageClaimText(item) {
+  const sourceCount = item.independentSourceCount === null || item.independentSourceCount === undefined
+    ? 'independent sources unknown'
+    : `${item.independentSourceCount} independent source${item.independentSourceCount === 1 ? '' : 's'}`;
+  const mapped = item.citedInScript ? 'mapped to script' : 'not mapped to script';
+  return `${coverageStatusLabel(item.status)}: ${item.text || item.claimId} | ${sourceCount} | ${mapped}`;
+}
+
+function renderCoverageSummary(summary) {
+  const section = document.createElement('section');
+  section.className = `coverage-panel ${summary?.status || 'unknown'}`;
+
+  const header = document.createElement('div');
+  header.className = 'coverage-panel-heading';
+  const title = document.createElement('h4');
+  title.textContent = 'Claim/source coverage';
+  const pill = document.createElement('span');
+  pill.className = `status-pill ${summary?.status === 'blocking' ? 'blocked' : summary?.status === 'covered' ? 'done' : summary?.status === 'needs_attention' ? 'needs-review' : 'neutral'}`;
+  pill.textContent = coverageStatusLabel(summary?.status);
+  header.append(title, pill);
+
+  const headline = document.createElement('p');
+  headline.textContent = summary?.headline || 'Coverage unknown from current metadata; verify claims manually before approval.';
+  section.append(header, headline);
+
+  if (!summary) {
+    return section;
+  }
+
+  const counts = asObject(summary.counts);
+  section.append(reviewFacts([
+    ['Claims covered', `${counts.covered ?? 0} of ${counts.totalClaims ?? 0}`],
+    ['Need attention', counts.needsAttention ?? 0],
+    ['Blocking findings', counts.blockingFindings ?? 0],
+    ['Integrity findings', counts.integrityFindings ?? 0],
+  ]));
+
+  section.append(
+    reviewList('Blocking coverage findings', asArray(summary.blockers), 'No blocking coverage findings recorded.', coverageFindingText),
+    reviewList('Needs attention', asArray(summary.needsAttention).slice(0, 8), 'No weak, stale, single-source, missing-primary, or uncertain coverage warnings recorded.', coverageFindingText),
+    reviewList('Covered claims', asArray(summary.coveredClaims).slice(0, 6), 'No claims are marked fully covered by current metadata.', coverageClaimText),
+  );
+
+  if (asArray(summary.unknowns).length > 0) {
+    section.append(reviewList('Coverage unknowns', summary.unknowns, 'Coverage can be derived from current metadata.', coverageFindingText));
+  }
+
+  return section;
+}
+
 function publishChecklistState() {
   const packet = selectedResearchPacket();
   const script = state.selectedScript;
@@ -991,6 +1059,7 @@ function clearPipelineSelections() {
   state.selectedScript = null;
   state.selectedRevision = null;
   state.selectedRevisions = [];
+  state.selectedCoverageSummary = null;
   state.selectedEpisodeId = '';
   state.selectedAssetIds = [];
   state.production = { episode: null, assets: [], jobs: [] };
@@ -3489,6 +3558,7 @@ function renderScriptReview() {
       ['Citation/provenance warning items', provenanceValidation.valid === false ? 'failed' : `${warningItems.length} warning(s)`],
       ['Revision history', `${state.selectedRevisions.length || 1} revision${(state.selectedRevisions.length || 1) === 1 ? '' : 's'}`],
     ]),
+    renderCoverageSummary(state.selectedCoverageSummary),
     ...(provenanceState.stale ? [actionBlockerNote(provenanceState.message, false)] : []),
     reviewList('Integrity review issues', integrityIssues, integrity.status === 'missing' ? 'Run the integrity reviewer before production.' : 'No unresolved integrity issues recorded.', integrityIssueText),
     integrity.override ? reviewList('Integrity override', [integrity.override], 'No override recorded.', (item) => `${item.actor || 'editor'} | ${item.reason} | ${formatTime(item.overriddenAt)}`) : settingsEmpty('No integrity override recorded.'),
@@ -3749,6 +3819,7 @@ async function loadScripts() {
     state.selectedScript = null;
     state.selectedRevision = null;
     state.selectedRevisions = [];
+    state.selectedCoverageSummary = null;
     return;
   }
 
@@ -3765,6 +3836,7 @@ async function loadScripts() {
     state.selectedScript = null;
     state.selectedRevision = null;
     state.selectedRevisions = [];
+    state.selectedCoverageSummary = null;
     state.production = { episode: null, assets: [], jobs: [] };
   }
 }
@@ -3974,6 +4046,10 @@ async function loadScript(id) {
   state.selectedScript = body.script;
   state.selectedRevision = body.latestRevision || null;
   state.selectedRevisions = body.revisions || [];
+  state.selectedCoverageSummary = body.coverageSummary || null;
+  if (body.script?.researchPacketId && state.researchPackets.some((packet) => packet.id === body.script.researchPacketId)) {
+    state.selectedResearchPacketId = body.script.researchPacketId;
+  }
   await loadProduction();
 }
 
@@ -4346,6 +4422,7 @@ async function loadAll() {
       state.selectedScript = null;
       state.selectedRevision = null;
       state.selectedRevisions = [];
+      state.selectedCoverageSummary = null;
       state.production = { episode: null, assets: [], jobs: [] };
     });
     render();
@@ -4902,6 +4979,7 @@ async function generateScriptDraft(researchPacketId, format) {
     state.selectedScript = body.script;
     state.selectedRevision = body.revision;
     state.selectedRevisions = [body.revision];
+    state.selectedCoverageSummary = body.coverageSummary || null;
     state.selectedResearchPacketId = researchPacketId;
     state.production = { episode: null, assets: [], jobs: [] };
     els.scriptResearchPacketId.value = '';
@@ -4935,6 +5013,7 @@ async function saveScriptRevision(event) {
     state.selectedScript = body.script;
     state.selectedRevision = body.revision;
     state.selectedRevisions = [body.revision, ...state.selectedRevisions.filter((revision) => revision.id !== body.revision.id)];
+    state.selectedCoverageSummary = body.coverageSummary || null;
     await loadProduction();
     await loadJobs();
     render();
@@ -4962,6 +5041,7 @@ async function approveSelectedScript() {
     });
     state.scripts = state.scripts.map((script) => script.id === body.script.id ? body.script : script);
     state.selectedScript = body.script;
+    state.selectedCoverageSummary = body.coverageSummary || state.selectedCoverageSummary;
     await loadProduction();
     await loadJobs();
     savePipelineState();
@@ -4989,6 +5069,7 @@ async function runSelectedIntegrityReview() {
     });
     state.selectedRevision = body.revision;
     state.selectedRevisions = state.selectedRevisions.map((revision) => revision.id === body.revision.id ? body.revision : revision);
+    state.selectedCoverageSummary = body.coverageSummary || null;
     await loadProduction();
     await loadJobs();
     savePipelineState();
@@ -5025,6 +5106,7 @@ async function overrideSelectedIntegrityReview() {
     });
     state.selectedRevision = body.revision;
     state.selectedRevisions = state.selectedRevisions.map((revision) => revision.id === body.revision.id ? body.revision : revision);
+    state.selectedCoverageSummary = body.coverageSummary || null;
     await loadProduction();
     savePipelineState();
     render();

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -895,7 +895,7 @@ function renderCoverageSummary(summary) {
   section.append(
     reviewList('Blocking coverage findings', asArray(summary.blockers), 'No blocking coverage findings recorded.', coverageFindingText),
     reviewList('Needs attention', asArray(summary.needsAttention), 'No weak, stale, single-source, missing-primary, or uncertain coverage warnings recorded.', coverageFindingText),
-    reviewList('Covered claims', asArray(summary.coveredClaims), 'No claims are marked fully covered by current metadata.', coverageClaimText),
+    reviewList('Covered claims', asArray(summary.claims).filter((claim) => claim.status === 'covered'), 'No claims are marked fully covered by current metadata.', coverageClaimText),
   );
 
   const unknowns = asArray(summary.unknowns);
@@ -4047,7 +4047,7 @@ async function loadScript(id) {
   state.selectedScript = body.script;
   state.selectedRevision = body.latestRevision || null;
   state.selectedRevisions = body.revisions || [];
-  state.selectedCoverageSummary = body.coverageSummary || null;
+  state.selectedCoverageSummary = body.coverageSummary ?? null;
   if (body.script?.researchPacketId && state.researchPackets.some((packet) => packet.id === body.script.researchPacketId)) {
     state.selectedResearchPacketId = body.script.researchPacketId;
   }
@@ -4980,7 +4980,7 @@ async function generateScriptDraft(researchPacketId, format) {
     state.selectedScript = body.script;
     state.selectedRevision = body.revision;
     state.selectedRevisions = [body.revision];
-    state.selectedCoverageSummary = body.coverageSummary || null;
+    state.selectedCoverageSummary = body.coverageSummary ?? null;
     state.selectedResearchPacketId = researchPacketId;
     state.production = { episode: null, assets: [], jobs: [] };
     els.scriptResearchPacketId.value = '';
@@ -5014,7 +5014,7 @@ async function saveScriptRevision(event) {
     state.selectedScript = body.script;
     state.selectedRevision = body.revision;
     state.selectedRevisions = [body.revision, ...state.selectedRevisions.filter((revision) => revision.id !== body.revision.id)];
-    state.selectedCoverageSummary = body.coverageSummary || null;
+    state.selectedCoverageSummary = body.coverageSummary ?? null;
     await loadProduction();
     await loadJobs();
     render();
@@ -5042,7 +5042,7 @@ async function approveSelectedScript() {
     });
     state.scripts = state.scripts.map((script) => script.id === body.script.id ? body.script : script);
     state.selectedScript = body.script;
-    state.selectedCoverageSummary = body.coverageSummary || state.selectedCoverageSummary;
+    state.selectedCoverageSummary = body.coverageSummary ?? null;
     await loadProduction();
     await loadJobs();
     savePipelineState();
@@ -5070,7 +5070,7 @@ async function runSelectedIntegrityReview() {
     });
     state.selectedRevision = body.revision;
     state.selectedRevisions = state.selectedRevisions.map((revision) => revision.id === body.revision.id ? body.revision : revision);
-    state.selectedCoverageSummary = body.coverageSummary || null;
+    state.selectedCoverageSummary = body.coverageSummary ?? null;
     await loadProduction();
     await loadJobs();
     savePipelineState();
@@ -5107,7 +5107,7 @@ async function overrideSelectedIntegrityReview() {
     });
     state.selectedRevision = body.revision;
     state.selectedRevisions = state.selectedRevisions.map((revision) => revision.id === body.revision.id ? body.revision : revision);
-    state.selectedCoverageSummary = body.coverageSummary || null;
+    state.selectedCoverageSummary = body.coverageSummary ?? null;
     await loadProduction();
     savePipelineState();
     render();

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -52,6 +52,8 @@ describe('api config endpoints', () => {
     assert.match(response.body, /renderNextAction/);
     assert.match(response.body, /checklistBlockers/);
     assert.match(response.body, /scrollToPanel/);
+    assert.match(response.body, /Claim\/source coverage/);
+    assert.match(response.body, /coverageStatusLabel/);
   });
 
   it('returns the bundled example config', async () => {

--- a/packages/api/src/scripts/coverage.test.ts
+++ b/packages/api/src/scripts/coverage.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { ResearchPacketRecord } from '../research/store.js';
+import type { ScriptRevisionRecord } from './store.js';
+import { buildClaimCoverageSummary } from './coverage.js';
+
+function packet(overrides: Partial<ResearchPacketRecord> = {}): ResearchPacketRecord {
+  return {
+    id: 'packet-1',
+    showId: 'show-1',
+    episodeCandidateId: null,
+    title: 'Coverage test packet',
+    status: 'ready',
+    sourceDocumentIds: ['source-1', 'source-2'],
+    claims: [],
+    citations: [],
+    warnings: [],
+    content: { readiness: { status: 'ready' } },
+    approvedAt: null,
+    createdAt: new Date('2026-04-20T00:00:00Z'),
+    updatedAt: new Date('2026-04-20T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function revision(overrides: Partial<ScriptRevisionRecord> = {}): ScriptRevisionRecord {
+  return {
+    id: 'revision-1',
+    scriptId: 'script-1',
+    version: 1,
+    title: 'Coverage test script',
+    body: 'HOST: A sourced line.',
+    format: 'feature-analysis',
+    speakers: ['HOST'],
+    author: 'test',
+    changeSummary: null,
+    modelProfile: {},
+    metadata: {
+      citationMap: [],
+      validation: {
+        provenance: {
+          valid: true,
+          warnings: [],
+        },
+      },
+    },
+    createdAt: new Date('2026-04-20T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('claim coverage summary', () => {
+  it('surfaces weak and unsupported claim coverage with blocking integrity findings', () => {
+    const summary = buildClaimCoverageSummary(
+      packet({
+        claims: [{
+          id: 'claim-weak',
+          text: 'The investigation proves a high-stakes security breach.',
+          sourceDocumentIds: [],
+          citationUrls: [],
+          claimType: 'fact',
+          confidence: 'low',
+          supportLevel: 'single_source',
+          highStakes: true,
+        }],
+      }),
+      revision({
+        metadata: {
+          citationMap: [],
+          validation: { provenance: { valid: true, warnings: [] } },
+          integrityReview: {
+            status: 'fail',
+            result: {
+              claimIssues: [{
+                claimId: 'claim-weak',
+                scriptExcerpt: 'proves a high-stakes security breach',
+                issue: 'The script upgrades weak research into certainty.',
+                severity: 'critical',
+                suggestedFix: 'Soften the claim and fetch primary evidence.',
+              }],
+            },
+          },
+        },
+      }),
+      { now: new Date('2026-04-20T00:00:00Z') },
+    );
+
+    assert.equal(summary.status, 'blocking');
+    assert.equal(summary.counts.totalClaims, 1);
+    assert.ok(summary.blockers.some((item) => item.code === 'INTEGRITY_CLAIM_ISSUE'));
+    assert.ok(summary.needsAttention.some((item) => item.code === 'CLAIM_MISSING_CITATIONS'));
+    assert.ok(summary.needsAttention.some((item) => item.code === 'CLAIM_SINGLE_SOURCE'));
+    assert.ok(summary.needsAttention.some((item) => item.code === 'CLAIM_MISSING_PRIMARY_SOURCE'));
+    assert.match(summary.headline, /blocking coverage finding/);
+  });
+
+  it('marks corroborated cited claims covered when no blockers are present', () => {
+    const summary = buildClaimCoverageSummary(
+      packet({
+        claims: [{
+          id: 'claim-covered',
+          text: 'Two independent fetched sources support the product launch timing.',
+          sourceDocumentIds: ['source-1', 'source-2'],
+          citationUrls: ['https://primary.example/launch', 'https://independent.example/report'],
+          claimType: 'fact',
+          confidence: 'high',
+          supportLevel: 'corroborated',
+          highStakes: false,
+        }],
+        citations: [{
+          sourceDocumentId: 'source-1',
+          url: 'https://primary.example/launch',
+          title: 'Launch source',
+          fetchedAt: '2026-04-20T00:00:00.000Z',
+          status: 'fetched',
+        }, {
+          sourceDocumentId: 'source-2',
+          url: 'https://independent.example/report',
+          title: 'Independent source',
+          fetchedAt: '2026-04-20T00:00:00.000Z',
+          status: 'fetched',
+        }],
+      }),
+      revision({
+        metadata: {
+          citationMap: [{
+            line: 'HOST: Two independent sources support the product launch timing.',
+            claimId: 'claim-covered',
+            sourceDocumentIds: ['source-1', 'source-2'],
+          }],
+          validation: { provenance: { valid: true, warnings: [] } },
+          integrityReview: {
+            status: 'pass',
+            result: {
+              claimIssues: [],
+              missingCitations: [],
+              unsupportedCertainty: [],
+              attributionWarnings: [],
+              balanceWarnings: [],
+              biasSensationalismWarnings: [],
+            },
+          },
+        },
+      }),
+      { now: new Date('2026-04-20T00:00:00Z') },
+    );
+
+    assert.equal(summary.status, 'covered');
+    assert.equal(summary.counts.covered, 1);
+    assert.equal(summary.counts.blockingFindings, 0);
+    assert.equal(summary.counts.needsAttentionFindings, 0);
+    assert.equal(summary.claims[0]?.independentSourceCount, 2);
+    assert.match(summary.headline, /adequate citation coverage/);
+  });
+});

--- a/packages/api/src/scripts/coverage.test.ts
+++ b/packages/api/src/scripts/coverage.test.ts
@@ -140,6 +140,69 @@ describe('claim coverage summary', () => {
     assert.ok(summary.needsAttention.some((item) => item.code === 'SOURCE_FETCH_FAILED'));
   });
 
+  it('keeps overridden critical integrity issues visible without blocking coverage', () => {
+    const summary = buildClaimCoverageSummary(
+      packet({
+        claims: [{
+          id: 'claim-overridden-integrity',
+          text: 'A claim whose failed integrity review was explicitly overridden.',
+          sourceDocumentIds: ['source-1', 'source-2'],
+          citationUrls: ['https://primary.example/source', 'https://independent.example/source'],
+          claimType: 'fact',
+          confidence: 'high',
+          supportLevel: 'corroborated',
+          highStakes: true,
+        }],
+        citations: [{
+          sourceDocumentId: 'source-1',
+          url: 'https://primary.example/source',
+          title: 'Primary source',
+          fetchedAt: '2026-04-20T00:00:00.000Z',
+          status: 'fetched',
+        }, {
+          sourceDocumentId: 'source-2',
+          url: 'https://independent.example/source',
+          title: 'Independent source',
+          fetchedAt: '2026-04-20T00:00:00.000Z',
+          status: 'fetched',
+        }],
+      }),
+      revision({
+        metadata: {
+          citationMap: [{
+            line: 'HOST: A claim whose failed integrity review was explicitly overridden.',
+            claimId: 'claim-overridden-integrity',
+            sourceDocumentIds: ['source-1', 'source-2'],
+          }],
+          validation: { provenance: { valid: true, warnings: [] } },
+          integrityReview: {
+            status: 'fail',
+            override: {
+              actor: 'editor',
+              reason: 'Checked manually against primary source before production.',
+              overriddenAt: '2026-04-20T00:00:00.000Z',
+            },
+            result: {
+              claimIssues: [{
+                claimId: 'claim-overridden-integrity',
+                scriptExcerpt: 'failed integrity review was explicitly overridden',
+                issue: 'Critical issue accepted with manual verification.',
+                severity: 'critical',
+                suggestedFix: 'Confirm the override remains appropriate before publishing.',
+              }],
+            },
+          },
+        },
+      }),
+      { now: new Date('2026-04-20T00:00:00Z') },
+    );
+
+    assert.notEqual(summary.status, 'blocking');
+    assert.equal(summary.counts.blockingFindings, 0);
+    assert.ok(summary.needsAttention.some((item) => item.code === 'INTEGRITY_REVIEW_OVERRIDDEN'));
+    assert.ok(summary.needsAttention.some((item) => item.code === 'INTEGRITY_CLAIM_ISSUE'));
+  });
+
   it('deduplicates repeated provenance warnings from mirrored metadata fields', () => {
     const duplicatedWarning = {
       code: 'CITATION_MAP_STALE',

--- a/packages/api/src/scripts/coverage.test.ts
+++ b/packages/api/src/scripts/coverage.test.ts
@@ -140,6 +140,47 @@ describe('claim coverage summary', () => {
     assert.ok(summary.needsAttention.some((item) => item.code === 'SOURCE_FETCH_FAILED'));
   });
 
+  it('deduplicates repeated provenance warnings from mirrored metadata fields', () => {
+    const duplicatedWarning = {
+      code: 'CITATION_MAP_STALE',
+      message: 'Citation map should be refreshed after script edits.',
+      severity: 'warning',
+      sourceDocumentId: 'source-1',
+      metadata: { claimId: 'claim-duplicate' },
+    };
+    const summary = buildClaimCoverageSummary(
+      packet({
+        claims: [{
+          id: 'claim-duplicate',
+          text: 'A claim with duplicated provenance metadata.',
+          sourceDocumentIds: ['source-1', 'source-2'],
+          citationUrls: ['https://primary.example/source', 'https://independent.example/source'],
+          claimType: 'fact',
+          confidence: 'high',
+          supportLevel: 'corroborated',
+          highStakes: false,
+        }],
+      }),
+      revision({
+        metadata: {
+          warnings: [duplicatedWarning],
+          provenance: { warnings: [duplicatedWarning] },
+          citationMap: [{
+            line: 'HOST: A claim with duplicated provenance metadata.',
+            claimId: 'claim-duplicate',
+            sourceDocumentIds: ['source-1', 'source-2'],
+          }],
+          validation: { provenance: { valid: true, warnings: [duplicatedWarning] } },
+          integrityReview: { status: 'pass', result: { claimIssues: [] } },
+        },
+      }),
+      { now: new Date('2026-04-20T00:00:00Z') },
+    );
+
+    assert.equal(summary.needsAttention.filter((item) => item.code === 'CITATION_MAP_STALE').length, 1);
+    assert.equal(summary.counts.needsAttentionFindings, 1);
+  });
+
   it('reports unknown coverage before non-blocking attention findings', () => {
     const summary = buildClaimCoverageSummary(
       packet({

--- a/packages/api/src/scripts/coverage.test.ts
+++ b/packages/api/src/scripts/coverage.test.ts
@@ -244,6 +244,51 @@ describe('claim coverage summary', () => {
     assert.equal(summary.counts.needsAttentionFindings, 1);
   });
 
+  it('reports unknown coverage when citation map entries omit claim IDs', () => {
+    const summary = buildClaimCoverageSummary(
+      packet({
+        claims: [{
+          id: 'claim-line-only-map',
+          text: 'A claim mapped only by line-level citation metadata.',
+          sourceDocumentIds: ['source-1', 'source-2'],
+          citationUrls: ['https://primary.example/source', 'https://independent.example/source'],
+          claimType: 'fact',
+          confidence: 'high',
+          supportLevel: 'corroborated',
+          highStakes: false,
+        }],
+        citations: [{
+          sourceDocumentId: 'source-1',
+          url: 'https://primary.example/source',
+          title: 'Primary source',
+          fetchedAt: '2026-04-20T00:00:00.000Z',
+          status: 'fetched',
+        }, {
+          sourceDocumentId: 'source-2',
+          url: 'https://independent.example/source',
+          title: 'Independent source',
+          fetchedAt: '2026-04-20T00:00:00.000Z',
+          status: 'fetched',
+        }],
+      }),
+      revision({
+        metadata: {
+          citationMap: [{
+            line: 'HOST: A claim mapped only by line-level citation metadata.',
+            sourceDocumentIds: ['source-1', 'source-2'],
+          }],
+          validation: { provenance: { valid: true, warnings: [] } },
+          integrityReview: { status: 'pass', result: { claimIssues: [] } },
+        },
+      }),
+      { now: new Date('2026-04-20T00:00:00Z') },
+    );
+
+    assert.equal(summary.status, 'unknown');
+    assert.ok(summary.unknowns.some((item) => item.code === 'COVERAGE_UNKNOWN_CITATION_MAP_MISSING_CLAIM_IDS'));
+    assert.ok(!summary.needsAttention.some((item) => item.code === 'CLAIM_NOT_MAPPED_TO_SCRIPT'));
+  });
+
   it('reports unknown coverage before non-blocking attention findings', () => {
     const summary = buildClaimCoverageSummary(
       packet({

--- a/packages/api/src/scripts/coverage.test.ts
+++ b/packages/api/src/scripts/coverage.test.ts
@@ -91,7 +91,7 @@ describe('claim coverage summary', () => {
     assert.ok(summary.blockers.some((item) => item.code === 'INTEGRITY_CLAIM_ISSUE'));
     assert.ok(summary.needsAttention.some((item) => item.code === 'CLAIM_MISSING_CITATIONS'));
     assert.ok(summary.needsAttention.some((item) => item.code === 'CLAIM_SINGLE_SOURCE'));
-    assert.ok(summary.needsAttention.some((item) => item.code === 'CLAIM_MISSING_PRIMARY_SOURCE'));
+    assert.ok(summary.unknowns.some((item) => item.code === 'CLAIM_MISSING_PRIMARY_SOURCE'));
     assert.match(summary.headline, /blocking coverage finding/);
   });
 

--- a/packages/api/src/scripts/coverage.test.ts
+++ b/packages/api/src/scripts/coverage.test.ts
@@ -95,6 +95,80 @@ describe('claim coverage summary', () => {
     assert.match(summary.headline, /blocking coverage finding/);
   });
 
+  it('does not turn overridden claim-level research warnings into blocking coverage', () => {
+    const summary = buildClaimCoverageSummary(
+      packet({
+        claims: [{
+          id: 'claim-overridden',
+          text: 'A claim with a recorded editorial override.',
+          sourceDocumentIds: ['source-1', 'source-2'],
+          citationUrls: ['https://primary.example/source', 'https://independent.example/source'],
+          claimType: 'fact',
+          confidence: 'high',
+          supportLevel: 'corroborated',
+          highStakes: false,
+        }],
+        warnings: [{
+          id: 'warning-overridden',
+          code: 'SOURCE_FETCH_FAILED',
+          message: 'A related source failed before an editor approved the fallback evidence.',
+          severity: 'error',
+          sourceDocumentId: 'source-1',
+          override: {
+            actor: 'editor',
+            reason: 'Independent replacement source was verified.',
+            overriddenAt: '2026-04-20T00:00:00.000Z',
+          },
+        }],
+      }),
+      revision({
+        metadata: {
+          citationMap: [{
+            line: 'HOST: A claim with a recorded editorial override.',
+            claimId: 'claim-overridden',
+            sourceDocumentIds: ['source-1', 'source-2'],
+          }],
+          validation: { provenance: { valid: true, warnings: [] } },
+          integrityReview: { status: 'pass', result: { claimIssues: [] } },
+        },
+      }),
+      { now: new Date('2026-04-20T00:00:00Z') },
+    );
+
+    assert.equal(summary.status, 'needs_attention');
+    assert.equal(summary.counts.blockingFindings, 0);
+    assert.ok(summary.needsAttention.some((item) => item.code === 'SOURCE_FETCH_FAILED'));
+  });
+
+  it('reports unknown coverage before non-blocking attention findings', () => {
+    const summary = buildClaimCoverageSummary(
+      packet({
+        claims: [{
+          id: 'claim-unknown',
+          text: 'A claim whose citation map is missing.',
+          sourceDocumentIds: ['source-1'],
+          citationUrls: ['https://primary.example/source'],
+          claimType: 'fact',
+          confidence: 'high',
+          supportLevel: 'single_source',
+          highStakes: false,
+        }],
+      }),
+      revision({
+        metadata: {
+          citationMap: [],
+          validation: { provenance: { valid: true, warnings: [] } },
+          integrityReview: { status: 'pass', result: { claimIssues: [] } },
+        },
+      }),
+      { now: new Date('2026-04-20T00:00:00Z') },
+    );
+
+    assert.equal(summary.status, 'unknown');
+    assert.ok(summary.unknowns.some((item) => item.code === 'COVERAGE_UNKNOWN_NO_CITATION_MAP'));
+    assert.ok(summary.needsAttention.some((item) => item.code === 'CLAIM_SINGLE_SOURCE'));
+  });
+
   it('marks corroborated cited claims covered when no blockers are present', () => {
     const summary = buildClaimCoverageSummary(
       packet({

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -117,7 +117,9 @@ function warningMatchesClaim(warning: ResearchWarning, claim: ResearchClaim): bo
     || (warning.url ? claim.citationUrls.includes(warning.url) : false);
 }
 
-function citationMapEntries(revision: ScriptRevisionRecord): Array<{ claimId?: string; line?: string; sourceDocumentIds: string[] }> {
+type CitationMapEntry = { claimId?: string; line?: string; sourceDocumentIds: string[] };
+
+function citationMapEntries(revision: ScriptRevisionRecord): CitationMapEntry[] {
   return asRecordArray(revision.metadata.citationMap).map((entry) => ({
     claimId: asString(entry.claimId),
     line: asString(entry.line),
@@ -183,9 +185,13 @@ function claimWarningFinding(warning: ResearchWarning, claim: ResearchClaim): Cl
   });
 }
 
-function claimFindings(packet: ResearchPacketRecord, claim: ResearchClaim, revision: ScriptRevisionRecord, now: Date): ClaimCoverageFinding[] {
+function claimFindings(
+  packet: ResearchPacketRecord,
+  claim: ResearchClaim,
+  citationMap: CitationMapEntry[],
+  now: Date,
+): ClaimCoverageFinding[] {
   const findings: ClaimCoverageFinding[] = [];
-  const citationMap = citationMapEntries(revision);
   const citedEntries = citationMap.filter((entry) => entry.claimId === claim.id);
   const sourceCount = independentSourceCount(claim.citationUrls);
 
@@ -325,9 +331,14 @@ function itemStatus(findings: ClaimCoverageFinding[]): ClaimCoverageStatus {
   return 'covered';
 }
 
-function claimItem(packet: ResearchPacketRecord, claim: ResearchClaim, revision: ScriptRevisionRecord, now: Date): ClaimCoverageItem {
-  const entries = citationMapEntries(revision).filter((entry) => entry.claimId === claim.id);
-  const findings = claimFindings(packet, claim, revision, now);
+function claimItem(
+  packet: ResearchPacketRecord,
+  claim: ResearchClaim,
+  citationMap: CitationMapEntry[],
+  now: Date,
+): ClaimCoverageItem {
+  const entries = citationMap.filter((entry) => entry.claimId === claim.id);
+  const findings = claimFindings(packet, claim, citationMap, now);
 
   return {
     claimId: claim.id,
@@ -508,7 +519,7 @@ function integrityFindings(revision: ScriptRevisionRecord): ClaimCoverageFinding
   return findings;
 }
 
-function unknownFindings(packet: ResearchPacketRecord, revision: ScriptRevisionRecord): ClaimCoverageFinding[] {
+function unknownFindings(packet: ResearchPacketRecord, citationMap: CitationMapEntry[]): ClaimCoverageFinding[] {
   const findings: ClaimCoverageFinding[] = [];
 
   if (packet.claims.length === 0) {
@@ -522,7 +533,7 @@ function unknownFindings(packet: ResearchPacketRecord, revision: ScriptRevisionR
     }));
   }
 
-  if (citationMapEntries(revision).length === 0) {
+  if (citationMap.length === 0) {
     findings.push(finding({
       category: 'metadata',
       status: 'unknown',
@@ -558,13 +569,14 @@ export function buildClaimCoverageSummary(
   options: { now?: Date } = {},
 ): ClaimCoverageSummary {
   const now = options.now ?? new Date();
-  const claims = packet.claims.map((claim) => claimItem(packet, claim, revision, now));
+  const citationMap = citationMapEntries(revision);
+  const claims = packet.claims.map((claim) => claimItem(packet, claim, citationMap, now));
   const blockerFindings = [
     ...researchPacketFindings(packet),
     ...provenanceFindings(revision),
     ...integrityFindings(revision),
   ];
-  const metadataUnknowns = unknownFindings(packet, revision);
+  const metadataUnknowns = unknownFindings(packet, citationMap);
   const allFindings = [
     ...claims.flatMap((claim) => claim.findings),
     ...blockerFindings,

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -165,14 +165,16 @@ function staleCitationUrls(packet: ResearchPacketRecord, claim: ResearchClaim, n
 }
 
 function claimWarningFinding(warning: ResearchWarning, claim: ResearchClaim): ClaimCoverageFinding {
+  const overridden = Boolean(warning.override);
+
   return finding({
     category: 'research',
-    status: warning.severity === 'error' ? 'blocking' : 'needs_attention',
-    severity: warning.severity === 'error' ? 'blocking' : warning.severity === 'warning' ? 'warning' : 'info',
+    status: !overridden && warning.severity === 'error' ? 'blocking' : 'needs_attention',
+    severity: !overridden && warning.severity === 'error' ? 'blocking' : warning.severity === 'info' ? 'info' : 'warning',
     code: warning.code || 'RESEARCH_WARNING',
-    message: warning.message || 'Research warning is associated with this claim.',
-    nextAction: warning.override
-      ? 'Review the recorded override reason before relying on this claim.'
+    message: `${warning.message || 'Research warning is associated with this claim.'}${overridden ? ' An editorial override is recorded.' : ''}`,
+    nextAction: overridden
+      ? 'Review the recorded override reason before relying on this claim; it no longer blocks coverage status by itself.'
       : 'Resolve or record an editorial override for this research warning.',
     claimId: claim.id,
     claimText: claim.text,
@@ -353,11 +355,11 @@ function provenanceFindings(revision: ScriptRevisionRecord): ClaimCoverageFindin
   if (stale) {
     findings.push(finding({
       category: 'provenance',
-      status: 'blocking',
-      severity: 'blocking',
+      status: 'needs_attention',
+      severity: 'warning',
       code: 'STALE_SCRIPT_PROVENANCE',
       message: asString(status.message) ?? 'Script text changed; citation mapping and provenance are stale for this revision.',
-      nextAction: 'Rerun integrity review and rebuild or verify citation coverage before production.',
+      nextAction: 'Rerun integrity review and rebuild or verify citation coverage before production; enforced production gates remain the source of truth for hard blocks.',
     }));
   }
 
@@ -578,10 +580,10 @@ export function buildClaimCoverageSummary(
   };
   const status: ClaimCoverageStatus = blockers.length > 0
     ? 'blocking'
-    : needsAttention.length > 0
-      ? 'needs_attention'
-      : unknowns.length > 0 || claims.length === 0
-        ? 'unknown'
+    : unknowns.length > 0 || claims.length === 0
+      ? 'unknown'
+      : needsAttention.length > 0
+        ? 'needs_attention'
         : 'covered';
 
   return {

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -1,0 +1,597 @@
+import type { ResearchClaim, ResearchPacketRecord, ResearchWarning } from '../research/store.js';
+import { integrityGateState } from './integrity.js';
+import type { ScriptRevisionRecord } from './store.js';
+
+export type ClaimCoverageStatus = 'blocking' | 'needs_attention' | 'covered' | 'unknown';
+export type ClaimCoverageSeverity = 'blocking' | 'warning' | 'info';
+export type ClaimCoverageCategory = 'claim' | 'integrity' | 'provenance' | 'research' | 'metadata';
+
+export interface ClaimCoverageFinding {
+  category: ClaimCoverageCategory;
+  status: Exclude<ClaimCoverageStatus, 'covered'>;
+  severity: ClaimCoverageSeverity;
+  code: string;
+  message: string;
+  nextAction: string;
+  claimId?: string;
+  claimText?: string;
+  line?: string;
+  context?: string;
+  sourceDocumentIds?: string[];
+  citationUrls?: string[];
+}
+
+export interface ClaimCoverageItem {
+  claimId: string;
+  text: string;
+  status: ClaimCoverageStatus;
+  sourceDocumentIds: string[];
+  citationUrls: string[];
+  independentSourceCount: number | null;
+  supportLevel: ResearchClaim['supportLevel'] | 'unknown';
+  confidence: ResearchClaim['confidence'] | 'unknown';
+  claimType: ResearchClaim['claimType'] | 'unknown';
+  findings: ClaimCoverageFinding[];
+  citedInScript: boolean;
+  scriptLines: string[];
+}
+
+export interface ClaimCoverageSummary {
+  status: ClaimCoverageStatus;
+  headline: string;
+  counts: {
+    totalClaims: number;
+    covered: number;
+    needsAttention: number;
+    blocking: number;
+    unknown: number;
+    blockingFindings: number;
+    needsAttentionFindings: number;
+    integrityFindings: number;
+  };
+  blockers: ClaimCoverageFinding[];
+  needsAttention: ClaimCoverageFinding[];
+  unknowns: ClaimCoverageFinding[];
+  coveredClaims: ClaimCoverageItem[];
+  claims: ClaimCoverageItem[];
+}
+
+const STALE_CITATION_DAYS = 14;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+const WEAK_SUPPORT_LEVELS = new Set<ResearchClaim['supportLevel']>([
+  'single_source',
+  'uncorroborated',
+  'contradicted',
+  'unknown',
+]);
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && !Array.isArray(item)))
+    : [];
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+
+function hostnameFor(value: string): string | null {
+  try {
+    return new URL(value).hostname.replace(/^www\./i, '').toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function independentSourceCount(citationUrls: string[]): number | null {
+  if (citationUrls.length === 0) {
+    return null;
+  }
+
+  const hosts = new Set(citationUrls.map(hostnameFor).filter((host): host is string => Boolean(host)));
+  return hosts.size > 0 ? hosts.size : null;
+}
+
+function finding(input: ClaimCoverageFinding): ClaimCoverageFinding {
+  return {
+    ...input,
+    sourceDocumentIds: input.sourceDocumentIds ? [...new Set(input.sourceDocumentIds)] : undefined,
+    citationUrls: input.citationUrls ? [...new Set(input.citationUrls)] : undefined,
+  };
+}
+
+function warningMatchesClaim(warning: ResearchWarning, claim: ResearchClaim): boolean {
+  const metadata = asObject(warning.metadata);
+  const claimId = asString(metadata.claimId);
+
+  return claimId === claim.id
+    || (warning.sourceDocumentId ? claim.sourceDocumentIds.includes(warning.sourceDocumentId) : false)
+    || (warning.url ? claim.citationUrls.includes(warning.url) : false);
+}
+
+function citationMapEntries(revision: ScriptRevisionRecord): Array<{ claimId?: string; line?: string; sourceDocumentIds: string[] }> {
+  return asRecordArray(revision.metadata.citationMap).map((entry) => ({
+    claimId: asString(entry.claimId),
+    line: asString(entry.line),
+    sourceDocumentIds: asStringArray(entry.sourceDocumentIds),
+  }));
+}
+
+function sourceMetadataHasPrimary(claim: ResearchClaim): boolean | null {
+  const metadata = asObject((claim as ResearchClaim & { metadata?: unknown }).metadata);
+  const sourceTypes = [
+    metadata.sourceType,
+    metadata.primarySource,
+    metadata.hasPrimarySource,
+    (claim as ResearchClaim & { sourceType?: unknown }).sourceType,
+  ];
+
+  if (sourceTypes.some((value) => value === 'primary' || value === true)) {
+    return true;
+  }
+
+  return sourceTypes.some((value) => value !== undefined) ? false : null;
+}
+
+function staleCitationUrls(packet: ResearchPacketRecord, claim: ResearchClaim, now: Date): string[] {
+  const urls: string[] = [];
+  const claimSourceIds = new Set(claim.sourceDocumentIds);
+
+  for (const citation of packet.citations) {
+    if (!claimSourceIds.has(citation.sourceDocumentId)) {
+      continue;
+    }
+
+    const fetchedAt = Date.parse(citation.fetchedAt);
+    if (!Number.isFinite(fetchedAt)) {
+      continue;
+    }
+
+    const ageDays = (now.getTime() - fetchedAt) / MILLISECONDS_PER_DAY;
+    if (ageDays > STALE_CITATION_DAYS) {
+      urls.push(citation.url);
+    }
+  }
+
+  return [...new Set(urls)];
+}
+
+function claimWarningFinding(warning: ResearchWarning, claim: ResearchClaim): ClaimCoverageFinding {
+  return finding({
+    category: 'research',
+    status: warning.severity === 'error' ? 'blocking' : 'needs_attention',
+    severity: warning.severity === 'error' ? 'blocking' : warning.severity === 'warning' ? 'warning' : 'info',
+    code: warning.code || 'RESEARCH_WARNING',
+    message: warning.message || 'Research warning is associated with this claim.',
+    nextAction: warning.override
+      ? 'Review the recorded override reason before relying on this claim.'
+      : 'Resolve or record an editorial override for this research warning.',
+    claimId: claim.id,
+    claimText: claim.text,
+    sourceDocumentIds: claim.sourceDocumentIds,
+    citationUrls: claim.citationUrls,
+  });
+}
+
+function claimFindings(packet: ResearchPacketRecord, claim: ResearchClaim, revision: ScriptRevisionRecord, now: Date): ClaimCoverageFinding[] {
+  const findings: ClaimCoverageFinding[] = [];
+  const citationMap = citationMapEntries(revision);
+  const citedEntries = citationMap.filter((entry) => entry.claimId === claim.id);
+  const sourceCount = independentSourceCount(claim.citationUrls);
+
+  if (claim.sourceDocumentIds.length === 0 || claim.citationUrls.length === 0) {
+    findings.push(finding({
+      category: 'claim',
+      status: 'needs_attention',
+      severity: 'warning',
+      code: 'CLAIM_MISSING_CITATIONS',
+      message: 'This claim has no citation URL or fetched source snapshot in current metadata.',
+      nextAction: 'Fetch or attach source evidence before approving the script language.',
+      claimId: claim.id,
+      claimText: claim.text,
+      sourceDocumentIds: claim.sourceDocumentIds,
+      citationUrls: claim.citationUrls,
+    }));
+  }
+
+  if (sourceCount === null || sourceCount < 2) {
+    findings.push(finding({
+      category: 'claim',
+      status: 'needs_attention',
+      severity: 'warning',
+      code: 'CLAIM_SINGLE_SOURCE',
+      message: 'This claim is backed by fewer than two independent fetched source hosts.',
+      nextAction: 'Fetch an independent corroborating source or soften attribution in the script.',
+      claimId: claim.id,
+      claimText: claim.text,
+      sourceDocumentIds: claim.sourceDocumentIds,
+      citationUrls: claim.citationUrls,
+    }));
+  }
+
+  if (claim.supportLevel && WEAK_SUPPORT_LEVELS.has(claim.supportLevel)) {
+    findings.push(finding({
+      category: 'claim',
+      status: claim.supportLevel === 'contradicted' ? 'blocking' : 'needs_attention',
+      severity: claim.supportLevel === 'contradicted' ? 'blocking' : 'warning',
+      code: `CLAIM_SUPPORT_${claim.supportLevel.toUpperCase()}`,
+      message: `Research metadata marks this claim support level as ${claim.supportLevel.replace(/_/g, ' ')}.`,
+      nextAction: claim.supportLevel === 'contradicted'
+        ? 'Do not approve the claim until the contradiction is resolved or removed.'
+        : 'Add corroboration or make the claim attribution explicit.',
+      claimId: claim.id,
+      claimText: claim.text,
+      sourceDocumentIds: claim.sourceDocumentIds,
+      citationUrls: claim.citationUrls,
+    }));
+  }
+
+  if (claim.claimType === 'uncertain' || claim.confidence === 'low' || claim.caveat) {
+    findings.push(finding({
+      category: 'claim',
+      status: 'needs_attention',
+      severity: 'info',
+      code: 'CLAIM_UNCERTAIN',
+      message: claim.caveat || 'Research metadata marks this claim as uncertain or low confidence.',
+      nextAction: 'Keep uncertainty visible in the script and avoid definitive language.',
+      claimId: claim.id,
+      claimText: claim.text,
+      sourceDocumentIds: claim.sourceDocumentIds,
+      citationUrls: claim.citationUrls,
+    }));
+  }
+
+  if (claim.highStakes && sourceMetadataHasPrimary(claim) !== true) {
+    findings.push(finding({
+      category: 'claim',
+      status: 'needs_attention',
+      severity: 'warning',
+      code: 'CLAIM_MISSING_PRIMARY_SOURCE',
+      message: 'This high-stakes claim has no primary-source backing visible in current metadata.',
+      nextAction: 'Fetch a primary source or add an explicit editorial caveat before relying on the claim.',
+      claimId: claim.id,
+      claimText: claim.text,
+      sourceDocumentIds: claim.sourceDocumentIds,
+      citationUrls: claim.citationUrls,
+    }));
+  }
+
+  const staleUrls = staleCitationUrls(packet, claim, now);
+  if (staleUrls.length > 0) {
+    findings.push(finding({
+      category: 'claim',
+      status: 'needs_attention',
+      severity: 'warning',
+      code: 'CLAIM_STALE_EVIDENCE',
+      message: `This claim cites source snapshots older than ${STALE_CITATION_DAYS} days.`,
+      nextAction: 'Refresh the source snapshot or verify the claim still holds.',
+      claimId: claim.id,
+      claimText: claim.text,
+      sourceDocumentIds: claim.sourceDocumentIds,
+      citationUrls: staleUrls,
+    }));
+  }
+
+  if (citationMap.length > 0 && citedEntries.length === 0) {
+    findings.push(finding({
+      category: 'provenance',
+      status: 'needs_attention',
+      severity: 'warning',
+      code: 'CLAIM_NOT_MAPPED_TO_SCRIPT',
+      message: 'The script citation map does not point to this research claim.',
+      nextAction: 'Confirm whether the claim appears in the script or update the citation map.',
+      claimId: claim.id,
+      claimText: claim.text,
+      sourceDocumentIds: claim.sourceDocumentIds,
+      citationUrls: claim.citationUrls,
+    }));
+  }
+
+  for (const warning of packet.warnings.filter((item) => warningMatchesClaim(item, claim))) {
+    findings.push(claimWarningFinding(warning, claim));
+  }
+
+  return findings;
+}
+
+function itemStatus(findings: ClaimCoverageFinding[]): ClaimCoverageStatus {
+  if (findings.some((item) => item.status === 'blocking')) {
+    return 'blocking';
+  }
+
+  if (findings.some((item) => item.status === 'unknown')) {
+    return 'unknown';
+  }
+
+  if (findings.length > 0) {
+    return 'needs_attention';
+  }
+
+  return 'covered';
+}
+
+function claimItem(packet: ResearchPacketRecord, claim: ResearchClaim, revision: ScriptRevisionRecord, now: Date): ClaimCoverageItem {
+  const entries = citationMapEntries(revision).filter((entry) => entry.claimId === claim.id);
+  const findings = claimFindings(packet, claim, revision, now);
+
+  return {
+    claimId: claim.id,
+    text: claim.text,
+    status: itemStatus(findings),
+    sourceDocumentIds: [...new Set(claim.sourceDocumentIds)],
+    citationUrls: [...new Set(claim.citationUrls)],
+    independentSourceCount: independentSourceCount(claim.citationUrls),
+    supportLevel: claim.supportLevel ?? 'unknown',
+    confidence: claim.confidence ?? 'unknown',
+    claimType: claim.claimType ?? 'unknown',
+    findings,
+    citedInScript: entries.length > 0,
+    scriptLines: entries.map((entry) => entry.line).filter((line): line is string => Boolean(line)),
+  };
+}
+
+function provenanceFindings(revision: ScriptRevisionRecord): ClaimCoverageFinding[] {
+  const validation = asObject(revision.metadata.validation);
+  const provenance = asObject(validation.provenance);
+  const status = asObject(revision.metadata.provenanceStatus);
+  const stale = status.status === 'stale' || status.verified === false;
+  const warnings = [
+    ...asRecordArray(revision.metadata.warnings),
+    ...asRecordArray(asObject(revision.metadata.provenance).warnings),
+    ...asRecordArray(provenance.warnings),
+  ];
+  const findings: ClaimCoverageFinding[] = [];
+
+  if (stale) {
+    findings.push(finding({
+      category: 'provenance',
+      status: 'blocking',
+      severity: 'blocking',
+      code: 'STALE_SCRIPT_PROVENANCE',
+      message: asString(status.message) ?? 'Script text changed; citation mapping and provenance are stale for this revision.',
+      nextAction: 'Rerun integrity review and rebuild or verify citation coverage before production.',
+    }));
+  }
+
+  if (provenance.valid === false) {
+    findings.push(finding({
+      category: 'provenance',
+      status: 'blocking',
+      severity: 'blocking',
+      code: 'INVALID_SCRIPT_PROVENANCE',
+      message: 'Script provenance validation failed.',
+      nextAction: 'Resolve provenance validation errors before production.',
+    }));
+  }
+
+  for (const warning of warnings) {
+    const severity = asString(warning.severity);
+    findings.push(finding({
+      category: 'provenance',
+      status: severity === 'error' ? 'blocking' : 'needs_attention',
+      severity: severity === 'error' ? 'blocking' : severity === 'info' ? 'info' : 'warning',
+      code: asString(warning.code) ?? 'SCRIPT_PROVENANCE_WARNING',
+      message: asString(warning.message) ?? 'Script provenance warning requires review.',
+      nextAction: severity === 'error'
+        ? 'Resolve this provenance error before production.'
+        : 'Review this provenance warning before approving production.',
+      claimId: asString(asObject(warning.metadata).claimId),
+      sourceDocumentIds: asString(warning.sourceDocumentId) ? [asString(warning.sourceDocumentId)!] : undefined,
+    }));
+  }
+
+  return findings;
+}
+
+function researchPacketFindings(packet: ResearchPacketRecord): ClaimCoverageFinding[] {
+  const findings: ClaimCoverageFinding[] = [];
+  const readiness = asObject(packet.content.readiness);
+  const readinessStatus = asString(readiness.status) ?? packet.status;
+
+  if (packet.status === 'blocked' || readinessStatus === 'blocked') {
+    findings.push(finding({
+      category: 'research',
+      status: 'blocking',
+      severity: 'blocking',
+      code: 'RESEARCH_PACKET_BLOCKED',
+      message: 'The research brief is blocked by existing readiness metadata.',
+      nextAction: 'Resolve research blockers before relying on the script.',
+    }));
+  }
+
+  for (const warning of packet.warnings.filter((item) => !item.override)) {
+    const metadata = asObject(warning.metadata);
+    if (asString(metadata.claimId) || warning.sourceDocumentId || warning.url) {
+      continue;
+    }
+
+    findings.push(finding({
+      category: 'research',
+      status: warning.severity === 'error' ? 'blocking' : 'needs_attention',
+      severity: warning.severity === 'error' ? 'blocking' : warning.severity === 'warning' ? 'warning' : 'info',
+      code: warning.code || 'RESEARCH_WARNING',
+      message: warning.message || 'Research warning requires editorial review.',
+      nextAction: warning.severity === 'error'
+        ? 'Resolve or override this blocking research warning.'
+        : 'Review this research warning before approval.',
+      sourceDocumentIds: warning.sourceDocumentId ? [warning.sourceDocumentId] : undefined,
+      citationUrls: warning.url ? [warning.url] : undefined,
+    }));
+  }
+
+  return findings;
+}
+
+function integrityFindings(revision: ScriptRevisionRecord): ClaimCoverageFinding[] {
+  const integrity = integrityGateState(revision);
+  const findings: ClaimCoverageFinding[] = [];
+
+  if (integrity.status === 'missing') {
+    findings.push(finding({
+      category: 'integrity',
+      status: 'blocking',
+      severity: 'blocking',
+      code: 'INTEGRITY_REVIEW_REQUIRED',
+      message: 'Integrity review has not been run for this script revision.',
+      nextAction: 'Run the integrity reviewer before production.',
+    }));
+    return findings;
+  }
+
+  if (integrity.status === 'overridden') {
+    findings.push(finding({
+      category: 'integrity',
+      status: 'needs_attention',
+      severity: 'warning',
+      code: 'INTEGRITY_REVIEW_OVERRIDDEN',
+      message: 'A blocking integrity review was overridden with an editorial reason.',
+      nextAction: 'Review the override reason before publishing.',
+    }));
+  }
+
+  const review = asObject(integrity.review);
+  const result = asObject(review.result);
+  const issueGroups: Array<[string, Array<Record<string, unknown>>]> = [
+    ['INTEGRITY_CLAIM_ISSUE', asRecordArray(result.claimIssues)],
+    ['INTEGRITY_MISSING_CITATION', asRecordArray(result.missingCitations)],
+    ['INTEGRITY_UNSUPPORTED_CERTAINTY', asRecordArray(result.unsupportedCertainty)],
+    ['INTEGRITY_ATTRIBUTION_WARNING', asRecordArray(result.attributionWarnings)],
+    ['INTEGRITY_BALANCE_WARNING', asRecordArray(result.balanceWarnings)],
+    ['INTEGRITY_BIAS_SENSATIONALISM_WARNING', asRecordArray(result.biasSensationalismWarnings)],
+  ];
+
+  for (const [code, issues] of issueGroups) {
+    for (const issue of issues) {
+      const critical = asString(issue.severity) === 'critical';
+      findings.push(finding({
+        category: 'integrity',
+        status: critical || integrity.status === 'fail' ? 'blocking' : 'needs_attention',
+        severity: critical || integrity.status === 'fail' ? 'blocking' : asString(issue.severity) === 'info' ? 'info' : 'warning',
+        code,
+        message: asString(issue.issue) ?? asString(issue.message) ?? 'Integrity reviewer flagged this script language.',
+        nextAction: asString(issue.suggestedFix) ?? 'Resolve this finding or record an explicit editorial override.',
+        claimId: asString(issue.claimId),
+        line: asString(issue.scriptExcerpt),
+        context: asString(issue.scriptExcerpt),
+        sourceDocumentIds: asStringArray(issue.sourceDocumentIds),
+        citationUrls: asStringArray(issue.citationUrls),
+      }));
+    }
+  }
+
+  if (integrity.status === 'fail' && !findings.some((item) => item.status === 'blocking')) {
+    findings.push(finding({
+      category: 'integrity',
+      status: 'blocking',
+      severity: 'blocking',
+      code: 'INTEGRITY_REVIEW_FAILED',
+      message: 'Integrity review failed without claim-level details in current metadata.',
+      nextAction: 'Inspect the integrity review result, then fix the script or record an explicit override.',
+    }));
+  }
+
+  return findings;
+}
+
+function unknownFindings(packet: ResearchPacketRecord, revision: ScriptRevisionRecord): ClaimCoverageFinding[] {
+  const findings: ClaimCoverageFinding[] = [];
+
+  if (packet.claims.length === 0) {
+    findings.push(finding({
+      category: 'metadata',
+      status: 'unknown',
+      severity: 'info',
+      code: 'COVERAGE_UNKNOWN_NO_CLAIMS',
+      message: 'Coverage unknown from current metadata: the research brief has no extracted claims.',
+      nextAction: 'Review source snapshots manually or rebuild the research brief with claim extraction.',
+    }));
+  }
+
+  if (citationMapEntries(revision).length === 0) {
+    findings.push(finding({
+      category: 'metadata',
+      status: 'unknown',
+      severity: 'info',
+      code: 'COVERAGE_UNKNOWN_NO_CITATION_MAP',
+      message: 'Coverage unknown from current metadata: the script revision has no citation map.',
+      nextAction: 'Run or rerun script generation/integrity review to produce citation mapping.',
+    }));
+  }
+
+  return findings;
+}
+
+function headlineFor(status: ClaimCoverageStatus, counts: ClaimCoverageSummary['counts']): string {
+  if (status === 'blocking') {
+    return `${counts.blockingFindings} blocking coverage finding${counts.blockingFindings === 1 ? '' : 's'} must be resolved or explicitly overridden before production.`;
+  }
+
+  if (status === 'needs_attention') {
+    return `${counts.needsAttentionFindings} coverage finding${counts.needsAttentionFindings === 1 ? '' : 's'} need editorial attention before relying on this draft.`;
+  }
+
+  if (status === 'covered') {
+    return `${counts.covered} claim${counts.covered === 1 ? '' : 's'} have adequate citation coverage from current metadata.`;
+  }
+
+  return 'Coverage unknown from current metadata; verify claims manually before approval.';
+}
+
+export function buildClaimCoverageSummary(
+  packet: ResearchPacketRecord,
+  revision: ScriptRevisionRecord,
+  options: { now?: Date } = {},
+): ClaimCoverageSummary {
+  const now = options.now ?? new Date();
+  const claims = packet.claims.map((claim) => claimItem(packet, claim, revision, now));
+  const blockerFindings = [
+    ...researchPacketFindings(packet),
+    ...provenanceFindings(revision),
+    ...integrityFindings(revision),
+  ];
+  const unknowns = unknownFindings(packet, revision);
+  const allFindings = [
+    ...claims.flatMap((claim) => claim.findings),
+    ...blockerFindings,
+    ...unknowns,
+  ];
+  const blockers = allFindings.filter((item) => item.status === 'blocking');
+  const needsAttention = allFindings.filter((item) => item.status === 'needs_attention');
+  const coveredClaims = claims.filter((claim) => claim.status === 'covered');
+  const counts = {
+    totalClaims: claims.length,
+    covered: coveredClaims.length,
+    needsAttention: claims.filter((claim) => claim.status === 'needs_attention').length,
+    blocking: claims.filter((claim) => claim.status === 'blocking').length,
+    unknown: claims.filter((claim) => claim.status === 'unknown').length,
+    blockingFindings: blockers.length,
+    needsAttentionFindings: needsAttention.length,
+    integrityFindings: allFindings.filter((item) => item.category === 'integrity').length,
+  };
+  const status: ClaimCoverageStatus = blockers.length > 0
+    ? 'blocking'
+    : needsAttention.length > 0
+      ? 'needs_attention'
+      : unknowns.length > 0 || claims.length === 0
+        ? 'unknown'
+        : 'covered';
+
+  return {
+    status,
+    headline: headlineFor(status, counts),
+    counts,
+    blockers,
+    needsAttention,
+    unknowns,
+    coveredClaims,
+    claims,
+  };
+}

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -219,7 +219,7 @@ function claimFindings(packet: ResearchPacketRecord, claim: ResearchClaim, revis
     }));
   }
 
-  if (claim.supportLevel && WEAK_SUPPORT_LEVELS.has(claim.supportLevel)) {
+  if (claim.supportLevel && claim.supportLevel !== 'single_source' && WEAK_SUPPORT_LEVELS.has(claim.supportLevel)) {
     findings.push(finding({
       category: 'claim',
       status: claim.supportLevel === 'contradicted' ? 'blocking' : 'needs_attention',
@@ -251,14 +251,19 @@ function claimFindings(packet: ResearchPacketRecord, claim: ResearchClaim, revis
     }));
   }
 
-  if (claim.highStakes && sourceMetadataHasPrimary(claim) !== true) {
+  const hasPrimarySource = sourceMetadataHasPrimary(claim);
+  if (claim.highStakes && hasPrimarySource !== true) {
     findings.push(finding({
       category: 'claim',
-      status: 'needs_attention',
-      severity: 'warning',
+      status: hasPrimarySource === false ? 'needs_attention' : 'unknown',
+      severity: hasPrimarySource === false ? 'warning' : 'info',
       code: 'CLAIM_MISSING_PRIMARY_SOURCE',
-      message: 'This high-stakes claim has no primary-source backing visible in current metadata.',
-      nextAction: 'Fetch a primary source or add an explicit editorial caveat before relying on the claim.',
+      message: hasPrimarySource === false
+        ? 'This high-stakes claim has no primary-source backing visible in current metadata.'
+        : 'Primary-source coverage is unknown for this high-stakes claim from current metadata.',
+      nextAction: hasPrimarySource === false
+        ? 'Fetch a primary source or add an explicit editorial caveat before relying on the claim.'
+        : 'Verify primary-source backing manually or rebuild research metadata before relying on the claim.',
       claimId: claim.id,
       claimText: claim.text,
       sourceDocumentIds: claim.sourceDocumentIds,
@@ -537,11 +542,11 @@ function headlineFor(status: ClaimCoverageStatus, counts: ClaimCoverageSummary['
   }
 
   if (status === 'needs_attention') {
-    return `${counts.needsAttentionFindings} coverage finding${counts.needsAttentionFindings === 1 ? '' : 's'} need editorial attention before relying on this draft.`;
+    return `${counts.needsAttentionFindings} coverage finding${counts.needsAttentionFindings === 1 ? ' needs' : 's need'} editorial attention before relying on this draft.`;
   }
 
   if (status === 'covered') {
-    return `${counts.covered} claim${counts.covered === 1 ? '' : 's'} have adequate citation coverage from current metadata.`;
+    return `${counts.covered} claim${counts.covered === 1 ? ' has' : 's have'} adequate citation coverage from current metadata.`;
   }
 
   return 'Coverage unknown from current metadata; verify claims manually before approval.';
@@ -559,14 +564,15 @@ export function buildClaimCoverageSummary(
     ...provenanceFindings(revision),
     ...integrityFindings(revision),
   ];
-  const unknowns = unknownFindings(packet, revision);
+  const metadataUnknowns = unknownFindings(packet, revision);
   const allFindings = [
     ...claims.flatMap((claim) => claim.findings),
     ...blockerFindings,
-    ...unknowns,
+    ...metadataUnknowns,
   ];
   const blockers = allFindings.filter((item) => item.status === 'blocking');
   const needsAttention = allFindings.filter((item) => item.status === 'needs_attention');
+  const unknowns = allFindings.filter((item) => item.status === 'unknown');
   const coveredClaims = claims.filter((claim) => claim.status === 'covered');
   const counts = {
     totalClaims: claims.length,

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -107,6 +107,29 @@ function finding(input: ClaimCoverageFinding): ClaimCoverageFinding {
   };
 }
 
+function warningKey(warning: Record<string, unknown>): string {
+  const metadata = asObject(warning.metadata);
+  return [
+    asString(warning.code) ?? 'SCRIPT_PROVENANCE_WARNING',
+    asString(warning.sourceDocumentId) ?? asString(metadata.sourceDocumentId) ?? '',
+    asString(metadata.claimId) ?? '',
+    asString(warning.message) ?? 'Script provenance warning requires editorial attention.',
+  ].join('\u0000');
+}
+
+function uniqueWarnings(warnings: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const seen = new Set<string>();
+  return warnings.filter((warning) => {
+    const key = warningKey(warning);
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
 function warningMatchesClaim(warning: ResearchWarning, claim: ResearchClaim): boolean {
   const metadata = asObject(warning.metadata);
   const claimId = asString(metadata.claimId);
@@ -361,11 +384,11 @@ function provenanceFindings(revision: ScriptRevisionRecord): ClaimCoverageFindin
   const provenance = asObject(validation.provenance);
   const status = asObject(revision.metadata.provenanceStatus);
   const stale = status.status === 'stale' || status.verified === false;
-  const warnings = [
+  const warnings = uniqueWarnings([
     ...asRecordArray(revision.metadata.warnings),
     ...asRecordArray(asObject(revision.metadata.provenance).warnings),
     ...asRecordArray(provenance.warnings),
-  ];
+  ]);
   const findings: ClaimCoverageFinding[] = [];
 
   if (stale) {

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -52,7 +52,6 @@ export interface ClaimCoverageSummary {
   blockers: ClaimCoverageFinding[];
   needsAttention: ClaimCoverageFinding[];
   unknowns: ClaimCoverageFinding[];
-  coveredClaims: ClaimCoverageItem[];
   claims: ClaimCoverageItem[];
 }
 
@@ -193,6 +192,7 @@ function claimFindings(
 ): ClaimCoverageFinding[] {
   const findings: ClaimCoverageFinding[] = [];
   const citedEntries = citationMap.filter((entry) => entry.claimId === claim.id);
+  const citationMapHasClaimIds = citationMap.some((entry) => Boolean(entry.claimId));
   const sourceCount = independentSourceCount(claim.citationUrls);
 
   if (claim.sourceDocumentIds.length === 0 || claim.citationUrls.length === 0) {
@@ -293,7 +293,7 @@ function claimFindings(
     }));
   }
 
-  if (citationMap.length > 0 && citedEntries.length === 0) {
+  if (citationMapHasClaimIds && citedEntries.length === 0) {
     findings.push(finding({
       category: 'provenance',
       status: 'needs_attention',
@@ -585,10 +585,9 @@ export function buildClaimCoverageSummary(
   const blockers = allFindings.filter((item) => item.status === 'blocking');
   const needsAttention = allFindings.filter((item) => item.status === 'needs_attention');
   const unknowns = allFindings.filter((item) => item.status === 'unknown');
-  const coveredClaims = claims.filter((claim) => claim.status === 'covered');
   const counts = {
     totalClaims: claims.length,
-    covered: coveredClaims.length,
+    covered: claims.filter((claim) => claim.status === 'covered').length,
     needsAttention: claims.filter((claim) => claim.status === 'needs_attention').length,
     blocking: claims.filter((claim) => claim.status === 'blocking').length,
     unknown: claims.filter((claim) => claim.status === 'unknown').length,
@@ -611,7 +610,6 @@ export function buildClaimCoverageSummary(
     blockers,
     needsAttention,
     unknowns,
-    coveredClaims,
     claims,
   };
 }

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -512,10 +512,11 @@ function integrityFindings(revision: ScriptRevisionRecord): ClaimCoverageFinding
   for (const [code, issues] of issueGroups) {
     for (const issue of issues) {
       const critical = asString(issue.severity) === 'critical';
+      const blocking = integrity.status !== 'overridden' && (critical || integrity.status === 'fail');
       findings.push(finding({
         category: 'integrity',
-        status: critical || integrity.status === 'fail' ? 'blocking' : 'needs_attention',
-        severity: critical || integrity.status === 'fail' ? 'blocking' : asString(issue.severity) === 'info' ? 'info' : 'warning',
+        status: blocking ? 'blocking' : 'needs_attention',
+        severity: blocking ? 'blocking' : asString(issue.severity) === 'info' ? 'info' : 'warning',
         code,
         message: asString(issue.issue) ?? asString(issue.message) ?? 'Integrity reviewer flagged this script language.',
         nextAction: asString(issue.suggestedFix) ?? 'Resolve this finding or record an explicit editorial override.',

--- a/packages/api/src/scripts/coverage.ts
+++ b/packages/api/src/scripts/coverage.ts
@@ -566,6 +566,15 @@ function unknownFindings(packet: ResearchPacketRecord, citationMap: CitationMapE
       message: 'Coverage unknown from current metadata: the script revision has no citation map.',
       nextAction: 'Run or rerun script generation/integrity review to produce citation mapping.',
     }));
+  } else if (packet.claims.length > 0 && !citationMap.some((entry) => entry.claimId)) {
+    findings.push(finding({
+      category: 'metadata',
+      status: 'unknown',
+      severity: 'info',
+      code: 'COVERAGE_UNKNOWN_CITATION_MAP_MISSING_CLAIM_IDS',
+      message: 'Coverage unknown from current metadata: the citation map has script lines but no claim IDs.',
+      nextAction: 'Rerun integrity review or rebuild the citation map so claims can be matched to script lines.',
+    }));
   }
 
   return findings;

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -17,6 +17,7 @@ import {
   invalidSpeakerLabels,
   provenanceWarnings,
 } from './builder.js';
+import { buildClaimCoverageSummary } from './coverage.js';
 import { buildIntegrityReview } from './integrity.js';
 import type { ScriptStore } from './store.js';
 
@@ -153,6 +154,19 @@ function hasScriptJobStore(store: object): store is Pick<SearchJobStore, 'create
     && 'updateJob' in store
     && typeof store.updateJob === 'function'
   );
+}
+
+async function coverageSummaryFor(
+  store: Partial<ResearchStore>,
+  script: { researchPacketId: string },
+  revision: Parameters<typeof buildClaimCoverageSummary>[1] | undefined,
+) {
+  if (!revision || typeof store.getResearchPacket !== 'function') {
+    return null;
+  }
+
+  const packet = await store.getResearchPacket(script.researchPacketId);
+  return packet ? buildClaimCoverageSummary(packet, revision) : null;
 }
 
 function log(level: 'info' | 'warn' | 'error', message: string, metadata: Record<string, unknown> = {}) {
@@ -360,6 +374,7 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
           metadata: draft.metadata,
         },
       });
+      const coverageSummary = buildClaimCoverageSummary(packet, result.revision);
 
       logs.push(log('info', 'Completed script.generate job.', {
         scriptId: result.script.id,
@@ -384,7 +399,7 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         }) ?? job;
       }
 
-      return reply.code(201).send({ ok: true, job, script: result.script, revision: result.revision });
+      return reply.code(201).send({ ok: true, job, script: result.script, revision: result.revision, coverageSummary });
     } catch (error) {
       if (jobStore && job) {
         const message = error instanceof Error ? error.message : 'Script generation failed.';
@@ -420,7 +435,8 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
 
   app.get<{ Params: { id: string } }>('/scripts/:id', async (request, reply) => {
     try {
-      const scriptStore = requireScriptStore(options.getStore());
+      const rawStore = options.getStore();
+      const scriptStore = requireScriptStore(rawStore);
       const script = await scriptStore.getScript(request.params.id);
 
       if (!script) {
@@ -428,7 +444,9 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
       }
 
       const revisions = await scriptStore.listScriptRevisions(script.id);
-      return { ok: true, script, revisions, latestRevision: revisions[0] };
+      const latestRevision = revisions[0];
+      const coverageSummary = await coverageSummaryFor(rawStore, script, latestRevision);
+      return { ok: true, script, revisions, latestRevision, coverageSummary };
     } catch (error) {
       return sendError(reply, error);
     }
@@ -489,7 +507,8 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         throw new ApiError(404, 'SCRIPT_NOT_FOUND', `Script not found: ${request.params.id}`);
       }
 
-      return reply.code(201).send({ ok: true, script: result.script, revision: result.revision });
+      const coverageSummary = buildClaimCoverageSummary(packet, result.revision);
+      return reply.code(201).send({ ok: true, script: result.script, revision: result.revision, coverageSummary });
     } catch (error) {
       return sendError(reply, error);
     }
@@ -545,7 +564,8 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         throw new ApiError(404, 'SCRIPT_REVISION_NOT_FOUND', `Script revision not found: ${request.params.revisionId}`);
       }
 
-      return reply.code(201).send({ ok: true, script, revision: updatedRevision, integrityReview: review });
+      const coverageSummary = buildClaimCoverageSummary(packet, updatedRevision);
+      return reply.code(201).send({ ok: true, script, revision: updatedRevision, integrityReview: review, coverageSummary });
     } catch (error) {
       return sendError(reply, error);
     }
@@ -553,7 +573,8 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
 
   app.post<{ Params: { id: string; revisionId: string } }>('/scripts/:id/revisions/:revisionId/integrity-review/override', async (request, reply) => {
     try {
-      const scriptStore = requireScriptStore(options.getStore());
+      const rawStore = options.getStore();
+      const scriptStore = requireScriptStore(rawStore);
       const body = overrideIntegrityReviewSchema.parse(request.body ?? {});
       const revision = await scriptStore.overrideIntegrityReview(request.params.id, request.params.revisionId, {
         actor: body.actor,
@@ -564,7 +585,9 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         throw new ApiError(404, 'SCRIPT_REVISION_NOT_FOUND', `Script revision not found: ${request.params.revisionId}`);
       }
 
-      return reply.code(201).send({ ok: true, revision, integrityReview: revision.metadata.integrityReview });
+      const script = await scriptStore.getScript(request.params.id);
+      const coverageSummary = script ? await coverageSummaryFor(rawStore, script, revision) : null;
+      return reply.code(201).send({ ok: true, revision, integrityReview: revision.metadata.integrityReview, coverageSummary });
     } catch (error) {
       return sendError(reply, error);
     }
@@ -572,7 +595,8 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
 
   app.post<{ Params: { id: string; revisionId: string } }>('/scripts/:id/revisions/:revisionId/approve-for-audio', async (request, reply) => {
     try {
-      const scriptStore = requireScriptStore(options.getStore());
+      const rawStore = options.getStore();
+      const scriptStore = requireScriptStore(rawStore);
       const body = approveSchema.parse(request.body ?? {});
       const script = await scriptStore.approveScriptRevision(request.params.id, request.params.revisionId, {
         actor: body.actor,
@@ -583,7 +607,9 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         throw new ApiError(404, 'SCRIPT_REVISION_NOT_FOUND', `Script revision not found: ${request.params.revisionId}`);
       }
 
-      return { ok: true, script };
+      const revision = await scriptStore.getScriptRevision(request.params.revisionId);
+      const coverageSummary = await coverageSummaryFor(rawStore, script, revision);
+      return { ok: true, script, coverageSummary };
     } catch (error) {
       return sendError(reply, error);
     }

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -165,8 +165,12 @@ async function coverageSummaryFor(
     return null;
   }
 
-  const packet = await store.getResearchPacket(script.researchPacketId);
-  return packet ? buildClaimCoverageSummary(packet, revision) : null;
+  try {
+    const packet = await store.getResearchPacket(script.researchPacketId);
+    return packet ? buildClaimCoverageSummary(packet, revision) : null;
+  } catch {
+    return null;
+  }
 }
 
 function log(level: 'info' | 'warn' | 'error', message: string, metadata: Record<string, unknown> = {}) {


### PR DESCRIPTION
## Summary
- Add deterministic claim/source coverage summary generation for script revisions
- Include coverage summaries in script/revision/integrity/approval responses where research metadata is available
- Surface claim/source coverage findings in the review UI with blocking, needs-attention, unknown, and covered states

Closes #48

## Verification
- npm run check