### PR TITLE
Add AI script coaching actions

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -410,7 +410,7 @@ Recommended order:
 7. #52 — PF2-09 Harden publishing validation and scheduled-run status semantics ✅ merged (#62)
 8. #47 — PF2-04 Add AI story brief / episode plan assistant ✅ merged (#63)
 9. #48 — PF2-05 Add AI source-gap and claim-coverage surfacing in review UI 🚧 active on branch `issue-48-source-gap-claim-coverage`
-10. #49 — PF2-06 Add AI rewrite/coaching actions for scripts without bypassing approval
+10. #49 — PF2-06 Add AI rewrite/coaching actions for scripts without bypassing approval ✅ implemented locally on `issue-49-ai-rewrite-coaching`; `npm run check` passed. Commit/push may need recovery if sandbox `.git` permissions block writes.
 11. #53 — PF2-10 Split UI state/render helpers into testable modules or sections
 12. #54 — PF2-11 Replace destructive/critical prompts with explicit confirmation dialogs
 13. #55 — PF2-12 Add local UI smoke checks for the guided flow

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,6 +110,11 @@ Public publishing requires:
 - publish target configured.
 - user-triggered publish action.
 
+AI script coaching uses the `script_editor` role only to create a new draft
+revision. Coaching never mutates an existing revision, never carries prior
+script approval forward, and marks citation/provenance/integrity metadata stale
+so the normal review and approval gates still apply before production.
+
 Scheduled pipeline publishing follows the same rule. A recurring pipeline can
 prepare or queue publish work, but RSS publication stays blocked on approval
 unless the schedule is explicitly configured for autopublish.

--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -445,6 +445,7 @@
                 <span>Body</span>
                 <textarea id="scriptBody" rows="16" required></textarea>
               </label>
+              <section id="scriptCoachingActions" class="script-coaching"></section>
               <div class="actions">
                 <button id="approveScript" class="secondary" type="button">Approve for Audio</button>
                 <button type="submit">Save New Revision</button>

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -720,6 +720,41 @@ textarea {
   min-width: 0;
 }
 
+.script-coaching {
+  border-top: 1px solid #d8dde5;
+  display: grid;
+  gap: 0.65rem;
+  padding-top: 0.85rem;
+}
+
+.script-coaching-heading h3 {
+  font-size: 0.95rem;
+  margin: 0 0 0.2rem;
+}
+
+.script-coaching-grid {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.coaching-action {
+  align-items: start;
+  display: grid;
+  gap: 0.2rem;
+  justify-items: start;
+  min-height: 5.25rem;
+  text-align: left;
+  white-space: normal;
+}
+
+.coaching-action span {
+  color: #4b5563;
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
 .production-panel {
   border-top: 1px solid #d8dde5;
   margin-top: 0.5rem;
@@ -1320,6 +1355,7 @@ textarea {
   .manual-form,
   .script-generate,
   .script-workspace,
+  .script-coaching-grid,
   .review-grid,
   .asset-preview-grid,
   .job-layout,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -4,6 +4,7 @@ const state = {
   profiles: [],
   queries: [],
   scripts: [],
+  scriptCoachingActions: [],
   researchPackets: [],
   modelProfiles: [],
   promptTemplates: [],
@@ -149,6 +150,7 @@ const els = {
   scriptEditForm: document.querySelector('#scriptEditForm'),
   scriptTitle: document.querySelector('#scriptTitle'),
   scriptBody: document.querySelector('#scriptBody'),
+  scriptCoachingActions: document.querySelector('#scriptCoachingActions'),
   approveScript: document.querySelector('#approveScript'),
   productionPanel: document.querySelector('#productionPanel'),
   productionMeta: document.querySelector('#productionMeta'),
@@ -281,6 +283,10 @@ function friendlyApiMessage(body, status) {
     SCHEDULED_RUN_NOT_FAILED: 'Only failed scheduled runs can be retried.',
     PUBLISH_BLOCKED: 'Publishing is blocked until the checklist items are complete.',
     PUBLISH_APPROVAL_BLOCKED: 'Publish approval is blocked until the checklist items are complete.',
+    SCRIPT_COACHING_RUNTIME_UNAVAILABLE: 'AI script coaching is unavailable because the local LLM runtime is not configured.',
+    SCRIPT_COACHING_MODEL_PROFILE_REQUIRED: 'Configure the script editor AI role before using coaching actions.',
+    MALFORMED_MODEL_OUTPUT: 'The AI returned an unreadable script revision. No approval or revision state changed.',
+    MODEL_INVOCATION_FAILED: 'The AI script editor failed. No approval or revision state changed.',
   };
 
   if (messages[code]) {
@@ -3369,7 +3375,48 @@ function renderScripts() {
     els.approveScript.disabled = state.selectedScript.approvedRevisionId === state.selectedRevision.id;
   }
 
+  renderScriptCoachingActions();
   renderProduction();
+}
+
+function renderScriptCoachingActions() {
+  els.scriptCoachingActions.innerHTML = '';
+
+  if (!state.selectedScript || !state.selectedRevision) {
+    return;
+  }
+
+  const heading = document.createElement('div');
+  heading.className = 'script-coaching-heading';
+  const title = document.createElement('h3');
+  title.textContent = 'AI coaching';
+  const help = document.createElement('p');
+  help.className = 'help';
+  help.textContent = 'Creates a new draft revision. It does not approve the script or carry review decisions forward.';
+  heading.append(title, help);
+
+  const actions = document.createElement('div');
+  actions.className = 'script-coaching-grid';
+  const running = isActionRunning('script');
+
+  for (const action of state.scriptCoachingActions) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'secondary coaching-action';
+    button.disabled = running;
+    button.innerHTML = '<strong></strong><span></span>';
+    button.querySelector('strong').textContent = action.label;
+    button.querySelector('span').textContent = action.description;
+    button.addEventListener('click', () => runScriptCoachingAction(action.action));
+    actions.append(button);
+  }
+
+  if (state.scriptCoachingActions.length === 0) {
+    els.scriptCoachingActions.append(heading, settingsEmpty('No coaching actions are available from the API.'));
+    return;
+  }
+
+  els.scriptCoachingActions.append(heading, actions);
 }
 
 function reviewSectionHeading(title, status, detail) {
@@ -3840,6 +3887,11 @@ async function loadScripts() {
     state.selectedCoverageSummary = null;
     state.production = { episode: null, assets: [], jobs: [] };
   }
+}
+
+async function loadScriptCoachingActions() {
+  const body = await api('/scripts/coaching-actions');
+  state.scriptCoachingActions = body.actions || [];
 }
 
 async function loadModelProfiles() {
@@ -4396,6 +4448,9 @@ async function loadAll() {
     });
     await safeLoad('AI role settings', loadModelProfiles, () => {
       state.modelProfiles = [];
+    });
+    await safeLoad('script coaching actions', loadScriptCoachingActions, () => {
+      state.scriptCoachingActions = [];
     });
     await safeLoad('prompt templates', loadPromptTemplates, () => {
       state.promptTemplates = [];
@@ -5021,6 +5076,39 @@ async function saveScriptRevision(event) {
     setStatus(`Saved script revision ${body.revision.version}.`);
   } catch (error) {
     reportError(error);
+  }
+}
+
+async function runScriptCoachingAction(action) {
+  if (!state.selectedScript || !state.selectedRevision) {
+    return;
+  }
+
+  setActionRunning('script', true);
+  setStatus('Creating coached script revision...');
+
+  try {
+    const body = await api(`/scripts/${state.selectedScript.id}/revisions/${state.selectedRevision.id}/coach`, {
+      method: 'POST',
+      body: JSON.stringify({
+        action,
+        actor: 'local-user',
+      }),
+    });
+    state.scripts = [body.script, ...state.scripts.filter((script) => script.id !== body.script.id)];
+    state.selectedScript = body.script;
+    state.selectedRevision = body.revision;
+    state.selectedRevisions = [body.revision, ...state.selectedRevisions.filter((revision) => revision.id !== body.revision.id)];
+    state.selectedCoverageSummary = body.coverageSummary ?? null;
+    await loadProduction();
+    await loadJobs();
+    savePipelineState();
+    render();
+    setStatus(`AI coaching created script revision ${body.revision.version}. Run integrity review before production.`);
+  } catch (error) {
+    reportError(error);
+  } finally {
+    setActionRunning('script', false);
   }
 }
 

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -54,6 +54,8 @@ describe('api config endpoints', () => {
     assert.match(response.body, /scrollToPanel/);
     assert.match(response.body, /Claim\/source coverage/);
     assert.match(response.body, /coverageStatusLabel/);
+    assert.match(response.body, /scriptCoachingActions/);
+    assert.match(response.body, /runScriptCoachingAction/);
   });
 
   it('returns the bundled example config', async () => {

--- a/packages/api/src/scripts/coaching.ts
+++ b/packages/api/src/scripts/coaching.ts
@@ -1,4 +1,4 @@
-import type { LlmInvocationMetadata, LlmRuntime } from '../llm/types.js';
+import type { LlmRuntime } from '../llm/types.js';
 import type { ResolvedModelProfile } from '../models/resolver.js';
 import { PROMPT_OUTPUT_SCHEMAS, type ScriptRevisionResult } from '../prompts/schemas.js';
 import { renderPromptTemplate } from '../prompts/renderer.js';
@@ -83,7 +83,7 @@ function packetReadiness(packet: Pick<ResearchPacketRecord, 'content'>): Record<
 }
 
 const secretKeyPattern = /(api[_-]?key|authorization|cookie|credential|password|secret|token)/i;
-const localDataKeyPattern = /(^|_)(local|absolute)?(file|dir|directory|path)$/i;
+const localDataKeyPattern = /(^|_|\b)(local|absolute)?(file|dir|directory|path)$|(?:file|dir|directory|path)$/i;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -245,7 +245,7 @@ export async function buildLlmScriptCoachingRevision(
       promptTemplateVersion: rendered.template.version,
       modelProfileId: modelProfile.id,
       modelRole: modelProfile.role,
-      modelRuntime: result.metadata as LlmInvocationMetadata,
+      modelRuntime: result.metadata,
       resolvedWarnings: result.value.resolvedWarnings,
       remainingWarnings: result.value.remainingWarnings,
     },

--- a/packages/api/src/scripts/coaching.ts
+++ b/packages/api/src/scripts/coaching.ts
@@ -91,7 +91,6 @@ function showContext(show: ShowRecord) {
     format: show.format,
     defaultRuntimeMinutes: show.defaultRuntimeMinutes,
     cast: show.cast.map((member) => ({ name: member.name, role: member.role })),
-    settings: show.settings,
   };
 }
 
@@ -108,7 +107,6 @@ function packetContext(packet: ResearchPacketRecord) {
     summary: asString(packet.content.summary),
     knownFacts: asStringArray(packet.content.knownFacts),
     openQuestions: asStringArray(packet.content.openQuestions),
-    content: packet.content,
   };
 }
 

--- a/packages/api/src/scripts/coaching.ts
+++ b/packages/api/src/scripts/coaching.ts
@@ -90,6 +90,7 @@ function showContext(show: ShowRecord) {
     description: show.description,
     format: show.format,
     defaultRuntimeMinutes: show.defaultRuntimeMinutes,
+    settings: show.settings,
     cast: show.cast.map((member) => ({ name: member.name, role: member.role })),
   };
 }

--- a/packages/api/src/scripts/coaching.ts
+++ b/packages/api/src/scripts/coaching.ts
@@ -82,6 +82,33 @@ function packetReadiness(packet: Pick<ResearchPacketRecord, 'content'>): Record<
     : {};
 }
 
+const secretKeyPattern = /(api[_-]?key|authorization|cookie|credential|password|secret|token)/i;
+const localDataKeyPattern = /(^|_)(local|absolute)?(file|dir|directory|path)$/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function sanitizePromptValue(value: unknown, depth = 0): unknown {
+  if (depth > 4) {
+    return '[max-depth]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizePromptValue(item, depth + 1));
+  }
+
+  if (!isRecord(value)) {
+    return value instanceof Date ? value.toISOString() : value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => !secretKeyPattern.test(key) && !localDataKeyPattern.test(key))
+      .map(([key, entry]) => [key, sanitizePromptValue(entry, depth + 1)]),
+  );
+}
+
 function showContext(show: ShowRecord) {
   return {
     id: show.id,
@@ -90,7 +117,7 @@ function showContext(show: ShowRecord) {
     description: show.description,
     format: show.format,
     defaultRuntimeMinutes: show.defaultRuntimeMinutes,
-    settings: show.settings,
+    settings: sanitizePromptValue(show.settings),
     cast: show.cast.map((member) => ({ name: member.name, role: member.role })),
   };
 }

--- a/packages/api/src/scripts/coaching.ts
+++ b/packages/api/src/scripts/coaching.ts
@@ -1,0 +1,230 @@
+import type { LlmInvocationMetadata, LlmRuntime } from '../llm/types.js';
+import type { ResolvedModelProfile } from '../models/resolver.js';
+import { PROMPT_OUTPUT_SCHEMAS, type ScriptRevisionResult } from '../prompts/schemas.js';
+import { renderPromptTemplate } from '../prompts/renderer.js';
+import type { PromptRegistry } from '../prompts/types.js';
+import type { ResearchPacketRecord } from '../research/store.js';
+import type { ShowRecord } from '../sources/store.js';
+import type { ScriptRecord, ScriptRevisionRecord } from './store.js';
+
+export const SCRIPT_COACHING_ACTION_IDS = [
+  'reduce_certainty',
+  'clarify_intro',
+  'add_attribution',
+  'reduce_sensationalism',
+] as const;
+
+export type ScriptCoachingAction = typeof SCRIPT_COACHING_ACTION_IDS[number];
+
+export interface ScriptCoachingActionDefinition {
+  action: ScriptCoachingAction;
+  label: string;
+  description: string;
+  instruction: string;
+}
+
+export interface ScriptCoachingRuntimeOptions {
+  runtime: LlmRuntime;
+  promptRegistry: PromptRegistry;
+}
+
+export interface BuiltScriptCoachingRevision {
+  title: string;
+  body: string;
+  speakers: string[];
+  changeSummary: string;
+  metadata: Record<string, unknown>;
+}
+
+export const SCRIPT_COACHING_ACTIONS: Record<ScriptCoachingAction, ScriptCoachingActionDefinition> = {
+  reduce_certainty: {
+    action: 'reduce_certainty',
+    label: 'Reduce certainty',
+    description: 'Soften claims that are stronger than the evidence and add caveats where the packet is incomplete.',
+    instruction: 'Reduce unsupported certainty. Add concise caveats where the research packet is incomplete, disputed, or based on limited sourcing. Do not remove necessary attribution.',
+  },
+  clarify_intro: {
+    action: 'clarify_intro',
+    label: 'Clarify intro',
+    description: 'Tighten the opening so the episode quickly states what happened, what is known, and what remains open.',
+    instruction: 'Tighten and clarify the introduction. Keep it grounded in the research packet, avoid new facts, and make the known/unknown split visible early.',
+  },
+  add_attribution: {
+    action: 'add_attribution',
+    label: 'Add attribution',
+    description: 'Add source attribution and uncertainty language where factual lines need clearer sourcing.',
+    instruction: 'Add source attribution and uncertainty language to factual lines that need it. Attribute claims to supplied sources, filings, statements, or the research packet where appropriate. Do not invent citations.',
+  },
+  reduce_sensationalism: {
+    action: 'reduce_sensationalism',
+    label: 'Reduce sensationalism',
+    description: 'Remove hype, unsupported framing, or dramatic language that goes beyond the sourced evidence.',
+    instruction: 'Reduce sensationalism, hype, and unsupported framing. Preserve the substance, but use restrained language that reflects the evidence actually present in the packet.',
+  },
+};
+
+export function listScriptCoachingActions(): ScriptCoachingActionDefinition[] {
+  return SCRIPT_COACHING_ACTION_IDS.map((action) => SCRIPT_COACHING_ACTIONS[action]);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+
+function packetReadiness(packet: Pick<ResearchPacketRecord, 'content'>): Record<string, unknown> {
+  const readiness = packet.content.readiness;
+  return readiness && typeof readiness === 'object' && !Array.isArray(readiness)
+    ? readiness as Record<string, unknown>
+    : {};
+}
+
+function showContext(show: ShowRecord) {
+  return {
+    id: show.id,
+    slug: show.slug,
+    title: show.title,
+    description: show.description,
+    format: show.format,
+    defaultRuntimeMinutes: show.defaultRuntimeMinutes,
+    cast: show.cast.map((member) => ({ name: member.name, role: member.role })),
+    settings: show.settings,
+  };
+}
+
+function packetContext(packet: ResearchPacketRecord) {
+  return {
+    id: packet.id,
+    title: packet.title,
+    status: packet.status,
+    readiness: packetReadiness(packet),
+    sourceDocumentIds: packet.sourceDocumentIds,
+    claims: packet.claims,
+    citations: packet.citations,
+    warnings: packet.warnings,
+    summary: asString(packet.content.summary),
+    knownFacts: asStringArray(packet.content.knownFacts),
+    openQuestions: asStringArray(packet.content.openQuestions),
+    content: packet.content,
+  };
+}
+
+function revisionContext(revision: ScriptRevisionRecord) {
+  return {
+    id: revision.id,
+    version: revision.version,
+    title: revision.title,
+    format: revision.format,
+    speakers: revision.speakers,
+    body: revision.body,
+    changeSummary: revision.changeSummary,
+    metadata: {
+      citationMap: revision.metadata.citationMap,
+      provenance: revision.metadata.provenance,
+      validation: revision.metadata.validation,
+      warnings: revision.metadata.warnings,
+      provenanceStatus: revision.metadata.provenanceStatus,
+      integrityReview: revision.metadata.integrityReview,
+    },
+  };
+}
+
+function instructionContext(input: {
+  action: ScriptCoachingActionDefinition;
+  actor: string;
+  show: ShowRecord;
+  script: ScriptRecord;
+  revision: ScriptRevisionRecord;
+}) {
+  return {
+    coachingAction: {
+      action: input.action.action,
+      label: input.action.label,
+      description: input.action.description,
+      instruction: input.action.instruction,
+    },
+    actor: input.actor,
+    safetyRules: [
+      'This is coaching/rewrite assistance only, not approval.',
+      'Return draft text that still requires normal human review, integrity review, and approval before production.',
+      'Use only the supplied research packet and current script. Do not add unsourced factual claims.',
+      'Preserve compatible speaker labels from the show cast.',
+      'If source support is unclear, add attribution or caveats rather than increasing certainty.',
+    ],
+    showContext: showContext(input.show),
+    script: {
+      id: input.script.id,
+      title: input.script.title,
+      status: input.script.status,
+      approvedRevisionId: input.script.approvedRevisionId,
+    },
+    sourceRevision: {
+      id: input.revision.id,
+      version: input.revision.version,
+    },
+  };
+}
+
+export async function buildLlmScriptCoachingRevision(
+  show: ShowRecord,
+  packet: ResearchPacketRecord,
+  script: ScriptRecord,
+  revision: ScriptRevisionRecord,
+  actionId: ScriptCoachingAction,
+  actor: string,
+  modelProfile: ResolvedModelProfile,
+  options: ScriptCoachingRuntimeOptions,
+): Promise<BuiltScriptCoachingRevision> {
+  const action = SCRIPT_COACHING_ACTIONS[actionId];
+  const rendered = await renderPromptTemplate(options.promptRegistry, {
+    key: modelProfile.promptTemplateKey ?? undefined,
+    role: modelProfile.promptTemplateKey ? undefined : 'script_editor',
+    showId: show.id,
+    variables: {
+      script_draft: revisionContext(revision),
+      research_packet: packetContext(packet),
+      revision_instructions: instructionContext({ action, actor, show, script, revision }),
+    },
+  });
+  const schema = PROMPT_OUTPUT_SCHEMAS.script_revision_result;
+  const result = await options.runtime.generateJson<ScriptRevisionResult>({
+    profile: modelProfile,
+    messages: rendered.messages,
+    schemaName: rendered.responseFormat.schemaName ?? schema.name,
+    schemaHint: rendered.responseFormat.schemaHint ?? schema.schemaHint,
+    validate: (value) => schema.validate(value) as ScriptRevisionResult,
+    requestMetadata: {
+      purpose: 'script_coaching',
+      scriptId: script.id,
+      revisionId: revision.id,
+      researchPacketId: packet.id,
+      coachingAction: action.action,
+      promptTemplateKey: rendered.template.key,
+      promptTemplateVersion: rendered.template.version,
+    },
+  });
+
+  return {
+    title: result.value.title,
+    body: result.value.body,
+    speakers: result.value.speakers,
+    changeSummary: `AI coaching: ${action.label}. ${result.value.changeSummary}`,
+    metadata: {
+      coachingAction: {
+        action: action.action,
+        label: action.label,
+        description: action.description,
+      },
+      promptTemplateKey: rendered.template.key,
+      promptTemplateVersion: rendered.template.version,
+      modelProfileId: modelProfile.id,
+      modelRole: modelProfile.role,
+      modelRuntime: result.metadata as LlmInvocationMetadata,
+      resolvedWarnings: result.value.resolvedWarnings,
+      remainingWarnings: result.value.remainingWarnings,
+    },
+  };
+}

--- a/packages/api/src/scripts/coaching.ts
+++ b/packages/api/src/scripts/coaching.ts
@@ -132,7 +132,6 @@ function revisionContext(revision: ScriptRevisionRecord) {
 
 function instructionContext(input: {
   action: ScriptCoachingActionDefinition;
-  actor: string;
   show: ShowRecord;
   script: ScriptRecord;
   revision: ScriptRevisionRecord;
@@ -144,7 +143,6 @@ function instructionContext(input: {
       description: input.action.description,
       instruction: input.action.instruction,
     },
-    actor: input.actor,
     safetyRules: [
       'This is coaching/rewrite assistance only, not approval.',
       'Return draft text that still requires normal human review, integrity review, and approval before production.',
@@ -172,7 +170,6 @@ export async function buildLlmScriptCoachingRevision(
   script: ScriptRecord,
   revision: ScriptRevisionRecord,
   actionId: ScriptCoachingAction,
-  actor: string,
   modelProfile: ResolvedModelProfile,
   options: ScriptCoachingRuntimeOptions,
 ): Promise<BuiltScriptCoachingRevision> {
@@ -184,7 +181,7 @@ export async function buildLlmScriptCoachingRevision(
     variables: {
       script_draft: revisionContext(revision),
       research_packet: packetContext(packet),
-      revision_instructions: instructionContext({ action, actor, show, script, revision }),
+      revision_instructions: instructionContext({ action, show, script, revision }),
     },
   });
   const schema = PROMPT_OUTPUT_SCHEMAS.script_revision_result;

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -326,7 +326,7 @@ function inheritedRevisionMetadata(
 export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutesOptions) {
   app.get('/scripts/coaching-actions', async () => ({
     ok: true,
-    actions: listScriptCoachingActions(),
+    actions: listScriptCoachingActions().map(({ action, label, description }) => ({ action, label, description })),
   }));
 
   app.post<{ Params: { id: string } }>('/research-packets/:id/script', async (request, reply) => {
@@ -580,7 +580,7 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         throw new ApiError(409, 'SCRIPT_COACHING_MODEL_PROFILE_REQUIRED', 'No script_editor model profile is configured for this show.');
       }
 
-      const coached = await buildLlmScriptCoachingRevision(show, packet, script, revision, body.action, body.actor, modelProfile, {
+      const coached = await buildLlmScriptCoachingRevision(show, packet, script, revision, body.action, modelProfile, {
         runtime: options.llmRuntime,
         promptRegistry: createPromptRegistry({ store: rawStore }),
       });

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -564,6 +564,7 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
       if (!packet) {
         throw new ApiError(404, 'RESEARCH_PACKET_NOT_FOUND', `Research packet not found: ${script.researchPacketId}`);
       }
+      assertPacketCanGenerate(packet);
 
       const show = await getShow(rawStore, script.showId);
       assertCast(show);

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -298,6 +298,7 @@ function inheritedRevisionMetadata(
   const reason = options.reason ?? 'human_edit';
 
   return {
+    ...(options.extra ?? {}),
     source: options.source ?? 'human-edit',
     previousSource: previous?.source ?? null,
     previousRevisionId: previousRevision?.id ?? null,
@@ -319,7 +320,6 @@ function inheritedRevisionMetadata(
     previousIntegrityReviewSnapshot: historicalMetadataValue(previous?.integrityReview),
     inheritedProvenance: inheritedCitationMap || inheritedProvenance,
     validation: validationMetadata(body, show, packet),
-    ...(options.extra ?? {}),
   };
 }
 

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -585,21 +585,13 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         promptRegistry: createPromptRegistry({ store: rawStore }),
       });
       assertValidSpeakers(coached.body, show);
-      const invalidSpeakers = coached.speakers.filter((speaker) => !show.cast.some((member) => member.name === speaker));
-
-      if (invalidSpeakers.length > 0) {
-        throw new ApiError(
-          400,
-          'INVALID_SCRIPT_SPEAKER',
-          `Speaker label(s) are not in the show cast: ${invalidSpeakers.join(', ')}`,
-        );
-      }
+      const coachedSpeakers = extractSpeakerLabels(coached.body);
 
       const result = await scriptStore.createScriptRevision(script.id, {
         title: coached.title,
         body: coached.body,
         format: revision.format || script.format,
-        speakers: coached.speakers,
+        speakers: coachedSpeakers,
         author: body.actor,
         changeSummary: coached.changeSummary,
         modelProfile: modelProfileRecord(modelProfile),

--- a/packages/api/src/scripts/routes.ts
+++ b/packages/api/src/scripts/routes.ts
@@ -17,6 +17,11 @@ import {
   invalidSpeakerLabels,
   provenanceWarnings,
 } from './builder.js';
+import {
+  buildLlmScriptCoachingRevision,
+  listScriptCoachingActions,
+  SCRIPT_COACHING_ACTION_IDS,
+} from './coaching.js';
 import { buildClaimCoverageSummary } from './coverage.js';
 import { buildIntegrityReview } from './integrity.js';
 import type { ScriptStore } from './store.js';
@@ -52,6 +57,11 @@ const createRevisionSchema = z.object({
   format: z.string().trim().min(1).optional(),
   actor: z.string().trim().min(1).default('local-user'),
   changeSummary: z.string().trim().min(1).nullable().optional(),
+});
+
+const coachRevisionSchema = z.object({
+  action: z.enum(SCRIPT_COACHING_ACTION_IDS),
+  actor: z.string().trim().min(1).default('local-user'),
 });
 
 const approveSchema = z.object({
@@ -274,22 +284,29 @@ function inheritedRevisionMetadata(
   body: string,
   show: ShowRecord,
   packet: Parameters<typeof validationMetadata>[2],
+  options: {
+    source?: string;
+    reason?: string;
+    message?: string;
+    extra?: Record<string, unknown>;
+  } = {},
 ) {
   const previous = previousRevision?.metadata;
   const inheritedCitationMap = previous?.citationMap !== undefined;
   const inheritedProvenance = previous?.provenance !== undefined;
   const inheritedIntegrityReview = previous?.integrityReview !== undefined;
+  const reason = options.reason ?? 'human_edit';
 
   return {
-    source: 'human-edit',
+    source: options.source ?? 'human-edit',
     previousSource: previous?.source ?? null,
     previousRevisionId: previousRevision?.id ?? null,
     previousApprovedRevisionId,
     provenanceStatus: {
       status: 'stale',
       verified: false,
-      reason: 'human_edit',
-      message: 'Script text changed in a human edit; citation mapping and provenance must be reviewed or rebuilt for this revision.',
+      reason,
+      message: options.message ?? 'Script text changed in a human edit; citation mapping and provenance must be reviewed or rebuilt for this revision.',
       previousRevisionId: previousRevision?.id ?? null,
       previousApprovedRevisionId,
       previousSource: previous?.source ?? null,
@@ -302,10 +319,16 @@ function inheritedRevisionMetadata(
     previousIntegrityReviewSnapshot: historicalMetadataValue(previous?.integrityReview),
     inheritedProvenance: inheritedCitationMap || inheritedProvenance,
     validation: validationMetadata(body, show, packet),
+    ...(options.extra ?? {}),
   };
 }
 
 export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutesOptions) {
+  app.get('/scripts/coaching-actions', async () => ({
+    ok: true,
+    actions: listScriptCoachingActions(),
+  }));
+
   app.post<{ Params: { id: string } }>('/research-packets/:id/script', async (request, reply) => {
     let job: JobRecord | undefined;
     let jobStore: Pick<SearchJobStore, 'createJob' | 'updateJob'> | undefined;
@@ -504,6 +527,89 @@ export function registerScriptRoutes(app: FastifyInstance, options: ScriptRoutes
         modelProfile: {},
         metadata: {
           ...inheritedRevisionMetadata(latestRevision, script.approvedRevisionId, body.body, show, packet),
+        },
+      });
+
+      if (!result) {
+        throw new ApiError(404, 'SCRIPT_NOT_FOUND', `Script not found: ${request.params.id}`);
+      }
+
+      const coverageSummary = buildClaimCoverageSummary(packet, result.revision);
+      return reply.code(201).send({ ok: true, script: result.script, revision: result.revision, coverageSummary });
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.post<{ Params: { id: string; revisionId: string } }>('/scripts/:id/revisions/:revisionId/coach', async (request, reply) => {
+    try {
+      const rawStore = options.getStore();
+      const scriptStore = requireScriptStore(rawStore);
+      const researchStore = requireResearchStore(rawStore);
+      const body = coachRevisionSchema.parse(request.body ?? {});
+      const script = await scriptStore.getScript(request.params.id);
+
+      if (!script) {
+        throw new ApiError(404, 'SCRIPT_NOT_FOUND', `Script not found: ${request.params.id}`);
+      }
+
+      const revision = await scriptStore.getScriptRevision(request.params.revisionId);
+
+      if (!revision || revision.scriptId !== script.id) {
+        throw new ApiError(404, 'SCRIPT_REVISION_NOT_FOUND', `Script revision not found: ${request.params.revisionId}`);
+      }
+
+      const packet = await researchStore.getResearchPacket(script.researchPacketId);
+
+      if (!packet) {
+        throw new ApiError(404, 'RESEARCH_PACKET_NOT_FOUND', `Research packet not found: ${script.researchPacketId}`);
+      }
+
+      const show = await getShow(rawStore, script.showId);
+      assertCast(show);
+
+      if (!options.llmRuntime) {
+        throw new ApiError(503, 'SCRIPT_COACHING_RUNTIME_UNAVAILABLE', 'Script coaching requires an injected LLM runtime.');
+      }
+
+      const modelProfile = hasModelProfileStore(rawStore)
+        ? await resolveModelProfile(rawStore, { showId: script.showId, role: 'script_editor' })
+        : undefined;
+
+      if (!modelProfile) {
+        throw new ApiError(409, 'SCRIPT_COACHING_MODEL_PROFILE_REQUIRED', 'No script_editor model profile is configured for this show.');
+      }
+
+      const coached = await buildLlmScriptCoachingRevision(show, packet, script, revision, body.action, body.actor, modelProfile, {
+        runtime: options.llmRuntime,
+        promptRegistry: createPromptRegistry({ store: rawStore }),
+      });
+      assertValidSpeakers(coached.body, show);
+      const invalidSpeakers = coached.speakers.filter((speaker) => !show.cast.some((member) => member.name === speaker));
+
+      if (invalidSpeakers.length > 0) {
+        throw new ApiError(
+          400,
+          'INVALID_SCRIPT_SPEAKER',
+          `Speaker label(s) are not in the show cast: ${invalidSpeakers.join(', ')}`,
+        );
+      }
+
+      const result = await scriptStore.createScriptRevision(script.id, {
+        title: coached.title,
+        body: coached.body,
+        format: revision.format || script.format,
+        speakers: coached.speakers,
+        author: body.actor,
+        changeSummary: coached.changeSummary,
+        modelProfile: modelProfileRecord(modelProfile),
+        metadata: {
+          ...inheritedRevisionMetadata(revision, script.approvedRevisionId, coached.body, show, packet, {
+            source: 'llm-coaching',
+            reason: 'ai_coaching',
+            message: 'AI coaching changed the script text; citation mapping, provenance, and integrity review must be checked again before production.',
+            extra: coached.metadata,
+          }),
         },
       });
 

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -2620,6 +2620,43 @@ describe('source profile routes', () => {
     assert.equal(scriptAfterFailure?.approvedRevisionId, initial.revision.id);
   });
 
+  it('rejects AI coaching output with speaker labels outside the show cast', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Unknown Speaker Coaching Story',
+      status: 'approved',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{ id: 'claim-1', text: 'An unknown speaker coaching claim exists.', sourceDocumentIds: ['source-document-1'], citationUrls: ['https://example.com/unknown-speaker-coaching'] }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/unknown-speaker-coaching',
+        title: 'Unknown Speaker Coaching Source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary for unknown speaker coaching testing.' },
+    });
+    const scriptResponse = await app.inject({ method: 'POST', url: `/research-packets/${packet.id}/script` });
+    const initial = scriptResponse.json();
+    const revisionCount = store.scriptRevisions.length;
+
+    scriptEditorMode = 'unknown-speaker';
+    const coachResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/coach`,
+      payload: {
+        action: 'add_attribution',
+        actor: 'editor@example.com',
+      },
+    });
+
+    assert.equal(coachResponse.statusCode, 400);
+    assert.equal(coachResponse.json().code, 'INVALID_SCRIPT_SPEAKER');
+    assert.equal(store.scriptRevisions.length, revisionCount);
+  });
+
   it('runs and persists a passing integrity review for a script revision', async () => {
     const packet = await store.createResearchPacket({
       showId: store.shows[0].id,

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -141,6 +141,7 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
     this.modelProfileRecord('claim_extractor', 'google-vertex', 'gemini-2.5-flash'),
     this.modelProfileRecord('research_synthesizer', 'google-gemini-cli', 'gemini-3-pro-preview'),
     this.modelProfileRecord('script_writer', 'openai-codex', 'gpt-5.3-codex'),
+    this.modelProfileRecord('script_editor', 'openai-codex', 'gpt-5.3-codex'),
     this.modelProfileRecord('integrity_reviewer', 'openai', 'gpt-5.5'),
     this.modelProfileRecord('cover_prompt_writer', 'openai', 'gpt-5.5'),
   ];
@@ -883,6 +884,7 @@ let uploadedPublishAssets: Array<{ feedId: string; episodeId: string; assetId: s
 let rssEntries = new Map<string, RssEpisodeEntry>();
 let validatedPublishUrls: string[] = [];
 let scriptLlmMode: 'valid' | 'malformed' | 'unknown-speaker' = 'valid';
+let scriptEditorMode: 'valid' | 'malformed' | 'unknown-speaker' = 'valid';
 let integrityReviewMode: 'pass' | 'notes' | 'fail' = 'pass';
 
 function quotedValue(content: string, key: string): string | undefined {
@@ -891,6 +893,37 @@ function quotedValue(content: string, key: string): string | undefined {
 }
 
 function scriptWriterResult(request: LlmProviderRequest): LlmProviderResult {
+  if (request.attempt.role === 'script_editor') {
+    if (scriptEditorMode === 'malformed') {
+      return { text: 'not json', rawOutput: 'not json', metadata: { adapter: 'test-fake-script-editor' } };
+    }
+
+    const body = scriptEditorMode === 'unknown-speaker'
+      ? 'BOGUS: This coached draft uses a speaker outside the configured show cast.'
+      : [
+        'DAVID: According to the captured source, this update remains preliminary while editors review the evidence.',
+        'INGRID: The revised intro keeps uncertainty visible and avoids declaring conclusions the packet has not settled.',
+        'MARCUS: The next step is a fresh integrity review before production.',
+      ].join('\n');
+    const output = {
+      title: 'Coached Story Script',
+      body,
+      changeSummary: 'Reduced certainty and made source limits clearer.',
+      speakers: scriptEditorMode === 'unknown-speaker' ? ['BOGUS'] : ['DAVID', 'INGRID', 'MARCUS'],
+      resolvedWarnings: ['unsupported_certainty'],
+      remainingWarnings: [],
+    };
+    const text = JSON.stringify(output);
+
+    return {
+      text,
+      rawOutput: text,
+      metadata: { adapter: 'test-fake-script-editor' },
+      usage: { inputTokens: 11, outputTokens: 17, totalTokens: 28 },
+      cost: { usd: 0, currency: 'USD' },
+    };
+  }
+
   if (request.attempt.role === 'integrity_reviewer') {
     const outputs = {
       pass: {
@@ -1245,6 +1278,7 @@ describe('source profile routes', () => {
     rssEntries = new Map<string, RssEpisodeEntry>();
     validatedPublishUrls = [];
     scriptLlmMode = 'valid';
+    scriptEditorMode = 'valid';
     integrityReviewMode = 'pass';
   });
 
@@ -2394,6 +2428,196 @@ describe('source profile routes', () => {
 
     assert.equal(audioResponse.statusCode, 409);
     assert.equal(audioResponse.json().code, 'INTEGRITY_REVIEW_REQUIRED');
+  });
+
+  it('creates a new draft revision from an AI coaching action', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Coaching Story',
+      status: 'approved',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{ id: 'claim-1', text: 'A coaching claim exists.', sourceDocumentIds: ['source-document-1'], citationUrls: ['https://example.com/coaching'] }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/coaching',
+        title: 'Coaching Source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary for script coaching.' },
+    });
+    const scriptResponse = await app.inject({ method: 'POST', url: `/research-packets/${packet.id}/script` });
+    const initial = scriptResponse.json();
+    const coachResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/coach`,
+      payload: {
+        action: 'reduce_certainty',
+        actor: 'editor@example.com',
+      },
+    });
+    const coached = coachResponse.json();
+
+    assert.equal(coachResponse.statusCode, 201);
+    assert.equal(coached.revision.version, 2);
+    assert.notEqual(coached.revision.id, initial.revision.id);
+    assert.match(coached.revision.changeSummary, /AI coaching: Reduce certainty/);
+    assert.match(coached.revision.body, /preliminary/);
+    assert.equal(coached.revision.author, 'editor@example.com');
+    assert.equal(coached.script.status, 'draft');
+    assert.equal(coached.script.approvedRevisionId, null);
+    assert.equal(coached.revision.metadata.source, 'llm-coaching');
+    assert.deepEqual(coached.revision.metadata.coachingAction, {
+      action: 'reduce_certainty',
+      label: 'Reduce certainty',
+      description: 'Soften claims that are stronger than the evidence and add caveats where the packet is incomplete.',
+    });
+    assert.equal(coached.revision.metadata.integrityReview, undefined);
+    assert.equal(coached.revision.metadata.citationMap, undefined);
+    assert.equal(coached.revision.metadata.provenance, undefined);
+    assert.deepEqual(coached.revision.metadata.staleCitationMap, initial.revision.metadata.citationMap);
+    assert.equal((coached.revision.metadata.provenanceStatus as { status: string }).status, 'stale');
+    assert.equal((coached.revision.metadata.provenanceStatus as { reason: string }).reason, 'ai_coaching');
+    assert.equal(coached.revision.metadata.validation.speakerLabels.valid, true);
+  });
+
+  it('rejects unsupported AI coaching actions', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Unsupported Coaching Story',
+      status: 'approved',
+      sourceDocumentIds: [],
+      claims: [{ id: 'claim-1', text: 'A claim exists.', sourceDocumentIds: [], citationUrls: ['https://example.com/unsupported-coaching'] }],
+      citations: [],
+      warnings: [],
+      content: { summary: 'A packet summary for unsupported action testing.' },
+    });
+    const scriptResponse = await app.inject({ method: 'POST', url: `/research-packets/${packet.id}/script` });
+    const initial = scriptResponse.json();
+    const coachResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/coach`,
+      payload: {
+        action: 'make_it_viral',
+        actor: 'editor@example.com',
+      },
+    });
+
+    assert.equal(coachResponse.statusCode, 400);
+    assert.equal(coachResponse.json().code, 'VALIDATION_ERROR');
+    assert.equal(store.scriptRevisions.length, 1);
+  });
+
+  it('does not carry prior approval or integrity review forward after AI coaching', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Approved Coaching Story',
+      status: 'approved',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{ id: 'claim-1', text: 'An approved coaching claim exists.', sourceDocumentIds: ['source-document-1'], citationUrls: ['https://example.com/approved-coaching'] }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/approved-coaching',
+        title: 'Approved Coaching Source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary for approved coaching testing.' },
+    });
+    const scriptResponse = await app.inject({ method: 'POST', url: `/research-packets/${packet.id}/script` });
+    const initial = scriptResponse.json();
+    const integrityResponse = await runIntegrityReview(initial.script.id, initial.revision.id);
+
+    assert.equal(integrityResponse.statusCode, 201);
+    assert.equal(integrityResponse.json().integrityReview.status, 'pass');
+
+    const initialApproval = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/approve-for-audio`,
+      payload: { actor: 'producer@example.com', reason: 'Initial revision reviewed.' },
+    });
+    assert.equal(initialApproval.statusCode, 200);
+    assert.equal(initialApproval.json().script.approvedRevisionId, initial.revision.id);
+
+    const coachResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/coach`,
+      payload: {
+        action: 'add_attribution',
+        actor: 'editor@example.com',
+      },
+    });
+    const coached = coachResponse.json();
+
+    assert.equal(coachResponse.statusCode, 201);
+    assert.equal(coached.script.status, 'draft');
+    assert.equal(coached.script.approvedRevisionId, null);
+    assert.equal(coached.script.approvedAt, null);
+    assert.equal(coached.revision.metadata.integrityReview, undefined);
+    assert.equal(coached.revision.metadata.previousApprovedRevisionId, initial.revision.id);
+    assert.deepEqual(coached.revision.metadata.previousIntegrityReviewSnapshot, integrityResponse.json().integrityReview);
+    assert.deepEqual(coached.revision.metadata.staleCitationMap, initial.revision.metadata.citationMap);
+    assert.equal((coached.revision.metadata.provenanceStatus as { previousApprovedRevisionId: string }).previousApprovedRevisionId, initial.revision.id);
+
+    const audioResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${coached.script.id}/production/audio-preview`,
+      payload: { actor: 'producer@example.com' },
+    });
+
+    assert.equal(audioResponse.statusCode, 409);
+    assert.equal(audioResponse.json().code, 'SCRIPT_NOT_APPROVED_FOR_AUDIO');
+  });
+
+  it('fails safely when AI coaching returns malformed output', async () => {
+    const packet = await store.createResearchPacket({
+      showId: store.shows[0].id,
+      episodeCandidateId: null,
+      title: 'Malformed Coaching Story',
+      status: 'approved',
+      sourceDocumentIds: ['source-document-1'],
+      claims: [{ id: 'claim-1', text: 'A malformed coaching claim exists.', sourceDocumentIds: ['source-document-1'], citationUrls: ['https://example.com/malformed-coaching'] }],
+      citations: [{
+        sourceDocumentId: 'source-document-1',
+        url: 'https://example.com/malformed-coaching',
+        title: 'Malformed Coaching Source',
+        fetchedAt: '2026-01-04T00:00:00.000Z',
+        status: 'fetched',
+      }],
+      warnings: [],
+      content: { summary: 'A packet summary for malformed coaching testing.' },
+    });
+    const scriptResponse = await app.inject({ method: 'POST', url: `/research-packets/${packet.id}/script` });
+    const initial = scriptResponse.json();
+    const initialApproval = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/approve-for-audio`,
+      payload: { actor: 'producer@example.com', reason: 'Approved before failed coaching.' },
+    });
+    assert.equal(initialApproval.statusCode, 200);
+
+    scriptEditorMode = 'malformed';
+    const revisionCount = store.scriptRevisions.length;
+    const coachResponse = await app.inject({
+      method: 'POST',
+      url: `/scripts/${initial.script.id}/revisions/${initial.revision.id}/coach`,
+      payload: {
+        action: 'reduce_sensationalism',
+        actor: 'editor@example.com',
+      },
+    });
+    const scriptAfterFailure = await store.getScript(initial.script.id);
+
+    assert.equal(coachResponse.statusCode, 502);
+    assert.equal(coachResponse.json().code, 'MALFORMED_MODEL_OUTPUT');
+    assert.equal(store.scriptRevisions.length, revisionCount);
+    assert.equal(scriptAfterFailure?.status, 'approved-for-audio');
+    assert.equal(scriptAfterFailure?.approvedRevisionId, initial.revision.id);
   });
 
   it('runs and persists a passing integrity review for a script revision', async () => {


### PR DESCRIPTION
Closes #49

## Summary
- add validated AI script coaching actions that create new draft revisions
- reset approval/integrity/provenance status for coached script text
- expose coaching controls in the static workflow UI

## Verification
- npm run check