### PR TITLE
fix: prevent stale local UI modules

### DIFF
--- a/packages/api/public/ui-api.js
+++ b/packages/api/public/ui-api.js
@@ -75,12 +75,14 @@ export function friendlyApiMessage(body, status) {
 }
 
 export async function api(path, options = {}) {
+  const headers = {
+    ...(options.body === undefined ? {} : { 'content-type': 'application/json' }),
+    ...(options.headers || {}),
+  };
+
   const response = await fetch(path, {
     ...options,
-    headers: {
-      'content-type': 'application/json',
-      ...(options.headers || {}),
-    },
+    headers,
   });
 
   if (response.status === 204) {

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -40,6 +40,7 @@ describe('api config endpoints', () => {
 
     assert.equal(response.statusCode, 200);
     assert.match(String(response.headers['content-type'] ?? ''), /application\/javascript/);
+    assert.match(String(response.headers['cache-control'] ?? ''), /no-store/);
     for (const modulePath of ['./ui-api.js', './ui-constants.js', './ui-state.js', './ui-formatters.js']) {
       assert.match(response.body, new RegExp(`from\\s+['\"]${modulePath.replace(/[./]/g, '\\$&')}['\"]`));
     }
@@ -89,6 +90,7 @@ describe('api config endpoints', () => {
 
       assert.equal(response.statusCode, 200, asset.path);
       assert.match(String(response.headers['content-type'] ?? ''), /application\/javascript/, asset.path);
+      assert.match(String(response.headers['cache-control'] ?? ''), /no-store/, asset.path);
       for (const pattern of asset.patterns) {
         assert.match(response.body, pattern, asset.path);
       }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -124,14 +124,14 @@ export function buildApp(options: BuildAppOptions = {}) {
   });
 
   app.get('/ui', async (_request, reply) => {
-    return reply.type('text/html').send(await readPublicFile('index.html'));
+    return reply.header('cache-control', 'no-store').type('text/html').send(await readPublicFile('index.html'));
   });
 
   const uiScriptFiles = ['ui.js', 'ui-api.js', 'ui-constants.js', 'ui-formatters.js', 'ui-state.js'];
 
   for (const file of uiScriptFiles) {
     app.get(`/${file}`, async (_request, reply) => {
-      return reply.type('application/javascript').send(await readPublicFile(file));
+      return reply.header('cache-control', 'no-store').type('application/javascript').send(await readPublicFile(file));
     });
   }
 

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -8,9 +8,10 @@ async function readProjectFile(path) {
   return readFile(new URL(path, repoRoot), 'utf8');
 }
 
-const [indexHtml, uiJs, uiStateJs, stylesCss, appTs] = await Promise.all([
+const [indexHtml, uiJs, uiApiJs, uiStateJs, stylesCss, appTs] = await Promise.all([
   readProjectFile('packages/api/public/index.html'),
   readProjectFile('packages/api/public/ui.js'),
+  readProjectFile('packages/api/public/ui-api.js'),
   readProjectFile('packages/api/public/ui-state.js'),
   readProjectFile('packages/api/public/styles.css'),
   readProjectFile('packages/api/src/app.ts'),
@@ -153,6 +154,15 @@ test('integrity, source coverage, and confirmation safety affordances remain pre
   assertContains(stylesCss, '.confirmation-overlay', 'confirmation overlay styles');
   assertContains(stylesCss, '.confirmation-dialog', 'confirmation dialog styles');
   assert.doesNotMatch(uiJs, /window\.prompt\b/, 'ui.js must not use window.prompt for critical actions');
+});
+
+test('api helper does not mark empty POSTs as JSON bodies', () => {
+  assertContains(uiApiJs, 'export async function api(path, options = {})', 'api helper export');
+  assert.doesNotMatch(
+    uiApiJs,
+    /headers:\s*\{\s*['\"]content-type['\"]:\s*['\"]application\/json['\"]/,
+    'api helper should not set JSON content-type unless a request body is present',
+  );
 });
 
 test('mobile workflow layout affordances are guarded', () => {


### PR DESCRIPTION
## Summary
- only send JSON content-type from the UI API helper when a request body exists
- serve /ui and split UI modules with cache-control: no-store for local dogfooding
- add regression coverage for empty POSTs and UI asset cache headers

Closes #71

## Test Plan
- npm run check
- git diff --check

## Review Notes
- Independent delegate review was attempted but blocked by configured subagent HTTP 402.
- Local static PR review was run; initial finding was missing linked issue/acceptance criteria, now addressed by #71.
