### PR TITLE
Replace critical prompts with confirmation UI

### DIFF
--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -551,6 +551,63 @@ textarea {
   margin-top: 0;
 }
 
+.confirmation-overlay {
+  align-items: center;
+  background: rgba(32, 36, 44, 0.56);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1rem;
+  position: fixed;
+  z-index: 100;
+}
+
+.confirmation-dialog {
+  background: white;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  box-shadow: 0 24px 60px rgba(17, 24, 39, 0.28);
+  max-height: calc(100vh - 2rem);
+  max-width: 34rem;
+  overflow: auto;
+  width: min(100%, 34rem);
+}
+
+.confirmation-form {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+}
+
+.confirmation-form h2,
+.confirmation-form p {
+  margin: 0;
+}
+
+.confirmation-form h2 {
+  font-size: 1.2rem;
+}
+
+.confirmation-consequence {
+  background: #fff9d9;
+  border: 1px solid #d8cf73;
+  border-radius: 6px;
+  color: #3f4b5a;
+  padding: 0.65rem 0.75rem;
+}
+
+.confirmation-status {
+  background: #fff1df;
+  border: 1px solid #e2c391;
+  border-radius: 6px;
+  color: #7a2d12;
+  padding: 0.55rem 0.65rem;
+}
+
+.confirmation-actions {
+  flex-wrap: wrap;
+}
+
 .row-actions {
   justify-content: flex-start;
 }
@@ -1388,7 +1445,19 @@ textarea {
   }
 
   .next-action-controls,
-  .next-action-controls button {
+  .next-action-controls button,
+  .confirmation-actions,
+  .confirmation-actions button {
+    width: 100%;
+  }
+
+  .confirmation-overlay {
+    align-items: end;
+    padding: 0.75rem;
+  }
+
+  .confirmation-dialog {
+    max-height: calc(100vh - 1.5rem);
     width: 100%;
   }
 }

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -67,6 +67,7 @@ function openConfirmationDialog({
     dialog.setAttribute('aria-modal', 'true');
     dialog.setAttribute('aria-labelledby', `${dialogId}-title`);
     dialog.setAttribute('aria-describedby', `${dialogId}-description`);
+    dialog.tabIndex = -1;
 
     const form = document.createElement('form');
     form.className = 'confirmation-form';
@@ -105,6 +106,11 @@ function openConfirmationDialog({
       }
       field.append(label, reasonInput);
       form.append(field);
+      reasonInput.addEventListener('input', () => {
+        status.hidden = true;
+        status.textContent = '';
+        reasonInput.removeAttribute('aria-invalid');
+      });
     }
 
     const status = document.createElement('p');
@@ -140,10 +146,36 @@ function openConfirmationDialog({
       resolve(value);
     };
 
+    function dialogFocusableElements() {
+      return Array.from(dialog.querySelectorAll('button, input, textarea, select, a[href], [tabindex]:not([tabindex="-1"])'))
+        .filter((element) => !element.disabled && element.offsetParent !== null);
+    }
+
+    function trapFocus(event) {
+      const focusable = dialogFocusableElements();
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
     function onKeydown(event) {
       if (event.key === 'Escape') {
         event.preventDefault();
         close(null);
+      } else if (event.key === 'Tab') {
+        trapFocus(event);
       }
     }
 
@@ -159,7 +191,7 @@ function openConfirmationDialog({
       if (requireReason && !reason) {
         status.hidden = false;
         status.textContent = emptyReasonMessage;
-        setStatus(emptyReasonMessage);
+        reasonInput?.setAttribute('aria-invalid', 'true');
         reasonInput?.focus();
         return;
       }

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -42,6 +42,138 @@ function reportError(error, fallback = 'Something went wrong. Open technical det
   return fallback;
 }
 
+function openConfirmationDialog({
+  title,
+  description,
+  consequence = '',
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  danger = false,
+  reasonLabel = '',
+  defaultReason = '',
+  reasonPlaceholder = '',
+  requireReason = false,
+  emptyReasonMessage = 'Enter a reason before continuing.',
+}) {
+  return new Promise((resolve) => {
+    const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const dialogId = `confirmation-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const overlay = document.createElement('div');
+    overlay.className = 'confirmation-overlay';
+
+    const dialog = document.createElement('section');
+    dialog.className = 'confirmation-dialog';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-labelledby', `${dialogId}-title`);
+    dialog.setAttribute('aria-describedby', `${dialogId}-description`);
+
+    const form = document.createElement('form');
+    form.className = 'confirmation-form';
+    form.noValidate = true;
+
+    const heading = document.createElement('h2');
+    heading.id = `${dialogId}-title`;
+    heading.textContent = title;
+
+    const body = document.createElement('p');
+    body.id = `${dialogId}-description`;
+    body.textContent = description;
+
+    form.append(heading, body);
+
+    if (consequence) {
+      const consequenceText = document.createElement('p');
+      consequenceText.className = 'confirmation-consequence';
+      consequenceText.textContent = consequence;
+      form.append(consequenceText);
+    }
+
+    let reasonInput = null;
+    if (reasonLabel) {
+      const field = document.createElement('label');
+      field.className = 'field';
+      const label = document.createElement('span');
+      label.textContent = reasonLabel;
+      reasonInput = document.createElement('input');
+      reasonInput.type = 'text';
+      reasonInput.value = defaultReason;
+      reasonInput.placeholder = reasonPlaceholder;
+      reasonInput.setAttribute('autocomplete', 'off');
+      if (requireReason) {
+        reasonInput.required = true;
+      }
+      field.append(label, reasonInput);
+      form.append(field);
+    }
+
+    const status = document.createElement('p');
+    status.className = 'confirmation-status';
+    status.setAttribute('role', 'alert');
+    status.hidden = true;
+    form.append(status);
+
+    const actions = document.createElement('div');
+    actions.className = 'actions inline confirmation-actions';
+
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'secondary';
+    cancel.textContent = cancelLabel;
+
+    const confirm = document.createElement('button');
+    confirm.type = 'submit';
+    confirm.className = danger ? 'danger' : '';
+    confirm.textContent = confirmLabel;
+
+    actions.append(cancel, confirm);
+    form.append(actions);
+    dialog.append(form);
+    overlay.append(dialog);
+
+    const close = (value) => {
+      document.removeEventListener('keydown', onKeydown);
+      overlay.remove();
+      if (previousFocus?.isConnected) {
+        previousFocus.focus();
+      }
+      resolve(value);
+    };
+
+    function onKeydown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close(null);
+      }
+    }
+
+    cancel.addEventListener('click', () => close(null));
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        close(null);
+      }
+    });
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const reason = reasonInput?.value.trim() ?? '';
+      if (requireReason && !reason) {
+        status.hidden = false;
+        status.textContent = emptyReasonMessage;
+        setStatus(emptyReasonMessage);
+        reasonInput?.focus();
+        return;
+      }
+      close(reasonInput ? reason : true);
+    });
+
+    document.addEventListener('keydown', onKeydown);
+    document.body.append(overlay);
+    window.setTimeout(() => {
+      (reasonInput || confirm).focus();
+    }, 0);
+  });
+}
+
 function selectedProfile() {
   return state.profiles.find((profile) => profile.id === state.selectedProfileId);
 }
@@ -1531,7 +1663,7 @@ function renderQueries() {
       await saveQuery(query.id, form, selectedProfile());
     });
     form.elements.delete.addEventListener('click', async () => {
-      await deleteQuery(query.id);
+      await confirmDeleteQuery(query);
     });
     els.queryList.append(form);
   }
@@ -2215,7 +2347,7 @@ function adminQueryForm(query, profile = selectedProfile()) {
     await saveQuery(query.id, form, profile);
   });
   form.elements.delete.addEventListener('click', async () => {
-    await deleteQuery(query.id);
+    await confirmDeleteQuery(query);
   });
   return form;
 }
@@ -4503,6 +4635,29 @@ async function createQuery(event) {
   }
 }
 
+function truncateConfirmationText(text, maxLength = 180) {
+  const value = String(text || '').replace(/\s+/g, ' ').trim();
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}
+
+async function confirmDeleteQuery(query) {
+  const queryText = truncateConfirmationText(query.query);
+  const confirmed = await openConfirmationDialog({
+    title: 'Delete Search Query',
+    description: 'This removes the saved source query/search recipe from this story source.',
+    consequence: `"${queryText}" will no longer run for future story discovery. Existing candidate stories and audit records are not deleted, but this destructive change removes the query from the profile.`,
+    confirmLabel: 'Delete Source Query',
+    danger: true,
+  });
+
+  if (!confirmed) {
+    setStatus('Search query deletion cancelled.');
+    return;
+  }
+
+  await deleteQuery(query.id);
+}
+
 async function deleteQuery(id) {
   try {
     await api(`/source-queries/${id}`, { method: 'DELETE' });
@@ -4704,9 +4859,19 @@ async function overrideSelectedIntegrityReview() {
     return;
   }
 
-  const reason = window.prompt('Integrity review override reason:');
-  if (!reason || !reason.trim()) {
-    setStatus('Integrity override cancelled. A reason is required.');
+  const reason = await openConfirmationDialog({
+    title: 'Override Integrity Gate',
+    description: 'This records an explicit override of a blocking integrity review gate and allows production to proceed despite blocking findings.',
+    consequence: 'The failed or missing integrity review record stays in the audit trail; this does not erase it.',
+    confirmLabel: 'Override Integrity Gate',
+    danger: true,
+    reasonLabel: 'Override reason',
+    reasonPlaceholder: 'Explain why production may continue despite the blocking gate.',
+    requireReason: true,
+    emptyReasonMessage: 'Enter an integrity override reason before continuing.',
+  });
+  if (reason === null) {
+    setStatus('Integrity override cancelled.');
     return;
   }
 
@@ -4718,7 +4883,7 @@ async function overrideSelectedIntegrityReview() {
       method: 'POST',
       body: JSON.stringify({
         actor: 'local-user',
-        reason: reason.trim(),
+        reason,
       }),
     });
     state.selectedRevision = body.revision;
@@ -4736,10 +4901,20 @@ async function overrideSelectedIntegrityReview() {
 }
 
 async function overrideResearchWarning(packetId, warning) {
-  const reason = window.prompt('Override reason for this research warning:');
+  const reason = await openConfirmationDialog({
+    title: 'Override Research Warning',
+    description: 'This records an editorial override for a warning and allows the brief to proceed despite that warning. It does not remove the original warning or audit trail.',
+    consequence: `${warning.code || 'warning'}: ${warning.message || 'No warning message recorded.'}`,
+    confirmLabel: 'Override Warning',
+    danger: true,
+    reasonLabel: 'Override reason',
+    reasonPlaceholder: 'Explain the editorial basis for overriding this warning.',
+    requireReason: true,
+    emptyReasonMessage: 'Enter a research warning override reason before continuing.',
+  });
 
-  if (!reason || !reason.trim()) {
-    setStatus('Warning override cancelled. A reason is required.');
+  if (reason === null) {
+    setStatus('Warning override cancelled.');
     return;
   }
 
@@ -4753,7 +4928,7 @@ async function overrideResearchWarning(packetId, warning) {
         warningId: warning.id,
         warningCode: warning.code,
         actor: 'local-user',
-        reason: reason.trim(),
+        reason,
       }),
     });
     state.researchPackets = state.researchPackets.map((packet) => packet.id === body.researchPacket.id ? body.researchPacket : packet);
@@ -4776,7 +4951,15 @@ async function approveSelectedResearch() {
     return;
   }
 
-  const reason = window.prompt('Research approval note:', 'Sources, claims, citations, and warnings reviewed.');
+  const defaultResearchApprovalNote = 'Sources, claims, citations, and warnings reviewed.';
+  const reason = await openConfirmationDialog({
+    title: 'Approve Research Brief',
+    description: 'Record research approval only after source, claim, citation, and warning review.',
+    consequence: 'This saves a review decision for the selected research brief; source snapshots, claims, and warning records remain available for audit.',
+    confirmLabel: 'Approve Research Brief',
+    reasonLabel: 'Approval note',
+    defaultReason: defaultResearchApprovalNote,
+  });
 
   if (reason === null) {
     setStatus('Research approval cancelled.');
@@ -4791,7 +4974,7 @@ async function approveSelectedResearch() {
       method: 'POST',
       body: JSON.stringify({
         actor: 'local-user',
-        reason: reason.trim() || 'Sources, claims, citations, and warnings reviewed.',
+        reason: reason.trim() || defaultResearchApprovalNote,
       }),
     });
     state.researchPackets = state.researchPackets.map((candidate) => candidate.id === body.researchPacket.id ? body.researchPacket : candidate);

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -57,6 +57,11 @@ describe('api config endpoints', () => {
     assert.match(response.body, /coverageStatusLabel/);
     assert.match(response.body, /scriptCoachingActions/);
     assert.match(response.body, /runScriptCoachingAction/);
+    assert.match(response.body, /openConfirmationDialog/);
+    assert.match(response.body, /Delete Search Query/);
+    assert.match(response.body, /Override Integrity Gate/);
+    assert.match(response.body, /Approve Research Brief/);
+    assert.doesNotMatch(response.body, /window\.prompt|prompt\(/);
   });
 
   it('serves guided pipeline module dependencies', async () => {


### PR DESCRIPTION
Closes #54\n\n## Summary\n- Adds reusable in-app confirmation/note UI for critical editorial/admin decisions.\n- Replaces research approval, research warning override, and integrity override browser prompts with explicit visible dialogs.\n- Requires confirmation before deleting source queries from both workflow and admin forms, with consequence copy and mobile styles.\n- Adds static UI assertions that prompt usage is removed.\n\n## Verification\n- npm run check\n- node --check packages/api/public/ui.js\n- git diff --check