### PR TITLE
feat: add Z.AI web search source provider

### DIFF
--- a/packages/api/public/ui-formatters.js
+++ b/packages/api/public/ui-formatters.js
@@ -12,12 +12,16 @@ export function listToLines(value) {
 }
 
 export function sourceControlsSupported(type) {
-  return type === 'brave' || type === 'rss';
+  return type === 'brave' || type === 'zai-web' || type === 'rss';
 }
 
 export function sourceControlHelp(type) {
   if (type === 'brave') {
     return 'Freshness is sent to Brave. Domain filters are enforced after results return.';
+  }
+
+  if (type === 'zai-web') {
+    return 'Freshness and the first include-domain filter are sent to Z.AI Web Search. Domain filters are also enforced after results return.';
   }
 
   if (type === 'rss') {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1327,7 +1327,7 @@ function buildPipelineStages() {
   const productionActionRunning = productionRunning || isActionRunning('production');
   const packetWarningCount = packet?.warnings?.length || 0;
   const packetBlocked = packet?.status === 'blocked';
-  const profileSupportsDiscovery = profile && ['brave', 'rss'].includes(profile.type);
+  const profileSupportsDiscovery = profile && ['brave', 'zai-web', 'rss'].includes(profile.type);
   const checklist = publishChecklistState();
   const publishChecklistReady = checklist.every((item) => item.passed);
   const publishPreApprovalReady = checklist.filter((item) => item.key !== 'publishApproval').every((item) => item.passed);
@@ -1395,13 +1395,13 @@ function buildPipelineStages() {
             ? 'Add a manual URL to create a candidate story with explicit source provenance.'
             : profileSupportsDiscovery
               ? `Ready: run ${profile.type === 'rss' ? 'RSS import' : 'source search'} to load candidate stories.`
-              : 'Blocked: this story source type cannot run discovery from the browser; use Brave, RSS, or manual intake.',
+              : 'Blocked: this story source type cannot run discovery from the browser; use Brave, Z.AI, RSS, or manual intake.',
       blockers: !profile
         ? ['Choose a story source/search recipe.']
         : !profileSupportsDiscovery && profile.type !== 'manual'
-          ? ['Choose a Brave, RSS, or manual story source for browser-triggered discovery.']
+          ? ['Choose a Brave, Z.AI, RSS, or manual story source for browser-triggered discovery.']
           : [],
-      actionLabel: !profile ? 'Choose Story Source' : profile.type === 'rss' ? 'Import RSS Items' : profile.type === 'brave' ? 'Run Source Search' : profile.type === 'manual' ? 'Add Manual Story' : 'Open Source Settings',
+      actionLabel: !profile ? 'Choose Story Source' : profile.type === 'rss' ? 'Import RSS Items' : ['brave', 'zai-web'].includes(profile.type) ? 'Run Source Search' : profile.type === 'manual' ? 'Add Manual Story' : 'Open Source Settings',
       action: !profile ? () => scrollToPanel('settingsPanel') : profileSupportsDiscovery ? runSelectedProfileDiscovery : profile.type === 'manual' ? focusManualStoryForm : () => scrollToPanel('settingsPanel'),
       disabled: discoverRunning,
       active: state.storyCandidates.length > 0,
@@ -2277,7 +2277,7 @@ function renderSettingsSources() {
       <div class="grid">
         <label class="field"><span>Name</span><input name="name" type="text" required></label>
         <label class="field"><span>Slug</span><input name="slug" type="text" required></label>
-        <label class="field"><span>Type</span><select name="type"><option value="brave">Brave</option><option value="rss">RSS</option><option value="manual">Manual</option><option value="local-json">Local JSON</option></select></label>
+        <label class="field"><span>Type</span><select name="type"><option value="brave">Brave</option><option value="zai-web">Z.AI Web Search</option><option value="rss">RSS</option><option value="manual">Manual</option><option value="local-json">Local JSON</option></select></label>
         <label class="field"><span>Weight</span><input name="weight" type="number" min="0" step="0.001" required></label>
         <label class="field"><span>Freshness window</span><input name="freshness" type="text" placeholder="pd, pw, pm"></label>
         <label class="toggle admin-toggle"><input name="enabled" type="checkbox"><span>Enabled</span></label>
@@ -3866,7 +3866,7 @@ function syncClusterFormFromInputs() {
 async function runSelectedProfileDiscovery() {
   const profile = selectedProfile();
 
-  if (!profile || !['brave', 'rss'].includes(profile.type)) {
+  if (!profile || !['brave', 'zai-web', 'rss'].includes(profile.type)) {
     focusManualStoryForm();
     return;
   }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -33,6 +33,7 @@ import type { BraveFetch } from './search/brave.js';
 import type { RssFetch } from './search/rss.js';
 import type { CandidateScorer } from './search/scoring.js';
 import type { SearchJobStore } from './search/store.js';
+import type { ZaiWebFetch } from './search/zai-web.js';
 import type { LlmRuntime } from './llm/types.js';
 import { registerSchedulerRoutes } from './scheduler/routes.js';
 import type { SchedulerStore } from './scheduler/store.js';
@@ -52,7 +53,9 @@ interface BuildAppOptions extends FastifyServerOptions {
     & Partial<ProductionStore>
     & Partial<SchedulerStore>;
   braveApiKey?: string;
+  zaiApiKey?: string;
   fetchImpl?: BraveFetch;
+  zaiFetchImpl?: ZaiWebFetch;
   rssFetchImpl?: RssFetch;
   candidateScorer?: CandidateScorer;
   llmRuntime?: LlmRuntime;
@@ -92,7 +95,9 @@ export function buildApp(options: BuildAppOptions = {}) {
   const {
     sourceStore,
     braveApiKey,
+    zaiApiKey,
     fetchImpl,
+    zaiFetchImpl,
     rssFetchImpl,
     candidateScorer,
     llmRuntime,
@@ -216,7 +221,9 @@ export function buildApp(options: BuildAppOptions = {}) {
       return resolvedSourceStore;
     },
     braveApiKey,
+    zaiApiKey,
     fetchImpl,
+    zaiFetchImpl,
     rssFetchImpl,
     candidateScorer,
     llmRuntime,

--- a/packages/api/src/config/types.ts
+++ b/packages/api/src/config/types.ts
@@ -22,7 +22,7 @@ export interface CastMemberConfig {
 
 export interface SourceConfig {
   id: string;
-  type: 'brave' | 'rss' | 'manual' | 'local-json';
+  type: 'brave' | 'zai-web' | 'rss' | 'manual' | 'local-json';
   enabled: boolean;
   weight?: number;
   freshness?: string;

--- a/packages/api/src/search/job.ts
+++ b/packages/api/src/search/job.ts
@@ -1,8 +1,9 @@
-import { searchBraveNews, type BraveCandidate, type BraveFetch } from './brave.js';
+import { searchBraveNews, type BraveFetch } from './brave.js';
 import { normalizeTitle, type SourceCandidate } from './candidate.js';
 import { filterCandidatesForSourceControls, type SourceControlSummary } from './controls.js';
 import { fetchRssCandidates, type RssFetch } from './rss.js';
 import { scoreCandidateBatch, scoringLimitFromProfile, type CandidateScorer, type CandidateScoringBatchResult } from './scoring.js';
+import { searchZaiWeb, type ZaiWebFetch } from './zai-web.js';
 import type { JobRecord, SearchJobStore, StoryCandidateRecord } from './store.js';
 import type { ResolvedModelProfile } from '../models/resolver.js';
 import type { SourceProfileRecord, SourceQueryRecord, SourceStore } from '../sources/store.js';
@@ -20,6 +21,7 @@ interface RunSourceSearchOptions {
   queries: SourceQueryRecord[];
   store: SourceStore & SearchJobStore;
   fetchImpl?: BraveFetch;
+  zaiFetchImpl?: ZaiWebFetch;
   sleep?: (ms: number) => Promise<void>;
   modelProfile?: ResolvedModelProfile;
   candidateScorer?: CandidateScorer;
@@ -53,9 +55,31 @@ function asPositiveNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-function queryIdFromCandidate(candidate: BraveCandidate): string | null {
+function queryIdFromCandidate(candidate: SourceCandidate): string | null {
   const query = asObject(candidate.metadata.query);
   return typeof query.id === 'string' ? query.id : null;
+}
+
+function providerLabel(profile: SourceProfileRecord): string {
+  return profile.type === 'zai-web' ? 'Z.AI web' : 'Brave news';
+}
+
+async function searchProviderCandidates(options: RunSourceSearchOptions, query: SourceQueryRecord) {
+  if (options.profile.type === 'zai-web') {
+    return searchZaiWeb({
+      apiKey: options.apiKey,
+      profile: options.profile,
+      queries: [query],
+      fetchImpl: options.zaiFetchImpl,
+    });
+  }
+
+  return searchBraveNews({
+    apiKey: options.apiKey,
+    profile: options.profile,
+    queries: [query],
+    fetchImpl: options.fetchImpl,
+  });
 }
 
 function sourceQueryIdFromCandidate(candidate: SourceCandidate): string | null {
@@ -236,21 +260,17 @@ export async function runSourceSearch(options: RunSourceSearchOptions): Promise<
     const sourceControlWarnings: Array<Record<string, unknown>> = [];
 
     for (const [index, query] of options.queries.entries()) {
-      logs.push(log('info', 'Running Brave news query.', { sourceQueryId: query.id, query: query.query }));
+      const provider = providerLabel(options.profile);
+      logs.push(log('info', `Running ${provider} query.`, { sourceQueryId: query.id, query: query.query }));
 
-      const rawCandidates = await searchBraveNews({
-        apiKey: options.apiKey,
-        profile: options.profile,
-        queries: [query],
-        fetchImpl: options.fetchImpl,
-      });
+      const rawCandidates = await searchProviderCandidates(options, query);
       const filtered = filterCandidatesForSourceControls(rawCandidates, options.profile, query, { verifyFreshness: false });
       const candidates = filtered.candidates;
       sourceControlSummaries.push(filtered.controls);
       addFilterTotals(sourceControlDropped, filtered.dropped);
       sourceControlWarnings.push(...filtered.warnings);
 
-      logs.push(log('info', 'Brave news query returned candidates.', {
+      logs.push(log('info', `${provider} query returned candidates.`, {
         sourceQueryId: query.id,
         candidateCount: rawCandidates.length,
         sourceControls: filterSummary(rawCandidates.length, candidates.length, filtered.dropped, filtered.warnings),

--- a/packages/api/src/search/routes.test.ts
+++ b/packages/api/src/search/routes.test.ts
@@ -5,6 +5,7 @@ import { buildApp } from '../app.js';
 import type { BraveFetch } from './brave.js';
 import type { RssFetch } from './rss.js';
 import type { CandidateScorer, CandidateScoringRequest } from './scoring.js';
+import type { ZaiWebFetch } from './zai-web.js';
 import type {
   CreateJobInput,
   CreateStoryCandidateInput,
@@ -256,6 +257,16 @@ function rssFetch(xml: string): RssFetch {
   });
 }
 
+function zaiWebFetch(results: Array<Record<string, unknown>>): ZaiWebFetch {
+  return async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return { search_result: results };
+    },
+  });
+}
+
 const deterministicScorer: CandidateScorer = {
   async score(request: CandidateScoringRequest) {
     if (request.candidate.title.includes('Fail')) {
@@ -286,6 +297,42 @@ const deterministicScorer: CandidateScorer = {
 };
 
 describe('search routes candidate scoring', () => {
+  it('runs a Z.AI web source.search job with GLM-compatible credentials', async () => {
+    const store = new FakeSearchStore();
+    store.profiles[0] = {
+      ...store.profiles[0],
+      slug: 'zai-news',
+      name: 'Z.AI News',
+      type: 'zai-web',
+      freshness: 'pd',
+    };
+    const app = buildApp({
+      sourceStore: store,
+      zaiApiKey: 'test-zai-key',
+      zaiFetchImpl: zaiWebFetch([{
+        title: 'High value ZAI result',
+        link: 'https://example.com/zai-story',
+        content: 'Structured Z.AI search result.',
+        media: 'Example News',
+        publish_date: '2026-04-23',
+        refer: 'ref_1',
+      }]),
+    });
+
+    try {
+      const response = await app.inject({ method: 'POST', url: '/source-profiles/22222222-2222-4222-8222-222222222222/search' });
+      const body = response.json();
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(body.inserted, 1);
+      assert.equal(body.candidates[0].url, 'https://example.com/zai-story');
+      assert.equal(body.candidates[0].metadata.provider, 'zai-web');
+      assert.match(JSON.stringify(body.job.logs), /Z\.AI web query returned candidates/);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('enforces Brave include and exclude domains without substring overmatching', async () => {
     const store = new FakeSearchStore();
     store.profiles[0].includeDomains = ['https://AI.com/news'];

--- a/packages/api/src/search/routes.ts
+++ b/packages/api/src/search/routes.ts
@@ -7,6 +7,7 @@ import { submitManualCandidate } from './manual.js';
 import { resolveRssFeedRefs, type RssFetch } from './rss.js';
 import { createLlmCandidateScorer, type CandidateScorer } from './scoring.js';
 import type { SearchJobStore } from './store.js';
+import type { ZaiWebFetch } from './zai-web.js';
 import { createLlmRuntime } from '../llm/runtime.js';
 import type { LlmRuntime } from '../llm/types.js';
 import { hasModelProfileStore, resolveModelProfile } from '../models/resolver.js';
@@ -29,7 +30,9 @@ class ApiError extends Error {
 export interface SearchRoutesOptions {
   getStore(): SourceStore & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<PromptTemplateStore>;
   braveApiKey?: string;
+  zaiApiKey?: string;
   fetchImpl?: BraveFetch;
+  zaiFetchImpl?: ZaiWebFetch;
   rssFetchImpl?: RssFetch;
   candidateScorer?: CandidateScorer;
   llmRuntime?: LlmRuntime;
@@ -143,6 +146,39 @@ function candidateScorerFor(
   });
 }
 
+function resolveZaiApiKey(options: SearchRoutesOptions): string | undefined {
+  return options.zaiApiKey
+    ?? process.env.ZAI_API_KEY
+    ?? process.env.GLM_API_KEY
+    ?? process.env.GLM_API
+    ?? process.env.ZHIPU_API_KEY
+    ?? process.env.ZHIPUAI_API_KEY;
+}
+
+function searchCredentialForSource(profileType: string, options: SearchRoutesOptions): string {
+  if (profileType === 'brave') {
+    const apiKey = options.braveApiKey ?? process.env.BRAVE_API_KEY;
+
+    if (!apiKey) {
+      throw new ApiError(400, 'BRAVE_API_KEY_REQUIRED', 'Set BRAVE_API_KEY before running a Brave source search.');
+    }
+
+    return apiKey;
+  }
+
+  if (profileType === 'zai-web') {
+    const apiKey = resolveZaiApiKey(options);
+
+    if (!apiKey) {
+      throw new ApiError(400, 'ZAI_API_KEY_REQUIRED', 'Set ZAI_API_KEY or GLM_API_KEY before running a Z.AI web source search.');
+    }
+
+    return apiKey;
+  }
+
+  throw new ApiError(400, 'UNSUPPORTED_SOURCE_TYPE', `source.search supports brave and zai-web profiles, not ${profileType}.`);
+}
+
 async function resolveShowId(store: SourceStore, showId?: string, showSlug?: string): Promise<string> {
   if (showId) {
     const show = (await store.listShows()).find((candidate) => candidate.id === showId);
@@ -178,19 +214,15 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
         throw new ApiError(404, 'SOURCE_PROFILE_NOT_FOUND', `Source profile not found: ${request.params.id}`);
       }
 
-      if (profile.type !== 'brave') {
-        throw new ApiError(400, 'UNSUPPORTED_SOURCE_TYPE', `source.search supports brave profiles, not ${profile.type}.`);
+      if (profile.type !== 'brave' && profile.type !== 'zai-web') {
+        throw new ApiError(400, 'UNSUPPORTED_SOURCE_TYPE', `source.search supports brave and zai-web profiles, not ${profile.type}.`);
       }
 
       if (!profile.enabled) {
         throw new ApiError(400, 'SOURCE_PROFILE_DISABLED', `Source profile is disabled: ${profile.slug}`);
       }
 
-      const apiKey = options.braveApiKey ?? process.env.BRAVE_API_KEY;
-
-      if (!apiKey) {
-        throw new ApiError(400, 'BRAVE_API_KEY_REQUIRED', 'Set BRAVE_API_KEY before running a Brave source search.');
-      }
+      const credential = searchCredentialForSource(profile.type, options);
 
       const queries = await store.listSourceQueries(profile.id, { enabledOnly: true });
 
@@ -203,11 +235,12 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
         : undefined;
       const candidateScorer = candidateScorerFor(options, rawStore, modelProfile);
       const result = await runSourceSearch({
-        apiKey,
+        apiKey: credential,
         profile,
         queries,
         store,
         fetchImpl: options.fetchImpl,
+        zaiFetchImpl: options.zaiFetchImpl,
         sleep: options.sleep,
         modelProfile,
         candidateScorer,

--- a/packages/api/src/search/zai-web.test.ts
+++ b/packages/api/src/search/zai-web.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { searchZaiWeb, type ZaiWebFetch } from './zai-web.js';
+import type { SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+
+const profile: SourceProfileRecord = {
+  id: '22222222-2222-4222-8222-222222222222',
+  showId: '11111111-1111-4111-8111-111111111111',
+  slug: 'zai-news',
+  name: 'Z.AI News',
+  type: 'zai-web',
+  enabled: true,
+  weight: 1,
+  freshness: 'pd',
+  includeDomains: ['example.com'],
+  excludeDomains: [],
+  rateLimit: {},
+  config: { count: 2 },
+  createdAt: new Date('2026-04-26T00:00:00Z'),
+  updatedAt: new Date('2026-04-26T00:00:00Z'),
+};
+
+const query: SourceQueryRecord = {
+  id: '33333333-3333-4333-8333-333333333333',
+  sourceProfileId: profile.id,
+  query: 'latest AI model releases',
+  enabled: true,
+  weight: 1,
+  region: null,
+  language: 'en',
+  freshness: 'pd',
+  includeDomains: [],
+  excludeDomains: [],
+  config: {},
+  createdAt: new Date('2026-04-26T00:00:00Z'),
+  updatedAt: new Date('2026-04-26T00:00:00Z'),
+};
+
+describe('Z.AI web search adapter', () => {
+  it('posts structured search requests and maps results to source candidates', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    const fetchImpl: ZaiWebFetch = async (_url, init) => {
+      capturedBody = JSON.parse(init.body) as Record<string, unknown>;
+
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            id: 'search-1',
+            search_result: [{
+              title: 'OpenAI announces GPT-5.5',
+              link: 'https://example.com/gpt-5-5',
+              content: 'A concise search result summary.',
+              media: 'Example News',
+              publish_date: '2026-04-23',
+              refer: 'ref_1',
+            }],
+          };
+        },
+      };
+    };
+
+    const candidates = await searchZaiWeb({ apiKey: 'test-key', profile, queries: [query], fetchImpl });
+
+    assert.equal(capturedBody?.search_engine, 'search-prime');
+    assert.equal(capturedBody?.search_query, 'latest AI model releases');
+    assert.equal(capturedBody?.count, 2);
+    assert.equal(capturedBody?.search_domain_filter, 'example.com');
+    assert.equal(capturedBody?.search_recency_filter, 'oneDay');
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].title, 'OpenAI announces GPT-5.5');
+    assert.equal(candidates[0].url, 'https://example.com/gpt-5-5');
+    assert.equal(candidates[0].sourceName, 'Example News');
+    const metadata = candidates[0].metadata as Record<string, { id: string } | string>;
+    assert.equal(metadata.provider, 'zai-web');
+    assert.equal((metadata.query as { id: string }).id, query.id);
+  });
+});

--- a/packages/api/src/search/zai-web.ts
+++ b/packages/api/src/search/zai-web.ts
@@ -1,0 +1,215 @@
+import type { SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+import { canonicalizeUrl, cleanText, type SourceCandidate } from './candidate.js';
+
+export interface ZaiWebResponse {
+  ok: boolean;
+  status: number;
+  statusText?: string;
+  json(): Promise<unknown>;
+}
+
+export type ZaiWebFetch = (
+  url: string,
+  init: { method: 'POST'; headers: Record<string, string>; body: string; signal?: AbortSignal },
+) => Promise<ZaiWebResponse>;
+
+export type ZaiWebCandidate = SourceCandidate;
+
+interface ZaiWebSearchOptions {
+  apiKey: string;
+  profile: SourceProfileRecord;
+  queries: SourceQueryRecord[];
+  fetchImpl?: ZaiWebFetch;
+  timeoutMs?: number;
+}
+
+type JsonObject = Record<string, unknown>;
+
+const ZAI_WEB_SEARCH_URL = 'https://api.z.ai/api/paas/v4/web_search';
+
+function defaultFetch(url: string, init: { method: 'POST'; headers: Record<string, string>; body: string; signal?: AbortSignal }) {
+  return fetch(url, init) as Promise<ZaiWebResponse>;
+}
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asPositiveInteger(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const parsed = Number(value);
+    return parsed > 0 ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function option(query: SourceQueryRecord, profile: SourceProfileRecord, key: string): unknown {
+  return query.config[key] ?? profile.config[key];
+}
+
+function resolveCount(query: SourceQueryRecord, profile: SourceProfileRecord): number {
+  return Math.min(asPositiveInteger(option(query, profile, 'count')) ?? 10, 50);
+}
+
+function resolveSearchEngine(query: SourceQueryRecord, profile: SourceProfileRecord): string {
+  return asString(option(query, profile, 'searchEngine'))
+    ?? asString(option(query, profile, 'search_engine'))
+    ?? 'search-prime';
+}
+
+function resolveFreshness(query: SourceQueryRecord, profile: SourceProfileRecord): string | undefined {
+  const value = query.freshness ?? profile.freshness ?? asString(option(query, profile, 'search_recency_filter'));
+
+  switch (value) {
+    case 'pd':
+    case 'oneDay':
+      return 'oneDay';
+    case 'pw':
+    case 'oneWeek':
+      return 'oneWeek';
+    case 'pm':
+    case 'oneMonth':
+      return 'oneMonth';
+    case 'py':
+    case 'oneYear':
+      return 'oneYear';
+    case 'noLimit':
+      return 'noLimit';
+    default:
+      return value ?? undefined;
+  }
+}
+
+function domainFilter(query: SourceQueryRecord, profile: SourceProfileRecord): string | undefined {
+  const configured = asString(option(query, profile, 'search_domain_filter'));
+
+  if (configured) {
+    return configured;
+  }
+
+  const domains = [...profile.includeDomains, ...query.includeDomains]
+    .map((domain) => domain.trim())
+    .filter(Boolean);
+
+  return domains[0];
+}
+
+function parsePublishedAt(value: unknown): Date | null {
+  const candidate = asString(value);
+
+  if (!candidate) {
+    return null;
+  }
+
+  const parsed = new Date(candidate);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function resultItems(payload: JsonObject): JsonObject[] {
+  const direct = payload.search_result;
+  const nested = asObject(payload.result).search_result;
+  const fallback = payload.results;
+  const items = Array.isArray(direct) ? direct : Array.isArray(nested) ? nested : Array.isArray(fallback) ? fallback : [];
+
+  return items.map(asObject);
+}
+
+function mapResult(item: JsonObject, query: SourceQueryRecord, profile: SourceProfileRecord, search: JsonObject): ZaiWebCandidate | undefined {
+  const title = asString(item.title);
+  const url = asString(item.link) ?? asString(item.url);
+
+  if (!title || !url) {
+    return undefined;
+  }
+
+  return {
+    title: cleanText(title),
+    url,
+    canonicalUrl: canonicalizeUrl(url),
+    sourceName: asString(item.media) ?? asString(item.source) ?? null,
+    summary: asString(item.content) ? cleanText(String(item.content)) : null,
+    publishedAt: parsePublishedAt(item.publish_date ?? item.published_at ?? item.date),
+    rawPayload: item,
+    metadata: {
+      provider: 'zai-web',
+      query: {
+        id: query.id,
+        text: query.query,
+        origin: {
+          sourceProfileId: profile.id,
+          sourceProfileSlug: profile.slug,
+          sourceQueryId: query.id,
+        },
+      },
+      search,
+      refer: item.refer ?? null,
+    },
+  };
+}
+
+export async function searchZaiWeb(options: ZaiWebSearchOptions): Promise<ZaiWebCandidate[]> {
+  const fetchImpl = options.fetchImpl ?? defaultFetch;
+  const candidates: ZaiWebCandidate[] = [];
+
+  for (const query of options.queries) {
+    const searchEngine = resolveSearchEngine(query, options.profile);
+    const count = resolveCount(query, options.profile);
+    const recency = resolveFreshness(query, options.profile);
+    const domain = domainFilter(query, options.profile);
+    const body: Record<string, unknown> = {
+      search_engine: searchEngine,
+      search_query: query.query,
+      count,
+    };
+
+    if (recency) {
+      body.search_recency_filter = recency;
+    }
+
+    if (domain) {
+      body.search_domain_filter = domain;
+    }
+
+    const response = await fetchImpl(ZAI_WEB_SEARCH_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${options.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(options.timeoutMs ?? 10_000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Z.AI web search failed with HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`);
+    }
+
+    const payload = asObject(await response.json());
+    const search = {
+      searchEngine,
+      count,
+      recency: recency ?? null,
+      domain: domain ?? null,
+    };
+
+    for (const item of resultItems(payload)) {
+      const mapped = mapResult(item, query, options.profile, search);
+
+      if (mapped) {
+        candidates.push(mapped);
+      }
+    }
+  }
+
+  return candidates;
+}

--- a/packages/api/src/shows/routes.ts
+++ b/packages/api/src/shows/routes.ts
@@ -40,10 +40,10 @@ const castSchema = z.array(z.object({
   role: z.string().trim().min(1).optional(),
   voice: z.string().trim().min(1),
 })).default([]);
-const sourceTypeSchema = z.enum(['brave', 'rss', 'manual', 'local-json']);
+const sourceTypeSchema = z.enum(['brave', 'zai-web', 'rss', 'manual', 'local-json']);
 
 function supportsDiscoveryControls(type: z.infer<typeof sourceTypeSchema>) {
-  return type === 'brave' || type === 'rss';
+  return type === 'brave' || type === 'zai-web' || type === 'rss';
 }
 
 const feedFieldsSchema = z.object({

--- a/packages/api/src/sources/routes.ts
+++ b/packages/api/src/sources/routes.ts
@@ -10,7 +10,7 @@ import type {
   UpdateSourceQueryInput,
 } from './store.js';
 
-const sourceTypeSchema = z.enum(['brave', 'rss', 'manual', 'local-json']);
+const sourceTypeSchema = z.enum(['brave', 'zai-web', 'rss', 'manual', 'local-json']);
 const domainListSchema = z.array(z.string().trim().min(1)).default([]);
 const jsonObjectSchema = z.record(z.string(), z.unknown()).default({});
 const nullableTextSchema = z.string().trim().min(1).nullable().default(null);
@@ -86,7 +86,7 @@ class ApiError extends Error {
 }
 
 function supportsDiscoveryControls(type: z.infer<typeof sourceTypeSchema> | undefined): boolean {
-  return type === 'brave' || type === 'rss';
+  return type === 'brave' || type === 'zai-web' || type === 'rss';
 }
 
 function normalizeProfileCreateInput(body: z.infer<typeof profileCreateSchema>): Omit<CreateSourceProfileInput, 'showId'> {

--- a/packages/api/src/sources/store.ts
+++ b/packages/api/src/sources/store.ts
@@ -1,4 +1,4 @@
-export type SourceType = 'brave' | 'rss' | 'manual' | 'local-json';
+export type SourceType = 'brave' | 'zai-web' | 'rss' | 'manual' | 'local-json';
 export type ShowSetupStatus = 'draft' | 'active';
 
 export interface ShowCastMember {

--- a/packages/db/drizzle/0004_zai_web_source_type.sql
+++ b/packages/db/drizzle/0004_zai_web_source_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'zai-web';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777140000000,
       "tag": "0003_show_onboarding",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777345000000,
+      "tag": "0004_zai_web_source_type",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -12,7 +12,7 @@ import {
   uuid
 } from 'drizzle-orm/pg-core';
 
-export const sourceType = pgEnum('source_type', ['brave', 'rss', 'manual', 'local-json']);
+export const sourceType = pgEnum('source_type', ['brave', 'zai-web', 'rss', 'manual', 'local-json']);
 export const showSetupStatus = pgEnum('show_setup_status', ['draft', 'active']);
 export const storyStatus = pgEnum('story_status', ['new', 'shortlisted', 'ignored', 'merged']);
 export const episodeCandidateStatus = pgEnum('episode_candidate_status', ['draft', 'researching', 'ready', 'rejected']);

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -17,7 +17,7 @@ type ExampleConfig = {
   };
   sources: Array<{
     id: string;
-    type: 'brave' | 'rss' | 'manual' | 'local-json';
+    type: 'brave' | 'zai-web' | 'rss' | 'manual' | 'local-json';
     enabled: boolean;
     weight?: number;
     freshness?: string;

--- a/schemas/podcast-forge.config.schema.json
+++ b/schemas/podcast-forge.config.schema.json
@@ -34,7 +34,7 @@
         "required": ["id", "type", "enabled"],
         "properties": {
           "id": { "type": "string" },
-          "type": { "enum": ["brave", "rss", "manual", "local-json"] },
+          "type": { "enum": ["brave", "zai-web", "rss", "manual", "local-json"] },
           "enabled": { "type": "boolean" },
           "weight": { "type": "number" },
           "freshness": { "type": "string" },


### PR DESCRIPTION
## Summary
- add Z.AI Web Search as a first-class source profile type (`zai-web`)
- support `ZAI_API_KEY`, `GLM_API_KEY`, `GLM_API`, and ZHIPU-compatible env aliases
- map Z.AI web results into story candidates with provenance metadata and existing scoring/dedupe flow
- expose Z.AI source type in static UI/config/schema and add a DB enum migration

## Verification
- `npm run check`
- `node --test scripts/ui-guided-flow-smoke.test.mjs`

Closes #72
