### PR TITLE
PF3-01 Define Produce workspace view-model contract

### DIFF
--- a/packages/api/public/ui-formatters.js
+++ b/packages/api/public/ui-formatters.js
@@ -105,15 +105,15 @@ export function readPublishingMode(show) {
 }
 
 export function outputPathForFeed(feed) {
-  const metadata = asObject(feed.metadata);
-  const storageConfig = asObject(feed.storageConfig);
-  const value = metadata.outputPath || storageConfig.outputPath || feed.rssFeedPath || '';
+  const metadata = asObject(feed?.metadata);
+  const storageConfig = asObject(feed?.storageConfig);
+  const value = metadata.outputPath || storageConfig.outputPath || feed?.rssFeedPath || '';
   return typeof value === 'string' ? safeVisiblePath(value) : '';
 }
 
 export function publicAssetBaseForFeed(feed) {
-  const metadata = asObject(feed.metadata);
-  return typeof metadata.publicAssetBaseUrl === 'string' ? metadata.publicAssetBaseUrl : feed.publicBaseUrl || '';
+  const metadata = asObject(feed?.metadata);
+  return typeof metadata.publicAssetBaseUrl === 'string' ? metadata.publicAssetBaseUrl : feed?.publicBaseUrl || '';
 }
 
 export function safeVisiblePath(value) {

--- a/packages/api/public/ui-formatters.js
+++ b/packages/api/public/ui-formatters.js
@@ -111,9 +111,35 @@ export function outputPathForFeed(feed) {
   return typeof value === 'string' ? safeVisiblePath(value) : '';
 }
 
+function rawOutputPathForFeed(feed) {
+  const metadata = asObject(feed?.metadata);
+  const storageConfig = asObject(feed?.storageConfig);
+  const value = feed?.rssFeedPath || metadata.outputPath || storageConfig.outputPath || '';
+  return typeof value === 'string' ? value.trim() : '';
+}
+
 export function publicAssetBaseForFeed(feed) {
   const metadata = asObject(feed?.metadata);
   return typeof metadata.publicAssetBaseUrl === 'string' ? metadata.publicAssetBaseUrl : feed?.publicBaseUrl || '';
+}
+
+export function validHttpUrl(value) {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function publishTargetConfiguredForFeed(feed) {
+  const publicFeedUrl = typeof feed?.publicFeedUrl === 'string' ? feed.publicFeedUrl.trim() : '';
+  const publicBaseUrl = publicAssetBaseForFeed(feed);
+  return Boolean(publicFeedUrl || (publicBaseUrl && rawOutputPathForFeed(feed)));
 }
 
 export function safeVisiblePath(value) {

--- a/packages/api/public/ui-formatters.js
+++ b/packages/api/public/ui-formatters.js
@@ -111,13 +111,6 @@ export function outputPathForFeed(feed) {
   return typeof value === 'string' ? safeVisiblePath(value) : '';
 }
 
-function rawOutputPathForFeed(feed) {
-  const metadata = asObject(feed?.metadata);
-  const storageConfig = asObject(feed?.storageConfig);
-  const value = feed?.rssFeedPath || metadata.outputPath || storageConfig.outputPath || '';
-  return typeof value === 'string' ? value.trim() : '';
-}
-
 export function publicAssetBaseForFeed(feed) {
   const metadata = asObject(feed?.metadata);
   return typeof metadata.publicAssetBaseUrl === 'string' ? metadata.publicAssetBaseUrl : feed?.publicBaseUrl || '';
@@ -139,7 +132,8 @@ export function validHttpUrl(value) {
 export function publishTargetConfiguredForFeed(feed) {
   const publicFeedUrl = typeof feed?.publicFeedUrl === 'string' ? feed.publicFeedUrl.trim() : '';
   const publicBaseUrl = publicAssetBaseForFeed(feed);
-  return Boolean(publicFeedUrl || (publicBaseUrl && rawOutputPathForFeed(feed)));
+  const rssFeedPath = typeof feed?.rssFeedPath === 'string' ? feed.rssFeedPath.trim() : '';
+  return Boolean(publicFeedUrl || (publicBaseUrl && rssFeedPath));
 }
 
 export function safeVisiblePath(value) {

--- a/packages/api/public/ui-state.js
+++ b/packages/api/public/ui-state.js
@@ -25,6 +25,12 @@ export const state = {
     assets: [],
     jobs: [],
   },
+  productionViewModel: null,
+  latestActionResult: {
+    status: 'idle',
+    message: '',
+    source: 'ui',
+  },
   productionPoll: null,
   jobPoll: null,
   selectedCandidateIds: [],

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -440,6 +440,7 @@ function deriveStages(context) {
     assets,
     jobs,
     feed,
+    sourceQueries,
   } = context;
   const integrity = integrityReviewState(activeRevision);
   const scriptApproved = Boolean(activeScript && activeRevision && activeScript.status === 'approved-for-audio' && activeScript.approvedRevisionId === activeRevision.id);
@@ -469,7 +470,7 @@ function deriveStages(context) {
 
   const stages = [
     makeStage('show', show ? 'done' : 'blocked', summarizeShow(show)),
-    makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source)),
+    makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source, sourceQueries)),
     makeStage('discover', hasCandidatePool ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
     makeStage('story', hasStorySelection ? 'done' : hasCandidatePool ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
     makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefBlocked ? 'blocked' : 'done') : hasStorySelection ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
@@ -495,9 +496,9 @@ function deriveStages(context) {
   } else if (!activeScript) {
     primaryNextAction = action('Generate script draft', 'script', true);
   } else if (!activeRevision) {
-    primaryNextAction = action('Select script revision', 'script', false, 'Select a script revision before integrity review.');
+    primaryNextAction = action('Select script revision', 'script', true);
   } else if (integrity.blocking) {
-    primaryNextAction = action(integrity.status === 'fail' ? 'Resolve integrity review' : 'Run integrity review', 'review', integrity.status === 'missing', integrity.status === 'fail' ? 'Resolve the failed integrity review or record an explicit override reason.' : '');
+    primaryNextAction = action(integrity.status === 'fail' ? 'Rerun integrity review' : 'Run integrity review', 'review', true);
   } else if (!scriptApproved) {
     primaryNextAction = action('Approve script for audio', 'review', true);
   } else if (!audio || !cover) {
@@ -638,6 +639,7 @@ export function deriveProductionViewModel(input = {}) {
     assets: activeAssets,
     jobs,
     feed,
+    sourceQueries,
   };
   const { stages, currentStage, primaryNextAction, checklist } = deriveStages(context);
   const activeIds = {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -666,8 +666,9 @@ export function deriveProductionViewModel(input = {}) {
   const activeRevision = input.selectedRevision || revisions[0] || null;
   const activeEpisode = production.episode || episodes.find((episode) => episode.id === input.selectedEpisodeId) || null;
   const selectedAssetIds = new Set(asArray(input.selectedAssetIds));
-  const activeAssets = selectedAssetIds.size > 0
-    ? productionAssets.filter((asset) => selectedAssetIds.has(asset.id))
+  const selectedAssets = productionAssets.filter((asset) => selectedAssetIds.has(asset.id));
+  const activeAssets = selectedAssetIds.size > 0 && selectedAssets.length > 0
+    ? selectedAssets
     : productionAssets;
   const feed = selectedFeed(feeds, activeEpisode, selectedShow);
   const sourceQueries = selectedSource ? queries.filter((query) => !query.sourceProfileId || query.sourceProfileId === selectedSource.id) : [];

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -309,6 +309,20 @@ function validHttpUrl(value) {
   }
 }
 
+function safeVisiblePath(value) {
+  const text = String(value || '').trim();
+
+  if (!text) {
+    return '';
+  }
+
+  if (text.startsWith('/') || text.startsWith('~') || /^[A-Za-z]:[\\/]/.test(text)) {
+    return '';
+  }
+
+  return text;
+}
+
 function publicAssetBaseForFeed(feed) {
   const metadata = asObject(feed?.metadata);
   return typeof metadata.publicAssetBaseUrl === 'string' ? metadata.publicAssetBaseUrl : feed?.publicBaseUrl || '';
@@ -317,7 +331,7 @@ function publicAssetBaseForFeed(feed) {
 function outputPathForFeed(feed) {
   const metadata = asObject(feed?.metadata);
   const storageConfig = asObject(feed?.storageConfig);
-  return metadata.outputPath || storageConfig.outputPath || feed?.rssFeedPath || '';
+  return safeVisiblePath(metadata.outputPath || storageConfig.outputPath || feed?.rssFeedPath || '');
 }
 
 function publishChecklist({ packet, script, revision, episode, assets, feed, jobs }) {
@@ -330,7 +344,7 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
   const feedPublicUrl = feed?.publicFeedUrl || '';
   const publicBaseUrl = publicAssetBaseForFeed(feed);
   const feedConfigured = Boolean(feed);
-  const targetConfigured = Boolean(feed?.rssFeedPath || outputPathForFeed(feed) || feedPublicUrl);
+  const targetConfigured = Boolean(outputPathForFeed(feed) || feedPublicUrl);
   const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
   const audioValid = Boolean(audio && audio.mimeType && audio.mimeType.startsWith('audio/') && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
   const coverValid = Boolean(cover && cover.mimeType && cover.mimeType.startsWith('image/'));
@@ -492,7 +506,7 @@ function deriveStages(context) {
   } else if (!activeBrief) {
     primaryNextAction = action('Build research brief', 'brief', true);
   } else if (briefBlocked) {
-    primaryNextAction = action('Resolve research warnings', 'brief', false, briefNeedsReview ? `${unresolvedBriefWarnings.length} research warning${unresolvedBriefWarnings.length === 1 ? '' : 's'} need override reasons before drafting.` : 'Resolve or override research warnings before drafting.');
+    primaryNextAction = action('Resolve research warnings', 'brief', true);
   } else if (!activeScript) {
     primaryNextAction = action('Generate script draft', 'script', true);
   } else if (!activeRevision) {
@@ -551,6 +565,20 @@ function warningItem(stage, message, source = null, severity = 'warning') {
   return compactObject({ stage, severity, message, source });
 }
 
+function checklistStage(key) {
+  return {
+    research: 'brief',
+    script: 'script',
+    integrity: 'review',
+    audio: 'production',
+    cover: 'production',
+    feed: 'publishing',
+    target: 'publishing',
+    warnings: 'publishing',
+    publishApproval: 'publishing',
+  }[key] || 'publishing';
+}
+
 function deriveWarningsAndBlockers({ activeBrief, activeRevision, activeEpisode, assets, jobs, checklist, selectedCandidates }) {
   const warnings = [];
   const blockers = [];
@@ -579,7 +607,7 @@ function deriveWarningsAndBlockers({ activeBrief, activeRevision, activeEpisode,
 
   if (activeEpisode || assets.length > 0) {
     for (const item of checklist.filter((entry) => !entry.passed)) {
-      const target = item.key === 'publishApproval' ? 'publishing' : item.key;
+      const target = checklistStage(item.key);
       blockers.push(warningItem(target, `${item.label}: ${item.reason}`, item, 'error'));
     }
   }

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -294,8 +294,14 @@ function productionWarnings(episode, assets, jobs) {
   ].filter(Boolean);
 }
 
-function selectedFeed(feeds, episode) {
-  return asArray(feeds).find((feed) => feed.id === episode?.feedId) || asArray(feeds)[0] || null;
+function selectedFeed(feeds, episode, show) {
+  const matchingEpisodeFeed = asArray(feeds).find((feed) => feed.id === episode?.feedId);
+  if (matchingEpisodeFeed) {
+    return matchingEpisodeFeed;
+  }
+
+  const showFeeds = show?.id ? asArray(feeds).filter((feed) => feed.showId === show.id) : asArray(feeds);
+  return showFeeds.length === 1 ? showFeeds[0] : null;
 }
 
 function validHttpUrl(value) {
@@ -469,7 +475,7 @@ function deriveStages(context) {
     makeStage('story', hasStorySelection ? 'done' : hasCandidatePool ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
     makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefBlocked ? 'blocked' : 'done') : hasStorySelection ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
     makeStage('script', activeScript ? 'done' : activeBrief && !briefBlocked ? 'ready' : 'blocked', summarizeScript(activeScript, activeRevision)),
-    makeStage('review', readyForProduction ? 'done' : activeScript && activeRevision ? 'needs-review' : 'blocked', summarizeReview(activeRevision)),
+    makeStage('review', readyForProduction ? 'done' : activeScript ? (activeRevision ? 'needs-review' : 'ready') : 'blocked', summarizeReview(activeRevision)),
     makeStage('production', audio && cover ? 'done' : readyForProduction ? 'ready' : 'blocked', summarizeAudioCover(assets)),
     makeStage('publishing', activeEpisode?.status === 'published' ? 'done' : audio && cover ? (publishPrerequisiteBlocker ? 'blocked' : 'ready') : 'blocked', summarizeEpisode(activeEpisode)),
   ];
@@ -633,7 +639,7 @@ export function deriveProductionViewModel(input = {}) {
   const activeAssets = selectedAssetIds.size > 0
     ? productionAssets.filter((asset) => selectedAssetIds.has(asset.id))
     : productionAssets;
-  const feed = selectedFeed(feeds, activeEpisode);
+  const feed = selectedFeed(feeds, activeEpisode, selectedShow);
   const sourceQueries = selectedSource ? queries.filter((query) => !query.sourceProfileId || query.sourceProfileId === selectedSource.id) : [];
   const context = {
     show: selectedShow,

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -1,3 +1,5 @@
+import { outputPathForFeed, publicAssetBaseForFeed } from './ui-formatters.js';
+
 const STAGE_DEFINITIONS = [
   { id: 'show', label: 'Choose show' },
   { id: 'source', label: 'Choose story source' },
@@ -307,31 +309,6 @@ function validHttpUrl(value) {
   } catch {
     return false;
   }
-}
-
-function safeVisiblePath(value) {
-  const text = String(value || '').trim();
-
-  if (!text) {
-    return '';
-  }
-
-  if (text.startsWith('/') || text.startsWith('~') || /^[A-Za-z]:[\\/]/.test(text)) {
-    return '';
-  }
-
-  return text;
-}
-
-function publicAssetBaseForFeed(feed) {
-  const metadata = asObject(feed?.metadata);
-  return typeof metadata.publicAssetBaseUrl === 'string' ? metadata.publicAssetBaseUrl : feed?.publicBaseUrl || '';
-}
-
-function outputPathForFeed(feed) {
-  const metadata = asObject(feed?.metadata);
-  const storageConfig = asObject(feed?.storageConfig);
-  return safeVisiblePath(metadata.outputPath || storageConfig.outputPath || feed?.rssFeedPath || '');
 }
 
 function publishChecklist({ packet, script, revision, episode, assets, feed, jobs }) {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -129,6 +129,18 @@ function summarizeCandidates(candidates) {
   };
 }
 
+function researchStatus(packet) {
+  if (!packet) {
+    return 'unknown';
+  }
+
+  return asObject(packet.content?.readiness).status || packet.status || 'unknown';
+}
+
+function researchReady(packet) {
+  return ['ready', 'approved', 'research-ready'].includes(researchStatus(packet));
+}
+
 function summarizeBrief(packet) {
   if (!packet) {
     return null;
@@ -140,7 +152,7 @@ function summarizeBrief(packet) {
     stage: 'brief',
     type: 'research-brief',
     title: packet.title || 'Untitled research brief',
-    status: packet.status || asObject(packet.content?.readiness).status || 'unknown',
+    status: researchStatus(packet),
     approved: Boolean(packet.approvedAt),
     warningCount: warnings.length,
     unresolvedWarningCount: warnings.filter((warning) => !warning.override).length,
@@ -342,7 +354,7 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
   const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
   const audioValid = Boolean(audio && audio.mimeType && audio.mimeType.startsWith('audio/') && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
   const coverValid = Boolean(cover && cover.mimeType && cover.mimeType.startsWith('image/'));
-  const packetReady = Boolean(packet && ['ready', 'approved', 'research-ready'].includes(packet.status || asObject(packet.content?.readiness).status));
+  const packetReady = researchReady(packet);
 
   return [
     {
@@ -352,7 +364,7 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
       reason: !packet
         ? 'Select a research brief.'
         : !packetReady
-          ? `Research status is ${packet.status || 'unknown'}.`
+          ? `Research status is ${researchStatus(packet)}.`
           : researchWarnings.length > 0
             ? `${researchWarnings.length} research warning${researchWarnings.length === 1 ? '' : 's'} need override reasons.`
             : !packet.approvedAt ? 'Approve the research brief after review.' : 'Research review decision recorded.',
@@ -459,6 +471,7 @@ function deriveStages(context) {
   const hasStorySelection = selectedCandidateCount > 0 || hasDownstreamArtifact;
   const unresolvedBriefWarnings = unresolvedResearchWarnings(activeBrief);
   const briefNeedsReview = Boolean(activeBrief && unresolvedBriefWarnings.length > 0);
+  const briefReady = researchReady(activeBrief);
   const audio = latest(assets.filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'));
   const cover = latest(assets.filter((asset) => asset.type === 'cover-art'));
   const checklist = publishChecklist({
@@ -474,14 +487,14 @@ function deriveStages(context) {
   const publishPrerequisiteBlocker = checklist.find((item) => !item.passed && item.key !== 'publishApproval');
   const publishApprovalReady = activeEpisode?.status === 'audio-ready';
   const profileSupportsDiscovery = source && ['brave', 'zai-web', 'rss', 'manual'].includes(source.type);
-  const briefBlocked = activeBrief?.status === 'blocked' || briefNeedsReview;
+  const briefBlocked = Boolean(activeBrief && (!briefReady || briefNeedsReview));
 
   const stages = [
     makeStage('show', show ? 'done' : 'blocked', summarizeShow(show)),
     makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source, sourceQueries)),
     makeStage('discover', hasCandidatePool ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
     makeStage('story', hasStorySelection ? 'done' : hasCandidatePool ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
-    makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefBlocked ? 'blocked' : 'done') : hasStorySelection ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
+    makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefReady ? 'done' : 'blocked') : hasStorySelection ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
     makeStage('script', activeScript ? 'done' : activeBrief && !briefBlocked ? 'ready' : 'blocked', summarizeScript(activeScript, activeRevision)),
     makeStage('review', readyForProduction ? 'done' : activeScript ? (activeRevision ? 'needs-review' : 'ready') : 'blocked', summarizeReview(activeRevision)),
     makeStage('production', audio && cover ? 'done' : readyForProduction ? 'ready' : 'blocked', summarizeAudioCover(assets)),
@@ -500,7 +513,7 @@ function deriveStages(context) {
   } else if (!activeBrief) {
     primaryNextAction = action('Build research brief', 'brief', true);
   } else if (briefBlocked) {
-    primaryNextAction = action('Resolve research warnings', 'brief', true);
+    primaryNextAction = action(briefNeedsReview ? 'Resolve research warnings' : 'Review blocked research brief', 'brief', true);
   } else if (!activeScript) {
     primaryNextAction = action('Generate script draft', 'script', true);
   } else if (!activeRevision) {
@@ -580,6 +593,10 @@ function deriveWarningsAndBlockers({ activeBrief, activeRevision, activeEpisode,
 
   for (const warning of unresolvedResearchWarnings(activeBrief)) {
     warnings.push(warningItem('brief', warning.message || warning.code || 'Research warning requires review.', warning, 'warning'));
+  }
+
+  if (activeBrief && !researchReady(activeBrief)) {
+    blockers.push(warningItem('brief', `Research brief status is ${researchStatus(activeBrief)}.`, summarizeBrief(activeBrief), 'error'));
   }
 
   for (const warning of productionWarnings(activeEpisode, assets, jobs)) {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -524,8 +524,13 @@ function deriveStages(context) {
     primaryNextAction = action('Approve script for audio', 'review', true);
   } else if (!audio || !cover) {
     primaryNextAction = action(`Create missing ${audio ? 'cover art' : cover ? 'audio' : 'audio and cover art'}`, 'production', readyForProduction);
-  } else if (activeEpisode?.status === 'approved-for-publish' && !publishBlocker) {
-    primaryNextAction = action('Publish to RSS', 'publishing', true);
+  } else if (activeEpisode?.status === 'approved-for-publish') {
+    primaryNextAction = action(
+      'Publish to RSS',
+      'publishing',
+      !publishBlocker,
+      publishBlocker ? `${publishBlocker.label}: ${publishBlocker.reason}` : '',
+    );
   } else if (activeEpisode?.status === 'published') {
     primaryNextAction = action('Review publishing record', 'publishing', false, 'Episode is already published.');
   } else {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -592,7 +592,7 @@ function deriveWarningsAndBlockers({ activeBrief, activeRevision, activeEpisode,
   }
 
   if (activeEpisode || assets.length > 0) {
-    for (const item of checklist.filter((entry) => !entry.passed)) {
+    for (const item of checklist.filter((entry) => !entry.passed && entry.key !== 'publishApproval')) {
       const target = checklistStage(item.key);
       blockers.push(warningItem(target, `${item.label}: ${item.reason}`, item, 'error'));
     }
@@ -656,6 +656,10 @@ export function deriveProductionViewModel(input = {}) {
     sourceQueries,
   };
   const { stages, currentStage, primaryNextAction, checklist } = deriveStages(context);
+  const navigationActions = stages.map((stage) => action(`Open ${stage.label}`, stage.id, true));
+  const secondaryActions = stages
+    .filter((stage) => stage.id === currentStage.id && stage.id !== primaryNextAction.targetStage)
+    .map((stage) => action(`Open ${stage.label}`, stage.id, true));
   const activeArtifactAudioCover = summarizeAudioCover(activeAssets);
   const activeArtifactAssetIds = new Set([
     activeArtifactAudioCover?.audio?.id,
@@ -715,9 +719,8 @@ export function deriveProductionViewModel(input = {}) {
     latestArtifacts,
     historicalArtifacts,
     primaryNextAction,
-    secondaryActions: stages
-      .filter((stage) => stage.id !== primaryNextAction.targetStage)
-      .map((stage) => action(`Open ${stage.label}`, stage.id, true)),
+    secondaryActions,
+    navigationActions,
     latestActionResult: deriveLatestActionResult(input, jobs),
     warnings,
     blockers,

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -220,7 +220,8 @@ function summarizeAsset(asset) {
 
   return compactObject({
     id: asset.id,
-    stage: asset.type === 'cover-art' ? 'cover' : 'audio',
+    stage: 'production',
+    productionKind: asset.type === 'cover-art' ? 'cover' : 'audio',
     type: asset.type,
     status: asset.status || 'ready',
     url: asset.publicUrl || asset.url || asset.metadata?.publicUrl || null,
@@ -290,9 +291,10 @@ function unresolvedResearchWarnings(packet) {
 }
 
 function productionWarnings(episode, assets, jobs) {
+  const audioCoverAssets = asArray(assets).filter(isAudioCoverAsset);
   return [
     ...asArray(episode?.warnings),
-    ...asArray(assets).flatMap((asset) => [
+    ...audioCoverAssets.flatMap((asset) => [
       ...asArray(asset?.metadata?.warnings),
       ...asArray(asset?.metadata?.validation?.warnings),
     ]),

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -614,10 +614,10 @@ export function deriveProductionViewModel(input = {}) {
   const selectedSource = profiles.find((profile) => profile.id === input.selectedProfileId) || null;
   const selectedCandidateIds = new Set(asArray(input.selectedCandidateIds));
   const selectedCandidates = candidates.filter((candidate) => selectedCandidateIds.has(candidate.id));
-  const activeBrief = packets.find((packet) => packet.id === input.selectedResearchPacketId)
-    || (input.selectedScript?.researchPacketId ? packets.find((packet) => packet.id === input.selectedScript.researchPacketId) : null)
-    || null;
   const activeScript = input.selectedScript || scripts.find((script) => script.id === input.selectedScriptId) || null;
+  const activeBrief = (activeScript?.researchPacketId ? packets.find((packet) => packet.id === activeScript.researchPacketId) : null)
+    || packets.find((packet) => packet.id === input.selectedResearchPacketId)
+    || null;
   const activeRevision = input.selectedRevision || revisions[0] || null;
   const activeEpisode = production.episode || episodes.find((episode) => episode.id === input.selectedEpisodeId) || null;
   const selectedAssetIds = new Set(asArray(input.selectedAssetIds));

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -465,6 +465,7 @@ function deriveStages(context) {
   });
   const publishBlocker = checklist.find((item) => !item.passed);
   const publishPrerequisiteBlocker = checklist.find((item) => !item.passed && item.key !== 'publishApproval');
+  const publishApprovalReady = activeEpisode?.status === 'audio-ready';
   const profileSupportsDiscovery = source && ['brave', 'zai-web', 'rss', 'manual'].includes(source.type);
   const briefBlocked = activeBrief?.status === 'blocked' || briefNeedsReview;
 
@@ -511,8 +512,8 @@ function deriveStages(context) {
     primaryNextAction = action(
       'Approve for publishing',
       'publishing',
-      !publishBlocker || publishBlocker.key === 'publishApproval',
-      publishBlocker ? `${publishBlocker.label}: ${publishBlocker.reason}` : '',
+      (!publishBlocker || publishBlocker.key === 'publishApproval') && publishApprovalReady,
+      !publishApprovalReady ? `Episode status must be audio-ready before publish approval; current status is ${activeEpisode?.status || 'missing'}.` : publishBlocker ? `${publishBlocker.label}: ${publishBlocker.reason}` : '',
     );
   }
 
@@ -656,11 +657,11 @@ export function deriveProductionViewModel(input = {}) {
     publishing: summarizeEpisode(activeEpisode),
   };
   const latestArtifacts = {
-    brief: activeArtifacts.brief || summarizeBrief(latest(packets)),
-    script: activeArtifacts.script || summarizeScript(latest(scripts)),
-    review: activeArtifacts.review || summarizeReview(latest(revisions)),
-    audioCover: activeArtifacts.audioCover || summarizeAudioCover(productionAssets),
-    publishing: activeArtifacts.publishing || summarizeEpisode(latest(episodes)),
+    brief: summarizeBrief(latest(packets)),
+    script: summarizeScript(latest(scripts)),
+    review: summarizeReview(latest(revisions)),
+    audioCover: summarizeAudioCover(productionAssets),
+    publishing: summarizeEpisode(latest(episodes)),
   };
   const historicalArtifacts = deriveHistoricalArtifacts({
     activeIds,

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -1,0 +1,681 @@
+const STAGE_DEFINITIONS = [
+  { id: 'show', label: 'Choose show' },
+  { id: 'source', label: 'Choose story source' },
+  { id: 'discover', label: 'Find story candidates' },
+  { id: 'story', label: 'Pick / cluster story' },
+  { id: 'brief', label: 'Build evidence brief' },
+  { id: 'script', label: 'Generate script' },
+  { id: 'review', label: 'Integrity review' },
+  { id: 'production', label: 'Produce audio / cover' },
+  { id: 'publishing', label: 'Approve and publish' },
+];
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function timestamp(value) {
+  const time = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(time) ? time : 0;
+}
+
+function newest(items) {
+  return [...asArray(items)].sort((left, right) => (
+    timestamp(right.updatedAt || right.createdAt || right.generatedAt || right.discoveredAt || right.publishedAt)
+    - timestamp(left.updatedAt || left.createdAt || left.generatedAt || left.discoveredAt || left.publishedAt)
+  ));
+}
+
+function firstPresent(...values) {
+  return values.find((value) => typeof value === 'string' && value.trim())?.trim() || '';
+}
+
+function compactObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined));
+}
+
+function summarizeShow(show) {
+  if (!show) {
+    return null;
+  }
+
+  return compactObject({
+    id: show.id,
+    slug: show.slug,
+    title: show.title || show.slug || 'Untitled show',
+    setupStatus: show.setupStatus,
+    format: show.format,
+    defaultRuntimeMinutes: show.defaultRuntimeMinutes,
+  });
+}
+
+function summarizeSource(profile, queries = []) {
+  if (!profile) {
+    return null;
+  }
+
+  const enabledQueries = asArray(queries).filter((query) => query.enabled !== false);
+  return compactObject({
+    id: profile.id,
+    slug: profile.slug,
+    name: profile.name || profile.slug || 'Untitled story source',
+    type: profile.type,
+    enabled: profile.enabled !== false,
+    weight: profile.weight,
+    freshness: profile.freshness || null,
+    queryCount: asArray(queries).length,
+    enabledQueryCount: enabledQueries.length,
+  });
+}
+
+function summarizeCandidate(candidate) {
+  if (!candidate) {
+    return null;
+  }
+
+  return compactObject({
+    id: candidate.id,
+    title: candidate.title || 'Untitled candidate story',
+    status: candidate.status || 'unknown',
+    sourceName: candidate.sourceName || null,
+    url: candidate.canonicalUrl || candidate.url || null,
+    score: candidate.score ?? null,
+    discoveredAt: candidate.discoveredAt,
+    publishedAt: candidate.publishedAt,
+  });
+}
+
+function summarizeCandidates(candidates) {
+  const items = asArray(candidates).map(summarizeCandidate).filter(Boolean);
+  return {
+    count: items.length,
+    primary: items[0] || null,
+    items,
+  };
+}
+
+function summarizeBrief(packet) {
+  if (!packet) {
+    return null;
+  }
+
+  const warnings = asArray(packet.warnings);
+  return compactObject({
+    id: packet.id,
+    stage: 'brief',
+    type: 'research-brief',
+    title: packet.title || 'Untitled research brief',
+    status: packet.status || asObject(packet.content?.readiness).status || 'unknown',
+    approved: Boolean(packet.approvedAt),
+    warningCount: warnings.length,
+    unresolvedWarningCount: warnings.filter((warning) => !warning.override).length,
+    citationCount: asArray(packet.citations).length,
+    createdAt: packet.createdAt,
+    updatedAt: packet.updatedAt,
+  });
+}
+
+function summarizeScript(script, revision = null) {
+  if (!script) {
+    return null;
+  }
+
+  return compactObject({
+    id: script.id,
+    stage: 'script',
+    type: 'script-draft',
+    title: script.title || revision?.title || 'Untitled script',
+    status: script.status || 'unknown',
+    approvedRevisionId: script.approvedRevisionId || null,
+    revisionId: revision?.id || null,
+    revisionVersion: revision?.version ?? null,
+    revisionCreatedAt: revision?.createdAt,
+    createdAt: script.createdAt,
+    updatedAt: script.updatedAt,
+  });
+}
+
+function integrityReviewState(revision) {
+  const review = asObject(revision?.metadata?.integrityReview);
+  const override = asObject(review.override);
+  const overrideReason = typeof override.reason === 'string' ? override.reason.trim() : '';
+
+  if (overrideReason) {
+    return {
+      status: 'overridden',
+      blocking: false,
+      review,
+      override,
+    };
+  }
+
+  const allowed = new Set(['pass', 'pass_with_notes', 'fail', 'missing']);
+  const status = allowed.has(review.status) ? review.status : 'missing';
+  return {
+    status,
+    blocking: status === 'fail' || status === 'missing',
+    review: status === 'missing' && !review.status ? null : review,
+    override: null,
+  };
+}
+
+function summarizeReview(revision) {
+  if (!revision) {
+    return null;
+  }
+
+  const integrity = integrityReviewState(revision);
+  return compactObject({
+    id: revision.id,
+    stage: 'review',
+    type: 'integrity-review',
+    status: integrity.status,
+    blocking: integrity.blocking,
+    overrideReason: integrity.override?.reason || null,
+    reviewedAt: integrity.review?.reviewedAt || integrity.review?.generatedAt || revision.updatedAt || revision.createdAt,
+    createdAt: revision.createdAt,
+    updatedAt: revision.updatedAt,
+  });
+}
+
+function summarizeAsset(asset) {
+  if (!asset) {
+    return null;
+  }
+
+  return compactObject({
+    id: asset.id,
+    stage: asset.type === 'cover-art' ? 'cover' : 'audio',
+    type: asset.type,
+    status: asset.status || 'ready',
+    url: asset.publicUrl || asset.url || asset.metadata?.publicUrl || null,
+    mimeType: asset.mimeType || null,
+    byteSize: asset.byteSize ?? null,
+    durationSeconds: asset.durationSeconds ?? asset.metadata?.durationSeconds ?? null,
+    createdAt: asset.createdAt,
+    updatedAt: asset.updatedAt,
+  });
+}
+
+function summarizeAudioCover(assets) {
+  const latestAudio = newest(asArray(assets).filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'))[0] || null;
+  const latestCover = newest(asArray(assets).filter((asset) => asset.type === 'cover-art'))[0] || null;
+
+  if (!latestAudio && !latestCover) {
+    return null;
+  }
+
+  return {
+    stage: 'production',
+    type: 'audio-cover',
+    status: latestAudio && latestCover ? 'ready' : 'partial',
+    audio: summarizeAsset(latestAudio),
+    cover: summarizeAsset(latestCover),
+  };
+}
+
+function summarizeEpisode(episode) {
+  if (!episode) {
+    return null;
+  }
+
+  return compactObject({
+    id: episode.id,
+    stage: 'publishing',
+    type: 'episode',
+    title: episode.title || episode.slug || 'Untitled episode',
+    slug: episode.slug,
+    status: episode.status || 'unknown',
+    feedId: episode.feedId || null,
+    feedGuid: episode.feedGuid || null,
+    publishedAt: episode.publishedAt,
+    createdAt: episode.createdAt,
+    updatedAt: episode.updatedAt,
+  });
+}
+
+function summarizeJob(job) {
+  if (!job) {
+    return null;
+  }
+
+  return compactObject({
+    id: job.id,
+    type: job.type,
+    status: job.status,
+    progress: job.progress,
+    message: job.error || job.summary?.message || job.summary?.status || null,
+    updatedAt: job.updatedAt,
+    createdAt: job.createdAt,
+  });
+}
+
+function unresolvedResearchWarnings(packet) {
+  return asArray(packet?.warnings).filter((warning) => !warning.override);
+}
+
+function productionWarnings(episode, assets, jobs) {
+  return [
+    ...asArray(episode?.warnings),
+    ...asArray(assets).flatMap((asset) => [
+      ...asArray(asset?.metadata?.warnings),
+      ...asArray(asset?.metadata?.validation?.warnings),
+    ]),
+    ...asArray(jobs).flatMap((job) => asArray(job?.summary?.warnings)),
+  ].filter(Boolean);
+}
+
+function selectedFeed(feeds, episode) {
+  return asArray(feeds).find((feed) => feed.id === episode?.feedId) || asArray(feeds)[0] || null;
+}
+
+function validHttpUrl(value) {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function publicAssetBaseForFeed(feed) {
+  const metadata = asObject(feed?.metadata);
+  return typeof metadata.publicAssetBaseUrl === 'string' ? metadata.publicAssetBaseUrl : feed?.publicBaseUrl || '';
+}
+
+function outputPathForFeed(feed) {
+  const metadata = asObject(feed?.metadata);
+  const storageConfig = asObject(feed?.storageConfig);
+  return metadata.outputPath || storageConfig.outputPath || feed?.rssFeedPath || '';
+}
+
+function publishChecklist({ packet, script, revision, episode, assets, feed, jobs }) {
+  const audio = newest(asArray(assets).filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'))[0] || null;
+  const cover = newest(asArray(assets).filter((asset) => asset.type === 'cover-art'))[0] || null;
+  const researchWarnings = unresolvedResearchWarnings(packet);
+  const prodWarnings = productionWarnings(episode, assets, jobs);
+  const integrity = integrityReviewState(revision);
+  const scriptApproved = Boolean(script && revision && script.status === 'approved-for-audio' && script.approvedRevisionId === revision.id);
+  const feedPublicUrl = feed?.publicFeedUrl || '';
+  const publicBaseUrl = publicAssetBaseForFeed(feed);
+  const feedConfigured = Boolean(feed);
+  const targetConfigured = Boolean(feed?.rssFeedPath || outputPathForFeed(feed) || feedPublicUrl);
+  const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
+  const audioValid = Boolean(audio && (!audio.mimeType || audio.mimeType.startsWith('audio/')) && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
+  const coverValid = Boolean(cover && (!cover.mimeType || cover.mimeType.startsWith('image/')));
+  const packetReady = Boolean(packet && ['ready', 'approved', 'research-ready'].includes(packet.status || asObject(packet.content?.readiness).status));
+
+  return [
+    {
+      key: 'research',
+      label: 'Research brief approved',
+      passed: Boolean(packetReady && packet?.approvedAt && researchWarnings.length === 0),
+      reason: !packet
+        ? 'Select a research brief.'
+        : !packetReady
+          ? `Research status is ${packet.status || 'unknown'}.`
+          : researchWarnings.length > 0
+            ? `${researchWarnings.length} research warning${researchWarnings.length === 1 ? '' : 's'} need override reasons.`
+            : !packet.approvedAt ? 'Approve the research brief after review.' : 'Research review decision recorded.',
+    },
+    {
+      key: 'script',
+      label: 'Script approved for audio',
+      passed: scriptApproved,
+      reason: scriptApproved ? 'Script review decision recorded.' : 'Approve the selected script revision.',
+    },
+    {
+      key: 'integrity',
+      label: 'Integrity review passed or overridden',
+      passed: Boolean(revision && !integrity.blocking),
+      reason: !revision
+        ? 'Select a script revision.'
+        : integrity.status === 'missing'
+          ? 'Run the integrity reviewer before production.'
+          : integrity.status === 'fail'
+            ? 'Resolve the failed integrity review or record an explicit override reason.'
+            : integrity.status === 'overridden' ? 'Integrity review override reason recorded.' : `Integrity review ${integrity.status}.`,
+    },
+    {
+      key: 'audio',
+      label: 'Valid audio asset exists',
+      passed: audioValid,
+      reason: audio ? (audioValid ? 'Audio asset metadata is usable.' : 'Audio asset metadata is incomplete or invalid.') : 'Create a preview MP3 or attach final audio.',
+    },
+    {
+      key: 'cover',
+      label: 'Cover art asset exists',
+      passed: coverValid,
+      reason: cover ? (coverValid ? 'Cover art metadata is usable.' : 'Cover art MIME type is not an image.') : 'Create cover art before publishing.',
+    },
+    {
+      key: 'feed',
+      label: 'Feed metadata configured',
+      passed: feedConfigured && feedUrlsValid,
+      reason: !feedConfigured ? 'Configure a feed for this show.' : feedUrlsValid ? 'Feed metadata is available.' : 'Feed public URLs must be valid http(s) URLs.',
+    },
+    {
+      key: 'target',
+      label: 'RSS/public target configured',
+      passed: feedConfigured && targetConfigured,
+      reason: targetConfigured ? 'RSS path or public feed URL is configured.' : 'Configure an RSS path, output path, or public feed URL.',
+    },
+    {
+      key: 'warnings',
+      label: 'No blocking warnings remain',
+      passed: researchWarnings.length === 0 && prodWarnings.length === 0,
+      reason: researchWarnings.length + prodWarnings.length === 0
+        ? 'No unresolved research or production warnings are selected.'
+        : `${researchWarnings.length + prodWarnings.length} warning${researchWarnings.length + prodWarnings.length === 1 ? '' : 's'} require review.`,
+    },
+    {
+      key: 'publishApproval',
+      label: 'Episode approved for publishing',
+      passed: Boolean(episode && ['approved-for-publish', 'published'].includes(episode.status)),
+      reason: episode ? (episode.status === 'published' ? 'Episode is already published.' : episode.status === 'approved-for-publish' ? 'Publish approval recorded.' : 'Approve audio and cover assets for publishing.') : 'Create production assets to create an episode record.',
+    },
+  ];
+}
+
+function makeStage(id, status, artifact = null) {
+  const definition = STAGE_DEFINITIONS.find((stage) => stage.id === id);
+  return {
+    id,
+    label: definition?.label || id,
+    status,
+    artifact,
+  };
+}
+
+function action(label, targetStage, enabled, blockerReason = '') {
+  return {
+    label,
+    targetStage,
+    enabled: Boolean(enabled),
+    blockerReason: enabled ? null : blockerReason || 'The current workflow state blocks this action.',
+  };
+}
+
+function deriveStages(context) {
+  const {
+    show,
+    source,
+    candidates,
+    activeBrief,
+    activeScript,
+    activeRevision,
+    activeEpisode,
+    assets,
+    jobs,
+    feed,
+  } = context;
+  const integrity = integrityReviewState(activeRevision);
+  const scriptApproved = Boolean(activeScript && activeRevision && activeScript.status === 'approved-for-audio' && activeScript.approvedRevisionId === activeRevision.id);
+  const readyForProduction = Boolean(scriptApproved && !integrity.blocking);
+  const audio = newest(assets.filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'))[0] || null;
+  const cover = newest(assets.filter((asset) => asset.type === 'cover-art'))[0] || null;
+  const checklist = publishChecklist({
+    packet: activeBrief,
+    script: activeScript,
+    revision: activeRevision,
+    episode: activeEpisode,
+    assets,
+    feed,
+    jobs,
+  });
+  const publishBlocker = checklist.find((item) => !item.passed);
+  const profileSupportsDiscovery = source && ['brave', 'zai-web', 'rss', 'manual'].includes(source.type);
+  const briefBlocked = activeBrief?.status === 'blocked';
+
+  const stages = [
+    makeStage('show', show ? 'done' : 'blocked', summarizeShow(show)),
+    makeStage('source', source ? 'done' : show ? 'blocked' : 'blocked', summarizeSource(source)),
+    makeStage('discover', candidates.length > 0 ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
+    makeStage('story', candidates.length > 0 ? 'done' : 'blocked', summarizeCandidates(candidates)),
+    makeStage('brief', activeBrief ? (briefBlocked ? 'blocked' : 'done') : candidates.length > 0 ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
+    makeStage('script', activeScript ? 'done' : activeBrief && !briefBlocked ? 'ready' : 'blocked', summarizeScript(activeScript, activeRevision)),
+    makeStage('review', readyForProduction ? 'done' : activeScript && activeRevision ? 'needs-review' : 'blocked', summarizeReview(activeRevision)),
+    makeStage('production', audio && cover ? 'done' : readyForProduction ? 'ready' : 'blocked', summarizeAudioCover(assets)),
+    makeStage('publishing', activeEpisode?.status === 'published' ? 'done' : audio && cover ? (publishBlocker ? 'blocked' : 'ready') : 'blocked', summarizeEpisode(activeEpisode)),
+  ];
+
+  let primaryNextAction;
+  if (!show) {
+    primaryNextAction = action('Select or create show', 'show', true);
+  } else if (!source) {
+    primaryNextAction = action('Choose story source', 'source', true);
+  } else if (candidates.length === 0) {
+    primaryNextAction = action(source.type === 'manual' ? 'Add manual story' : source.type === 'rss' ? 'Import RSS items' : 'Run source search', 'discover', profileSupportsDiscovery, 'Choose a browser-supported story source before discovery.');
+  } else if (!activeBrief) {
+    primaryNextAction = action('Build research brief', 'brief', true);
+  } else if (briefBlocked) {
+    primaryNextAction = action('Resolve research warnings', 'brief', false, 'Resolve or override research warnings before drafting.');
+  } else if (!activeScript) {
+    primaryNextAction = action('Generate script draft', 'script', true);
+  } else if (!activeRevision) {
+    primaryNextAction = action('Select script revision', 'script', false, 'Select a script revision before integrity review.');
+  } else if (integrity.blocking) {
+    primaryNextAction = action(integrity.status === 'fail' ? 'Resolve integrity review' : 'Run integrity review', 'review', integrity.status === 'missing', integrity.status === 'fail' ? 'Resolve the failed integrity review or record an explicit override reason.' : '');
+  } else if (!scriptApproved) {
+    primaryNextAction = action('Approve script for audio', 'review', true);
+  } else if (!audio || !cover) {
+    primaryNextAction = action(`Create missing ${audio ? 'cover art' : cover ? 'audio' : 'audio and cover art'}`, 'production', readyForProduction);
+  } else if (activeEpisode?.status === 'approved-for-publish' && !publishBlocker) {
+    primaryNextAction = action('Publish to RSS', 'publishing', true);
+  } else if (activeEpisode?.status === 'published') {
+    primaryNextAction = action('Review publishing record', 'publishing', false, 'Episode is already published.');
+  } else {
+    primaryNextAction = action(
+      'Approve for publishing',
+      'publishing',
+      !publishBlocker || publishBlocker.key === 'publishApproval',
+      publishBlocker ? `${publishBlocker.label}: ${publishBlocker.reason}` : '',
+    );
+  }
+
+  const currentStage = stages.find((stage) => stage.status !== 'done') || stages[stages.length - 1];
+  return { stages, currentStage, primaryNextAction, checklist };
+}
+
+function deriveLatestActionResult(input, jobs) {
+  const explicit = asObject(input.latestActionResult);
+  if (typeof explicit.message === 'string' && explicit.message.trim()) {
+    return {
+      status: explicit.status || 'info',
+      message: explicit.message.trim(),
+      source: explicit.source || 'ui',
+    };
+  }
+
+  const latestJob = newest(jobs)[0] || null;
+  if (latestJob) {
+    return {
+      status: latestJob.status || 'unknown',
+      message: `${latestJob.type || 'Task run'} ${latestJob.status || 'updated'}`,
+      source: 'job',
+      job: summarizeJob(latestJob),
+    };
+  }
+
+  return {
+    status: 'idle',
+    message: 'No action result recorded yet.',
+    source: 'view-model',
+  };
+}
+
+function warningItem(stage, message, source = null, severity = 'warning') {
+  return compactObject({ stage, severity, message, source });
+}
+
+function deriveWarningsAndBlockers({ activeBrief, activeRevision, activeEpisode, assets, jobs, checklist, selectedCandidates }) {
+  const warnings = [];
+  const blockers = [];
+  const integrity = integrityReviewState(activeRevision);
+
+  for (const warning of unresolvedResearchWarnings(activeBrief)) {
+    warnings.push(warningItem('brief', warning.message || warning.code || 'Research warning requires review.', warning, 'warning'));
+  }
+
+  for (const warning of productionWarnings(activeEpisode, assets, jobs)) {
+    warnings.push(warningItem('production', warning.message || warning.code || String(warning), warning, 'warning'));
+  }
+
+  for (const candidate of selectedCandidates) {
+    if (!firstPresent(candidate.canonicalUrl, candidate.url)) {
+      warnings.push(warningItem('story', `${candidate.title || 'Selected candidate'} is missing a source URL.`, summarizeCandidate(candidate), 'warning'));
+    }
+    if (['ignored', 'merged'].includes(candidate.status)) {
+      blockers.push(warningItem('story', `${candidate.title || 'Selected candidate'} has ${candidate.status} status.`, summarizeCandidate(candidate), 'error'));
+    }
+  }
+
+  if (activeRevision && integrity.blocking) {
+    blockers.push(warningItem('review', integrity.status === 'fail' ? 'Integrity review failed or needs an explicit override.' : 'Integrity review has not been run.', summarizeReview(activeRevision), 'error'));
+  }
+
+  if (activeEpisode || assets.length > 0) {
+    for (const item of checklist.filter((entry) => !entry.passed)) {
+      const target = item.key === 'publishApproval' ? 'publishing' : item.key;
+      blockers.push(warningItem(target, `${item.label}: ${item.reason}`, item, 'error'));
+    }
+  }
+
+  return { warnings, blockers };
+}
+
+function deriveHistoricalArtifacts({ activeIds, packets, scripts, revisions, assets, episodes }) {
+  return {
+    briefs: newest(packets).filter((packet) => packet.id !== activeIds.briefId).map(summarizeBrief),
+    scripts: newest(scripts).filter((script) => script.id !== activeIds.scriptId).map((script) => summarizeScript(script)),
+    reviews: newest(revisions).filter((revision) => revision.id !== activeIds.revisionId).map(summarizeReview),
+    audioCover: newest(assets).filter((asset) => !activeIds.assetIds.has(asset.id)).map(summarizeAsset),
+    publishing: newest(episodes).filter((episode) => episode.id !== activeIds.episodeId).map(summarizeEpisode),
+  };
+}
+
+export function deriveProductionViewModel(input = {}) {
+  const shows = asArray(input.shows);
+  const feeds = asArray(input.feeds);
+  const profiles = asArray(input.profiles);
+  const queries = asArray(input.queries);
+  const candidates = asArray(input.storyCandidates);
+  const packets = asArray(input.researchPackets);
+  const scripts = asArray(input.scripts);
+  const revisions = asArray(input.selectedRevisions);
+  const production = asObject(input.production);
+  const productionAssets = asArray(production.assets);
+  const productionJobs = asArray(production.jobs);
+  const jobs = [...asArray(input.recentJobs), ...productionJobs];
+  const episodes = production.episode ? [production.episode, ...asArray(input.episodes).filter((episode) => episode.id !== production.episode.id)] : asArray(input.episodes);
+  const selectedShow = shows.find((show) => show.slug === input.selectedShowSlug) || null;
+  const selectedSource = profiles.find((profile) => profile.id === input.selectedProfileId) || null;
+  const selectedCandidateIds = new Set(asArray(input.selectedCandidateIds));
+  const selectedCandidates = candidates.filter((candidate) => selectedCandidateIds.has(candidate.id));
+  const activeBrief = packets.find((packet) => packet.id === input.selectedResearchPacketId)
+    || (input.selectedScript?.researchPacketId ? packets.find((packet) => packet.id === input.selectedScript.researchPacketId) : null)
+    || null;
+  const activeScript = input.selectedScript || scripts.find((script) => script.id === input.selectedScriptId) || null;
+  const activeRevision = input.selectedRevision || revisions[0] || null;
+  const activeEpisode = production.episode || episodes.find((episode) => episode.id === input.selectedEpisodeId) || null;
+  const selectedAssetIds = new Set(asArray(input.selectedAssetIds));
+  const activeAssets = selectedAssetIds.size > 0
+    ? productionAssets.filter((asset) => selectedAssetIds.has(asset.id))
+    : productionAssets;
+  const feed = selectedFeed(feeds, activeEpisode);
+  const sourceQueries = selectedSource ? queries.filter((query) => !query.sourceProfileId || query.sourceProfileId === selectedSource.id) : [];
+  const context = {
+    show: selectedShow,
+    source: selectedSource,
+    candidates: selectedCandidates,
+    activeBrief,
+    activeScript,
+    activeRevision,
+    activeEpisode,
+    assets: activeAssets,
+    jobs,
+    feed,
+  };
+  const { stages, currentStage, primaryNextAction, checklist } = deriveStages(context);
+  const activeIds = {
+    briefId: activeBrief?.id || null,
+    scriptId: activeScript?.id || null,
+    revisionId: activeRevision?.id || null,
+    episodeId: activeEpisode?.id || null,
+    assetIds: new Set(activeAssets.map((asset) => asset.id)),
+  };
+  const activeArtifacts = {
+    brief: summarizeBrief(activeBrief),
+    script: summarizeScript(activeScript, activeRevision),
+    review: summarizeReview(activeRevision),
+    audioCover: summarizeAudioCover(activeAssets),
+    publishing: summarizeEpisode(activeEpisode),
+  };
+  const latestArtifacts = {
+    brief: activeArtifacts.brief || summarizeBrief(newest(packets)[0]),
+    script: activeArtifacts.script || summarizeScript(newest(scripts)[0]),
+    review: activeArtifacts.review || summarizeReview(newest(revisions)[0]),
+    audioCover: activeArtifacts.audioCover || summarizeAudioCover(productionAssets),
+    publishing: activeArtifacts.publishing || summarizeEpisode(newest(episodes)[0]),
+  };
+  const historicalArtifacts = deriveHistoricalArtifacts({
+    activeIds,
+    packets,
+    scripts,
+    revisions,
+    assets: productionAssets,
+    episodes,
+  });
+  const { warnings, blockers } = deriveWarningsAndBlockers({
+    activeBrief,
+    activeRevision,
+    activeEpisode,
+    assets: activeAssets,
+    jobs,
+    checklist,
+    selectedCandidates,
+  });
+
+  return {
+    selectedShowSummary: summarizeShow(selectedShow),
+    selectedStorySourceSummary: summarizeSource(selectedSource, sourceQueries),
+    selectedCandidateStorySummary: summarizeCandidates(selectedCandidates),
+    activeDraftEpisodeSummary: activeEpisode && activeEpisode.status !== 'published' ? summarizeEpisode(activeEpisode) : null,
+    currentStage: {
+      id: currentStage.id,
+      label: currentStage.label,
+      status: currentStage.status,
+    },
+    stages,
+    activeArtifacts,
+    latestArtifacts,
+    historicalArtifacts,
+    primaryNextAction,
+    secondaryActions: stages
+      .filter((stage) => stage.id !== primaryNextAction.targetStage)
+      .map((stage) => action(`Open ${stage.label}`, stage.id, true)),
+    latestActionResult: deriveLatestActionResult(input, jobs),
+    warnings,
+    blockers,
+    visibility: {
+      workflow: true,
+      settings: input.activeSurface === 'settings',
+      debug: input.activeSurface === 'debug',
+      advanced: Boolean(input.activeSurface === 'settings' || input.activeSurface === 'debug'),
+      groups: {
+        activeWorkflow: true,
+        history: Object.values(historicalArtifacts).some((items) => items.length > 0),
+        admin: input.activeSurface === 'settings',
+        debug: input.activeSurface === 'debug',
+      },
+    },
+  };
+}

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -409,6 +409,7 @@ function deriveStages(context) {
     show,
     source,
     candidates,
+    selectedCandidates,
     activeBrief,
     activeScript,
     activeRevision,
@@ -420,6 +421,7 @@ function deriveStages(context) {
   const integrity = integrityReviewState(activeRevision);
   const scriptApproved = Boolean(activeScript && activeRevision && activeScript.status === 'approved-for-audio' && activeScript.approvedRevisionId === activeRevision.id);
   const readyForProduction = Boolean(scriptApproved && !integrity.blocking);
+  const selectedCandidateCount = selectedCandidates.length;
   const audio = newest(assets.filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'))[0] || null;
   const cover = newest(assets.filter((asset) => asset.type === 'cover-art'))[0] || null;
   const checklist = publishChecklist({
@@ -432,19 +434,20 @@ function deriveStages(context) {
     jobs,
   });
   const publishBlocker = checklist.find((item) => !item.passed);
+  const publishPrerequisiteBlocker = checklist.find((item) => !item.passed && item.key !== 'publishApproval');
   const profileSupportsDiscovery = source && ['brave', 'zai-web', 'rss', 'manual'].includes(source.type);
   const briefBlocked = activeBrief?.status === 'blocked';
 
   const stages = [
     makeStage('show', show ? 'done' : 'blocked', summarizeShow(show)),
-    makeStage('source', source ? 'done' : show ? 'blocked' : 'blocked', summarizeSource(source)),
+    makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source)),
     makeStage('discover', candidates.length > 0 ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
-    makeStage('story', candidates.length > 0 ? 'done' : 'blocked', summarizeCandidates(candidates)),
-    makeStage('brief', activeBrief ? (briefBlocked ? 'blocked' : 'done') : candidates.length > 0 ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
+    makeStage('story', selectedCandidateCount > 0 ? 'done' : candidates.length > 0 ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
+    makeStage('brief', activeBrief ? (briefBlocked ? 'blocked' : 'done') : selectedCandidateCount > 0 ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
     makeStage('script', activeScript ? 'done' : activeBrief && !briefBlocked ? 'ready' : 'blocked', summarizeScript(activeScript, activeRevision)),
     makeStage('review', readyForProduction ? 'done' : activeScript && activeRevision ? 'needs-review' : 'blocked', summarizeReview(activeRevision)),
     makeStage('production', audio && cover ? 'done' : readyForProduction ? 'ready' : 'blocked', summarizeAudioCover(assets)),
-    makeStage('publishing', activeEpisode?.status === 'published' ? 'done' : audio && cover ? (publishBlocker ? 'blocked' : 'ready') : 'blocked', summarizeEpisode(activeEpisode)),
+    makeStage('publishing', activeEpisode?.status === 'published' ? 'done' : audio && cover ? (publishPrerequisiteBlocker ? 'blocked' : 'ready') : 'blocked', summarizeEpisode(activeEpisode)),
   ];
 
   let primaryNextAction;
@@ -454,6 +457,8 @@ function deriveStages(context) {
     primaryNextAction = action('Choose story source', 'source', true);
   } else if (candidates.length === 0) {
     primaryNextAction = action(source.type === 'manual' ? 'Add manual story' : source.type === 'rss' ? 'Import RSS items' : 'Run source search', 'discover', profileSupportsDiscovery, 'Choose a browser-supported story source before discovery.');
+  } else if (selectedCandidateCount === 0) {
+    primaryNextAction = action('Pick or cluster story', 'story', true);
   } else if (!activeBrief) {
     primaryNextAction = action('Build research brief', 'brief', true);
   } else if (briefBlocked) {
@@ -595,7 +600,8 @@ export function deriveProductionViewModel(input = {}) {
   const context = {
     show: selectedShow,
     source: selectedSource,
-    candidates: selectedCandidates,
+    candidates,
+    selectedCandidates,
     activeBrief,
     activeScript,
     activeRevision,

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -447,6 +447,9 @@ function deriveStages(context) {
   const scriptApproved = Boolean(activeScript && activeRevision && activeScript.status === 'approved-for-audio' && activeScript.approvedRevisionId === activeRevision.id);
   const readyForProduction = Boolean(scriptApproved && !integrity.blocking);
   const selectedCandidateCount = selectedCandidates.length;
+  const hasDownstreamArtifact = Boolean(activeBrief || activeScript || activeRevision || activeEpisode || assets.length > 0);
+  const hasCandidatePool = candidates.length > 0 || hasDownstreamArtifact;
+  const hasStorySelection = selectedCandidateCount > 0 || hasDownstreamArtifact;
   const unresolvedBriefWarnings = unresolvedResearchWarnings(activeBrief);
   const briefNeedsReview = Boolean(activeBrief && unresolvedBriefWarnings.length > 0);
   const audio = latest(assets.filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'));
@@ -468,9 +471,9 @@ function deriveStages(context) {
   const stages = [
     makeStage('show', show ? 'done' : 'blocked', summarizeShow(show)),
     makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source)),
-    makeStage('discover', candidates.length > 0 ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
-    makeStage('story', selectedCandidateCount > 0 ? 'done' : candidates.length > 0 ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
-    makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefBlocked ? 'blocked' : 'done') : selectedCandidateCount > 0 ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
+    makeStage('discover', hasCandidatePool ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
+    makeStage('story', hasStorySelection ? 'done' : hasCandidatePool ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
+    makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefBlocked ? 'blocked' : 'done') : hasStorySelection ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
     makeStage('script', activeScript ? 'done' : activeBrief && !briefBlocked ? 'ready' : 'blocked', summarizeScript(activeScript, activeRevision)),
     makeStage('review', readyForProduction ? 'done' : activeScript && activeRevision ? 'needs-review' : 'blocked', summarizeReview(activeRevision)),
     makeStage('production', audio && cover ? 'done' : readyForProduction ? 'ready' : 'blocked', summarizeAudioCover(assets)),
@@ -482,9 +485,9 @@ function deriveStages(context) {
     primaryNextAction = action('Select or create show', 'show', true);
   } else if (!source) {
     primaryNextAction = action('Choose story source', 'source', true);
-  } else if (candidates.length === 0) {
+  } else if (!hasCandidatePool) {
     primaryNextAction = action(source.type === 'manual' ? 'Add manual story' : source.type === 'rss' ? 'Import RSS items' : 'Run source search', 'discover', profileSupportsDiscovery, 'Choose a browser-supported story source before discovery.');
-  } else if (selectedCandidateCount === 0) {
+  } else if (!hasStorySelection) {
     primaryNextAction = action('Pick or cluster story', 'story', true);
   } else if (!activeBrief) {
     primaryNextAction = action('Build research brief', 'brief', true);

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -23,11 +23,36 @@ function timestamp(value) {
   return Number.isFinite(time) ? time : 0;
 }
 
+function latest(items) {
+  return asArray(items).reduce((selected, item) => {
+    if (!selected) {
+      return item;
+    }
+    const itemTime = timestamp(item.updatedAt || item.createdAt || item.generatedAt || item.discoveredAt || item.publishedAt);
+    const selectedTime = timestamp(selected.updatedAt || selected.createdAt || selected.generatedAt || selected.discoveredAt || selected.publishedAt);
+    return itemTime > selectedTime ? item : selected;
+  }, null);
+}
+
 function newest(items) {
   return [...asArray(items)].sort((left, right) => (
     timestamp(right.updatedAt || right.createdAt || right.generatedAt || right.discoveredAt || right.publishedAt)
     - timestamp(left.updatedAt || left.createdAt || left.generatedAt || left.discoveredAt || left.publishedAt)
   ));
+}
+
+function uniqueById(items) {
+  const seen = new Set();
+  const unique = [];
+  for (const item of asArray(items)) {
+    const key = item?.id || `${item?.type || 'item'}:${item?.createdAt || unique.length}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(item);
+  }
+  return unique;
 }
 
 function firstPresent(...values) {
@@ -202,8 +227,8 @@ function summarizeAsset(asset) {
 }
 
 function summarizeAudioCover(assets) {
-  const latestAudio = newest(asArray(assets).filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'))[0] || null;
-  const latestCover = newest(asArray(assets).filter((asset) => asset.type === 'cover-art'))[0] || null;
+  const latestAudio = latest(asArray(assets).filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'));
+  const latestCover = latest(asArray(assets).filter((asset) => asset.type === 'cover-art'));
 
   if (!latestAudio && !latestCover) {
     return null;
@@ -298,8 +323,8 @@ function outputPathForFeed(feed) {
 }
 
 function publishChecklist({ packet, script, revision, episode, assets, feed, jobs }) {
-  const audio = newest(asArray(assets).filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'))[0] || null;
-  const cover = newest(asArray(assets).filter((asset) => asset.type === 'cover-art'))[0] || null;
+  const audio = latest(asArray(assets).filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'));
+  const cover = latest(asArray(assets).filter((asset) => asset.type === 'cover-art'));
   const researchWarnings = unresolvedResearchWarnings(packet);
   const prodWarnings = productionWarnings(episode, assets, jobs);
   const integrity = integrityReviewState(revision);
@@ -422,8 +447,10 @@ function deriveStages(context) {
   const scriptApproved = Boolean(activeScript && activeRevision && activeScript.status === 'approved-for-audio' && activeScript.approvedRevisionId === activeRevision.id);
   const readyForProduction = Boolean(scriptApproved && !integrity.blocking);
   const selectedCandidateCount = selectedCandidates.length;
-  const audio = newest(assets.filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'))[0] || null;
-  const cover = newest(assets.filter((asset) => asset.type === 'cover-art'))[0] || null;
+  const unresolvedBriefWarnings = unresolvedResearchWarnings(activeBrief);
+  const briefNeedsReview = Boolean(activeBrief && unresolvedBriefWarnings.length > 0);
+  const audio = latest(assets.filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'));
+  const cover = latest(assets.filter((asset) => asset.type === 'cover-art'));
   const checklist = publishChecklist({
     packet: activeBrief,
     script: activeScript,
@@ -436,14 +463,14 @@ function deriveStages(context) {
   const publishBlocker = checklist.find((item) => !item.passed);
   const publishPrerequisiteBlocker = checklist.find((item) => !item.passed && item.key !== 'publishApproval');
   const profileSupportsDiscovery = source && ['brave', 'zai-web', 'rss', 'manual'].includes(source.type);
-  const briefBlocked = activeBrief?.status === 'blocked';
+  const briefBlocked = activeBrief?.status === 'blocked' || briefNeedsReview;
 
   const stages = [
     makeStage('show', show ? 'done' : 'blocked', summarizeShow(show)),
     makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source)),
     makeStage('discover', candidates.length > 0 ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
     makeStage('story', selectedCandidateCount > 0 ? 'done' : candidates.length > 0 ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
-    makeStage('brief', activeBrief ? (briefBlocked ? 'blocked' : 'done') : selectedCandidateCount > 0 ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
+    makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefBlocked ? 'blocked' : 'done') : selectedCandidateCount > 0 ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
     makeStage('script', activeScript ? 'done' : activeBrief && !briefBlocked ? 'ready' : 'blocked', summarizeScript(activeScript, activeRevision)),
     makeStage('review', readyForProduction ? 'done' : activeScript && activeRevision ? 'needs-review' : 'blocked', summarizeReview(activeRevision)),
     makeStage('production', audio && cover ? 'done' : readyForProduction ? 'ready' : 'blocked', summarizeAudioCover(assets)),
@@ -462,7 +489,7 @@ function deriveStages(context) {
   } else if (!activeBrief) {
     primaryNextAction = action('Build research brief', 'brief', true);
   } else if (briefBlocked) {
-    primaryNextAction = action('Resolve research warnings', 'brief', false, 'Resolve or override research warnings before drafting.');
+    primaryNextAction = action('Resolve research warnings', 'brief', false, briefNeedsReview ? `${unresolvedBriefWarnings.length} research warning${unresolvedBriefWarnings.length === 1 ? '' : 's'} need override reasons before drafting.` : 'Resolve or override research warnings before drafting.');
   } else if (!activeScript) {
     primaryNextAction = action('Generate script draft', 'script', true);
   } else if (!activeRevision) {
@@ -500,7 +527,7 @@ function deriveLatestActionResult(input, jobs) {
     };
   }
 
-  const latestJob = newest(jobs)[0] || null;
+  const latestJob = latest(jobs);
   if (latestJob) {
     return {
       status: latestJob.status || 'unknown',
@@ -579,7 +606,7 @@ export function deriveProductionViewModel(input = {}) {
   const production = asObject(input.production);
   const productionAssets = asArray(production.assets);
   const productionJobs = asArray(production.jobs);
-  const jobs = [...asArray(input.recentJobs), ...productionJobs];
+  const jobs = uniqueById([...asArray(input.recentJobs), ...productionJobs]);
   const episodes = production.episode ? [production.episode, ...asArray(input.episodes).filter((episode) => episode.id !== production.episode.id)] : asArray(input.episodes);
   const selectedShow = shows.find((show) => show.slug === input.selectedShowSlug) || null;
   const selectedSource = profiles.find((profile) => profile.id === input.selectedProfileId) || null;
@@ -626,11 +653,11 @@ export function deriveProductionViewModel(input = {}) {
     publishing: summarizeEpisode(activeEpisode),
   };
   const latestArtifacts = {
-    brief: activeArtifacts.brief || summarizeBrief(newest(packets)[0]),
-    script: activeArtifacts.script || summarizeScript(newest(scripts)[0]),
-    review: activeArtifacts.review || summarizeReview(newest(revisions)[0]),
+    brief: activeArtifacts.brief || summarizeBrief(latest(packets)),
+    script: activeArtifacts.script || summarizeScript(latest(scripts)),
+    review: activeArtifacts.review || summarizeReview(latest(revisions)),
     audioCover: activeArtifacts.audioCover || summarizeAudioCover(productionAssets),
-    publishing: activeArtifacts.publishing || summarizeEpisode(newest(episodes)[0]),
+    publishing: activeArtifacts.publishing || summarizeEpisode(latest(episodes)),
   };
   const historicalArtifacts = deriveHistoricalArtifacts({
     activeIds,

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -12,6 +12,12 @@ const STAGE_DEFINITIONS = [
   { id: 'publishing', label: 'Approve and publish' },
 ];
 
+const AUDIO_COVER_ASSET_TYPES = new Set(['audio-preview', 'audio-final', 'cover-art']);
+
+function isAudioCoverAsset(asset) {
+  return AUDIO_COVER_ASSET_TYPES.has(asset?.type);
+}
+
 function asArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -606,7 +612,7 @@ function deriveHistoricalArtifacts({ activeIds, packets, scripts, revisions, ass
     briefs: newest(packets).filter((packet) => packet.id !== activeIds.briefId).map(summarizeBrief),
     scripts: newest(scripts).filter((script) => script.id !== activeIds.scriptId).map((script) => summarizeScript(script)),
     reviews: newest(revisions).filter((revision) => revision.id !== activeIds.revisionId).map(summarizeReview),
-    audioCover: newest(assets).filter((asset) => !activeIds.assetIds.has(asset.id)).map(summarizeAsset),
+    audioCover: newest(assets).filter((asset) => !activeIds.assetIds.has(asset.id) && isAudioCoverAsset(asset)).map(summarizeAsset),
     publishing: newest(episodes).filter((episode) => episode.id !== activeIds.episodeId).map(summarizeEpisode),
   };
 }

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -397,7 +397,7 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
       key: 'target',
       label: 'RSS/public target configured',
       passed: feedConfigured && targetConfigured,
-      reason: targetConfigured ? 'RSS path or public feed URL is configured.' : 'Configure an RSS path, output path, or public feed URL.',
+      reason: targetConfigured ? 'Public feed URL or RSS path with public base URL is configured.' : 'Configure a public feed URL, or both an RSS path and public base URL.',
     },
     {
       key: 'warnings',

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -320,9 +320,11 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
   const scriptApproved = Boolean(script && revision && script.status === 'approved-for-audio' && script.approvedRevisionId === revision.id);
   const feedPublicUrl = feed?.publicFeedUrl || '';
   const publicBaseUrl = publicAssetBaseForFeed(feed);
-  const rssFeedPath = typeof feed?.rssFeedPath === 'string' ? feed.rssFeedPath.trim() : '';
+  const feedMetadata = asObject(feed?.metadata);
+  const feedStorageConfig = asObject(feed?.storageConfig);
+  const rawTargetPath = firstPresent(feed?.rssFeedPath, feedMetadata.outputPath, feedStorageConfig.outputPath);
   const feedConfigured = Boolean(feed);
-  const targetConfigured = Boolean(feedPublicUrl || (publicBaseUrl && rssFeedPath));
+  const targetConfigured = Boolean(feedPublicUrl || (publicBaseUrl && rawTargetPath));
   const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
   const audioValid = Boolean(audio && audio.mimeType && audio.mimeType.startsWith('audio/') && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
   const coverValid = Boolean(cover && cover.mimeType && cover.mimeType.startsWith('image/'));

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -42,17 +42,15 @@ function newest(items) {
 }
 
 function uniqueById(items) {
-  const seen = new Set();
-  const unique = [];
+  const selected = new Map();
   for (const item of asArray(items)) {
-    const key = item?.id || `${item?.type || 'item'}:${item?.createdAt || unique.length}`;
-    if (seen.has(key)) {
-      continue;
+    const key = item?.id || `${item?.type || 'item'}:${item?.createdAt || selected.size}`;
+    const existing = selected.get(key);
+    if (!existing || timestamp(item?.updatedAt || item?.createdAt || item?.generatedAt || item?.discoveredAt || item?.publishedAt) >= timestamp(existing.updatedAt || existing.createdAt || existing.generatedAt || existing.discoveredAt || existing.publishedAt)) {
+      selected.set(key, item);
     }
-    seen.add(key);
-    unique.push(item);
   }
-  return unique;
+  return [...selected.values()];
 }
 
 function firstPresent(...values) {
@@ -334,8 +332,8 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
   const feedConfigured = Boolean(feed);
   const targetConfigured = Boolean(feed?.rssFeedPath || outputPathForFeed(feed) || feedPublicUrl);
   const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
-  const audioValid = Boolean(audio && (!audio.mimeType || audio.mimeType.startsWith('audio/')) && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
-  const coverValid = Boolean(cover && (!cover.mimeType || cover.mimeType.startsWith('image/')));
+  const audioValid = Boolean(audio && audio.mimeType && audio.mimeType.startsWith('audio/') && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
+  const coverValid = Boolean(cover && cover.mimeType && cover.mimeType.startsWith('image/'));
   const packetReady = Boolean(packet && ['ready', 'approved', 'research-ready'].includes(packet.status || asObject(packet.content?.readiness).status));
 
   return [

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -1,4 +1,4 @@
-import { outputPathForFeed, publicAssetBaseForFeed } from './ui-formatters.js';
+import { publicAssetBaseForFeed } from './ui-formatters.js';
 
 const STAGE_DEFINITIONS = [
   { id: 'show', label: 'Choose show' },
@@ -320,8 +320,9 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
   const scriptApproved = Boolean(script && revision && script.status === 'approved-for-audio' && script.approvedRevisionId === revision.id);
   const feedPublicUrl = feed?.publicFeedUrl || '';
   const publicBaseUrl = publicAssetBaseForFeed(feed);
+  const rssFeedPath = typeof feed?.rssFeedPath === 'string' ? feed.rssFeedPath.trim() : '';
   const feedConfigured = Boolean(feed);
-  const targetConfigured = Boolean(outputPathForFeed(feed) || feedPublicUrl);
+  const targetConfigured = Boolean(feedPublicUrl || (publicBaseUrl && rssFeedPath));
   const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
   const audioValid = Boolean(audio && audio.mimeType && audio.mimeType.startsWith('audio/') && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
   const coverValid = Boolean(cover && cover.mimeType && cover.mimeType.startsWith('image/'));
@@ -647,18 +648,23 @@ export function deriveProductionViewModel(input = {}) {
     sourceQueries,
   };
   const { stages, currentStage, primaryNextAction, checklist } = deriveStages(context);
+  const activeArtifactAudioCover = summarizeAudioCover(activeAssets);
+  const activeArtifactAssetIds = new Set([
+    activeArtifactAudioCover?.audio?.id,
+    activeArtifactAudioCover?.cover?.id,
+  ].filter(Boolean));
   const activeIds = {
     briefId: activeBrief?.id || null,
     scriptId: activeScript?.id || null,
     revisionId: activeRevision?.id || null,
     episodeId: activeEpisode?.id || null,
-    assetIds: new Set(activeAssets.map((asset) => asset.id)),
+    assetIds: activeArtifactAssetIds,
   };
   const activeArtifacts = {
     brief: summarizeBrief(activeBrief),
     script: summarizeScript(activeScript, activeRevision),
     review: summarizeReview(activeRevision),
-    audioCover: summarizeAudioCover(activeAssets),
+    audioCover: activeArtifactAudioCover,
     publishing: summarizeEpisode(activeEpisode),
   };
   const latestArtifacts = {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -1,4 +1,8 @@
-import { publicAssetBaseForFeed } from './ui-formatters.js';
+import {
+  publicAssetBaseForFeed,
+  publishTargetConfiguredForFeed,
+  validHttpUrl,
+} from './ui-formatters.js';
 
 const STAGE_DEFINITIONS = [
   { id: 'show', label: 'Choose show' },
@@ -182,7 +186,7 @@ function summarizeScript(script, revision = null) {
   });
 }
 
-function integrityReviewState(revision) {
+export function integrityReviewState(revision) {
   const review = asObject(revision?.metadata?.integrityReview);
   const override = asObject(review.override);
   const overrideReason = typeof override.reason === 'string' ? override.reason.trim() : '';
@@ -324,19 +328,6 @@ function selectedFeed(feeds, episode, show) {
   return showFeeds.length === 1 ? showFeeds[0] : null;
 }
 
-function validHttpUrl(value) {
-  if (!value) {
-    return false;
-  }
-
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
 function publishChecklist({ packet, script, revision, episode, assets, feed, jobs }) {
   const audio = latest(asArray(assets).filter((asset) => asset.type === 'audio-final' || asset.type === 'audio-preview'));
   const cover = latest(asArray(assets).filter((asset) => asset.type === 'cover-art'));
@@ -346,11 +337,8 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
   const scriptApproved = Boolean(script && revision && script.status === 'approved-for-audio' && script.approvedRevisionId === revision.id);
   const feedPublicUrl = feed?.publicFeedUrl || '';
   const publicBaseUrl = publicAssetBaseForFeed(feed);
-  const feedMetadata = asObject(feed?.metadata);
-  const feedStorageConfig = asObject(feed?.storageConfig);
-  const rawTargetPath = firstPresent(feed?.rssFeedPath, feedMetadata.outputPath, feedStorageConfig.outputPath);
   const feedConfigured = Boolean(feed);
-  const targetConfigured = Boolean(feedPublicUrl || (publicBaseUrl && rawTargetPath));
+  const targetConfigured = publishTargetConfiguredForFeed(feed);
   const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
   const audioValid = Boolean(audio && audio.mimeType && audio.mimeType.startsWith('audio/') && (audio.byteSize === null || audio.byteSize === undefined || audio.byteSize > 0));
   const coverValid = Boolean(cover && cover.mimeType && cover.mimeType.startsWith('image/'));

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1,7 +1,7 @@
 import { api, ApiRequestError, debugText } from './ui-api.js';
 import { SETTINGS_SECTIONS, SURFACES } from './ui-constants.js';
 import { els, state } from './ui-state.js';
-import { deriveProductionViewModel } from './ui-view-model.js';
+import { deriveProductionViewModel, integrityReviewState as viewModelIntegrityReviewState } from './ui-view-model.js';
 import {
   applySourceControlState,
   applySourceControlStateToForms,
@@ -15,6 +15,7 @@ import {
   maybeNull,
   optionalNumber,
   outputPathForFeed,
+  publishTargetConfiguredForFeed,
   publicAssetBaseForFeed,
   readOnboardingSetting,
   readPublishingMode,
@@ -23,6 +24,7 @@ import {
   sanitizedDebug,
   slugify,
   sourceControlsSupported,
+  validHttpUrl,
 } from './ui-formatters.js';
 
 function setStatus(message, debugDetails = '', status = debugDetails ? 'warning' : 'info') {
@@ -453,42 +455,8 @@ function productionWarningItems() {
   ];
 }
 
-function validHttpUrl(value) {
-  if (!value) {
-    return false;
-  }
-
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
 function integrityReviewState(revision = state.selectedRevision) {
-  const review = asObject(revision?.metadata?.integrityReview);
-  const override = asObject(review.override);
-  const overrideReason = typeof override.reason === 'string' ? override.reason.trim() : '';
-
-  if (overrideReason) {
-    return {
-      status: 'overridden',
-      blocking: false,
-      review,
-      override,
-    };
-  }
-
-  const allowedStatuses = new Set(['pass', 'pass_with_notes', 'fail', 'missing']);
-  const status = allowedStatuses.has(review.status) ? review.status : 'missing';
-
-  return {
-    status,
-    blocking: status === 'fail' || status === 'missing',
-    review: status === 'missing' && !review.status ? null : review,
-    override: null,
-  };
+  return viewModelIntegrityReviewState(revision);
 }
 
 function integrityReviewPassed(revision = state.selectedRevision) {
@@ -626,7 +594,7 @@ function publishChecklistState() {
   const feedPublicUrl = feed?.publicFeedUrl || '';
   const publicBaseUrl = publicAssetBaseForFeed(feed || {});
   const feedConfigured = Boolean(feed);
-  const targetConfigured = Boolean(feed?.rssFeedPath || outputPathForFeed(feed || {}) || feedPublicUrl);
+  const targetConfigured = publishTargetConfiguredForFeed(feed || {});
   const feedUrlsValid = (!feedPublicUrl || validHttpUrl(feedPublicUrl)) && (!publicBaseUrl || validHttpUrl(publicBaseUrl));
   const audioValid = Boolean(audioAsset && audioAsset.mimeType?.startsWith('audio/') && (audioAsset.byteSize === null || audioAsset.byteSize > 0));
   const coverValid = Boolean(coverAsset && coverAsset.mimeType?.startsWith('image/'));

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1,6 +1,7 @@
 import { api, ApiRequestError, debugText } from './ui-api.js';
 import { SETTINGS_SECTIONS, SURFACES } from './ui-constants.js';
 import { els, state } from './ui-state.js';
+import { deriveProductionViewModel } from './ui-view-model.js';
 import {
   applySourceControlState,
   applySourceControlStateToForms,
@@ -25,6 +26,11 @@ import {
 } from './ui-formatters.js';
 
 function setStatus(message, debugDetails = '') {
+  state.latestActionResult = {
+    status: debugDetails ? 'warning' : 'info',
+    message,
+    source: 'ui',
+  };
   els.status.textContent = message;
   const detail = debugText(debugDetails);
   els.errorDetails.hidden = !detail;
@@ -1585,6 +1591,7 @@ function buildPipelineStages() {
 }
 
 function renderPipeline() {
+  const viewModel = state.productionViewModel || deriveProductionViewModel(state);
   const show = selectedShow();
   const profile = selectedProfile();
   els.pipelineMeta.textContent = show
@@ -1619,6 +1626,7 @@ function renderPipeline() {
   }
 
   els.pipelineDebug.textContent = JSON.stringify({
+    productionViewModel: viewModel,
     showSlug: state.selectedShowSlug,
     sourceProfileId: state.selectedProfileId,
     selectedCandidateIds: state.selectedCandidateIds,
@@ -3492,6 +3500,7 @@ function renderReviewGates() {
 }
 
 function render() {
+  state.productionViewModel = deriveProductionViewModel(state);
   renderShows();
   renderSettings();
   renderPipeline();

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -25,9 +25,9 @@ import {
   sourceControlsSupported,
 } from './ui-formatters.js';
 
-function setStatus(message, debugDetails = '') {
+function setStatus(message, debugDetails = '', status = debugDetails ? 'warning' : 'info') {
   state.latestActionResult = {
-    status: debugDetails ? 'warning' : 'info',
+    status,
     message,
     source: 'ui',
   };
@@ -39,12 +39,12 @@ function setStatus(message, debugDetails = '') {
 
 function reportError(error, fallback = 'Something went wrong. Open technical details for the API response.') {
   if (error instanceof ApiRequestError) {
-    setStatus(error.message, error.debugDetails);
+    setStatus(error.message, error.debugDetails, 'error');
     return error.message;
   }
 
   const message = error instanceof Error && error.message ? error.message : fallback;
-  setStatus(fallback, message);
+  setStatus(fallback, message, 'error');
   return fallback;
 }
 
@@ -1625,7 +1625,7 @@ function renderPipeline() {
     els.pipelineStages.append(stageCard(stage));
   }
 
-  els.pipelineDebug.textContent = JSON.stringify({
+  els.pipelineDebug.textContent = JSON.stringify(sanitizedDebug({
     productionViewModel: viewModel,
     showSlug: state.selectedShowSlug,
     sourceProfileId: state.selectedProfileId,
@@ -1636,7 +1636,7 @@ function renderPipeline() {
     selectedRevisionId: state.selectedRevision?.id ?? null,
     selectedEpisodeId: state.selectedEpisodeId || state.production.episode?.id || null,
     selectedAssetIds: state.selectedAssetIds,
-  }, null, 2);
+  }), null, 2);
 }
 
 function renderQueries() {

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -41,7 +41,7 @@ describe('api config endpoints', () => {
     assert.equal(response.statusCode, 200);
     assert.match(String(response.headers['content-type'] ?? ''), /application\/javascript/);
     assert.match(String(response.headers['cache-control'] ?? ''), /no-store/);
-    for (const modulePath of ['./ui-api.js', './ui-constants.js', './ui-state.js', './ui-formatters.js']) {
+    for (const modulePath of ['./ui-api.js', './ui-constants.js', './ui-state.js', './ui-formatters.js', './ui-view-model.js']) {
       assert.match(response.body, new RegExp(`from\\s+['\"]${modulePath.replace(/[./]/g, '\\$&')}['\"]`));
     }
     assert.match(response.body, /renderSettings/);
@@ -82,6 +82,10 @@ describe('api config endpoints', () => {
       {
         path: '/ui-formatters.js',
         patterns: [/sourceControlsSupported/, /safeVisiblePath/, /linesToCast/],
+      },
+      {
+        path: '/ui-view-model.js',
+        patterns: [/deriveProductionViewModel/, /selectedShowSummary/, /primaryNextAction/],
       },
     ];
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -132,7 +132,7 @@ export function buildApp(options: BuildAppOptions = {}) {
     return reply.header('cache-control', 'no-store').type('text/html').send(await readPublicFile('index.html'));
   });
 
-  const uiScriptFiles = ['ui.js', 'ui-api.js', 'ui-constants.js', 'ui-formatters.js', 'ui-state.js'];
+  const uiScriptFiles = ['ui.js', 'ui-api.js', 'ui-constants.js', 'ui-formatters.js', 'ui-state.js', 'ui-view-model.js'];
 
   for (const file of uiScriptFiles) {
     app.get(`/${file}`, async (_request, reply) => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -52,6 +52,12 @@ const readyBrief = {
   updatedAt: '2026-04-27T13:00:00.000Z',
 };
 
+const warningBrief = {
+  ...readyBrief,
+  id: 'brief-warning',
+  warnings: [{ code: 'LOW_CORROBORATION', message: 'Needs another independent source.' }],
+};
+
 const script = {
   id: 'script-1',
   researchPacketId: 'brief-1',
@@ -234,6 +240,22 @@ test('view model covers candidate selected with no research brief', () => {
   assert.equal(model.primaryNextAction.enabled, true);
 });
 
+test('view model blocks drafting while research warnings are unresolved', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [warningBrief],
+    selectedResearchPacketId: 'brief-warning',
+  }));
+
+  assert.equal(model.currentStage.id, 'brief');
+  assert.equal(model.currentStage.status, 'needs-review');
+  assert.equal(model.primaryNextAction.label, 'Resolve research warnings');
+  assert.equal(model.primaryNextAction.enabled, false);
+  assert.match(model.primaryNextAction.blockerReason, /research warning/);
+  assert.ok(model.warnings.some((warning) => warning.stage === 'brief'));
+});
+
 test('view model covers research brief ready with no script', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],
@@ -345,6 +367,38 @@ test('view model covers publish blocked with concrete blocker reason', () => {
   assert.equal(model.primaryNextAction.enabled, false);
   assert.match(model.primaryNextAction.blockerReason, /Feed metadata configured/);
   assert.ok(model.blockers.some((blocker) => blocker.stage === 'feed'));
+});
+
+test('view model deduplicates overlapping recent and production jobs', () => {
+  const duplicateJob = {
+    id: 'job-1',
+    type: 'production.audio',
+    status: 'succeeded',
+    createdAt: '2026-04-27T14:20:00.000Z',
+    updatedAt: '2026-04-27T14:45:00.000Z',
+    summary: { warnings: [{ message: 'Preview asset needs review.' }] },
+  };
+
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    recentJobs: [duplicateJob],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [duplicateJob] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+    latestActionResult: { status: '', message: '', source: 'test' },
+  }));
+
+  assert.equal(model.latestActionResult.job.id, 'job-1');
+  assert.equal(model.warnings.filter((warning) => warning.message === 'Preview asset needs review.').length, 1);
 });
 
 test('view model separates active artifacts from historical artifacts', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -361,6 +361,29 @@ test('view model treats publish approval as actionable when prerequisites are re
   assert.equal(model.primaryNextAction.enabled, true);
 });
 
+test('view model blocks publish approval until episode is audio-ready', () => {
+  const draftEpisode = { ...episode, status: 'draft' };
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode: draftEpisode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [draftEpisode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.primaryNextAction.label, 'Approve for publishing');
+  assert.equal(model.primaryNextAction.enabled, false);
+  assert.match(model.primaryNextAction.blockerReason, /audio-ready/);
+});
+
 test('view model covers publish blocked with concrete blocker reason', () => {
   const model = deriveProductionViewModel(baseInput({
     feeds: [],
@@ -417,6 +440,20 @@ test('view model deduplicates overlapping recent and production jobs', () => {
 
   assert.equal(model.latestActionResult.job.id, 'job-1');
   assert.equal(model.warnings.filter((warning) => warning.message === 'Preview asset needs review.').length, 1);
+});
+
+test('view model keeps latest artifacts independent from active selection', () => {
+  const olderBrief = { ...readyBrief, id: 'brief-old', title: 'Older brief', updatedAt: '2026-04-26T10:00:00.000Z' };
+  const newestBrief = { ...readyBrief, id: 'brief-new', title: 'Newest brief', updatedAt: '2026-04-28T10:00:00.000Z' };
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [olderBrief, newestBrief],
+    selectedResearchPacketId: 'brief-old',
+  }));
+
+  assert.equal(model.activeArtifacts.brief.id, 'brief-old');
+  assert.equal(model.latestArtifacts.brief.id, 'brief-new');
 });
 
 test('view model separates active artifacts from historical artifacts', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -420,6 +420,29 @@ test('view model covers audio produced with cover still active work', () => {
   assert.equal(model.primaryNextAction.enabled, true);
 });
 
+test('view model falls back to current production assets when saved asset selection is stale', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-deleted'],
+  }));
+
+  assert.equal(model.activeArtifacts.audioCover.status, 'ready');
+  assert.equal(model.activeArtifacts.audioCover.audio.id, 'asset-audio-1');
+  assert.equal(model.activeArtifacts.audioCover.cover.id, 'asset-cover-1');
+  assert.equal(model.currentStage.id, 'publishing');
+});
+
 test('view model treats publish approval as actionable when prerequisites are ready', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -673,6 +673,13 @@ test('view model separates active artifacts from historical artifacts', () => {
     createdAt: '2026-04-26T12:00:00.000Z',
     updatedAt: '2026-04-26T12:00:00.000Z',
   };
+  const nonProductionAsset = {
+    ...audioAsset,
+    id: 'asset-script-old',
+    type: 'script',
+    createdAt: '2026-04-26T12:30:00.000Z',
+    updatedAt: '2026-04-26T12:30:00.000Z',
+  };
   const olderEpisode = {
     ...episode,
     id: 'episode-old',
@@ -694,7 +701,7 @@ test('view model separates active artifacts from historical artifacts', () => {
     selectedScript: approvedScript,
     selectedRevision: passedReviewRevision,
     selectedRevisions: [olderRevision, passedReviewRevision],
-    production: { episode, assets: [olderAudio, audioAsset, coverAsset], jobs: [] },
+    production: { episode, assets: [olderAudio, nonProductionAsset, audioAsset, coverAsset], jobs: [] },
     episodes: [olderEpisode, episode],
     selectedEpisodeId: 'episode-1',
   });

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -264,8 +264,8 @@ test('view model blocks drafting while research warnings are unresolved', () => 
   assert.equal(model.currentStage.id, 'brief');
   assert.equal(model.currentStage.status, 'needs-review');
   assert.equal(model.primaryNextAction.label, 'Resolve research warnings');
-  assert.equal(model.primaryNextAction.enabled, false);
-  assert.match(model.primaryNextAction.blockerReason, /research warning/);
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.primaryNextAction.blockerReason, null);
   assert.ok(model.warnings.some((warning) => warning.stage === 'brief'));
 });
 
@@ -320,7 +320,7 @@ test('view model uses selected script provenance over stale selected brief', () 
 
   assert.equal(model.activeArtifacts.brief.id, 'brief-warning');
   assert.equal(model.primaryNextAction.label, 'Resolve research warnings');
-  assert.equal(model.primaryNextAction.enabled, false);
+  assert.equal(model.primaryNextAction.enabled, true);
 });
 
 test('view model covers script ready with required integrity review', () => {
@@ -461,7 +461,37 @@ test('view model covers publish blocked with concrete blocker reason', () => {
   assert.equal(model.primaryNextAction.label, 'Approve for publishing');
   assert.equal(model.primaryNextAction.enabled, false);
   assert.match(model.primaryNextAction.blockerReason, /Feed metadata configured/);
-  assert.ok(model.blockers.some((blocker) => blocker.stage === 'feed'));
+  assert.ok(model.blockers.some((blocker) => blocker.stage === 'publishing'));
+});
+
+test('view model does not treat private local feed paths as publish targets', () => {
+  const localPathFeed = {
+    ...feed,
+    rssFeedPath: '/private/demo.xml',
+    publicFeedUrl: '',
+    publicBaseUrl: '',
+  };
+  const model = deriveProductionViewModel(baseInput({
+    feeds: [localPathFeed],
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.currentStage.status, 'blocked');
+  assert.match(model.primaryNextAction.blockerReason, /RSS\/public target configured/);
+  assert.ok(model.blockers.some((blocker) => blocker.stage === 'publishing' && blocker.message.includes('RSS/public target configured')));
 });
 
 test('view model deduplicates overlapping recent and production jobs', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -1,0 +1,366 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { deriveProductionViewModel } from '../packages/api/public/ui-view-model.js';
+
+const show = {
+  id: 'show-1',
+  slug: 'demo-show',
+  title: 'Demo Show',
+  setupStatus: 'active',
+  format: 'daily-briefing',
+  defaultRuntimeMinutes: 8,
+};
+
+const profile = {
+  id: 'profile-1',
+  slug: 'demo-sources',
+  name: 'Demo Story Sources',
+  type: 'brave',
+  enabled: true,
+  weight: 1,
+  freshness: 'pd',
+};
+
+const query = {
+  id: 'query-1',
+  sourceProfileId: 'profile-1',
+  query: 'AI policy',
+  enabled: true,
+};
+
+const candidate = {
+  id: 'candidate-1',
+  showId: 'show-1',
+  sourceProfileId: 'profile-1',
+  title: 'Regulators publish new AI safety guidance',
+  status: 'new',
+  canonicalUrl: 'https://example.com/ai-safety',
+  sourceName: 'Example News',
+  score: 82,
+  discoveredAt: '2026-04-27T12:00:00.000Z',
+};
+
+const readyBrief = {
+  id: 'brief-1',
+  title: 'AI safety guidance brief',
+  status: 'ready',
+  approvedAt: '2026-04-27T13:00:00.000Z',
+  warnings: [],
+  citations: [{ url: 'https://example.com/ai-safety' }],
+  createdAt: '2026-04-27T12:30:00.000Z',
+  updatedAt: '2026-04-27T13:00:00.000Z',
+};
+
+const script = {
+  id: 'script-1',
+  researchPacketId: 'brief-1',
+  title: 'AI safety guidance script',
+  status: 'draft',
+  approvedRevisionId: null,
+  createdAt: '2026-04-27T13:30:00.000Z',
+  updatedAt: '2026-04-27T13:30:00.000Z',
+};
+
+const missingReviewRevision = {
+  id: 'revision-1',
+  scriptId: 'script-1',
+  version: 1,
+  title: 'AI safety guidance script',
+  metadata: {},
+  createdAt: '2026-04-27T13:30:00.000Z',
+  updatedAt: '2026-04-27T13:30:00.000Z',
+};
+
+const passedReviewRevision = {
+  ...missingReviewRevision,
+  metadata: {
+    integrityReview: {
+      status: 'pass',
+      reviewedAt: '2026-04-27T14:00:00.000Z',
+    },
+  },
+  updatedAt: '2026-04-27T14:00:00.000Z',
+};
+
+const approvedScript = {
+  ...script,
+  status: 'approved-for-audio',
+  approvedRevisionId: 'revision-1',
+  updatedAt: '2026-04-27T14:05:00.000Z',
+};
+
+const audioAsset = {
+  id: 'asset-audio-1',
+  type: 'audio-preview',
+  status: 'ready',
+  mimeType: 'audio/mpeg',
+  byteSize: 1024,
+  durationSeconds: 420,
+  createdAt: '2026-04-27T14:30:00.000Z',
+  updatedAt: '2026-04-27T14:30:00.000Z',
+};
+
+const coverAsset = {
+  id: 'asset-cover-1',
+  type: 'cover-art',
+  status: 'ready',
+  mimeType: 'image/png',
+  byteSize: 2048,
+  createdAt: '2026-04-27T14:35:00.000Z',
+  updatedAt: '2026-04-27T14:35:00.000Z',
+};
+
+const episode = {
+  id: 'episode-1',
+  feedId: 'feed-1',
+  title: 'AI safety guidance episode',
+  slug: 'ai-safety-guidance',
+  status: 'audio-ready',
+  createdAt: '2026-04-27T14:40:00.000Z',
+  updatedAt: '2026-04-27T14:40:00.000Z',
+};
+
+const feed = {
+  id: 'feed-1',
+  showId: 'show-1',
+  title: 'Demo Feed',
+  rssFeedPath: 'feeds/demo.xml',
+  publicFeedUrl: 'https://podcasts.example.com/demo.xml',
+  publicBaseUrl: 'https://podcasts.example.com/assets/',
+  storageType: 'local',
+};
+
+function baseInput(overrides = {}) {
+  return {
+    shows: [show],
+    feeds: [feed],
+    profiles: [profile],
+    queries: [query],
+    storyCandidates: [],
+    researchPackets: [],
+    scripts: [],
+    selectedRevisions: [],
+    production: { episode: null, assets: [], jobs: [] },
+    recentJobs: [],
+    episodes: [],
+    selectedShowSlug: 'demo-show',
+    selectedProfileId: 'profile-1',
+    selectedCandidateIds: [],
+    selectedResearchPacketId: '',
+    selectedScriptId: '',
+    selectedScript: null,
+    selectedRevision: null,
+    selectedEpisodeId: '',
+    selectedAssetIds: [],
+    activeSurface: 'workflow',
+    latestActionResult: { status: 'info', message: 'Fixture loaded.', source: 'test' },
+    ...overrides,
+  };
+}
+
+test('view model covers no show selected', () => {
+  const model = deriveProductionViewModel(baseInput({
+    selectedShowSlug: '',
+    selectedProfileId: '',
+    shows: [],
+    profiles: [],
+    queries: [],
+    feeds: [],
+  }));
+
+  assert.equal(model.selectedShowSummary, null);
+  assert.equal(model.currentStage.id, 'show');
+  assert.equal(model.currentStage.status, 'blocked');
+  assert.deepEqual(model.primaryNextAction, {
+    label: 'Select or create show',
+    targetStage: 'show',
+    enabled: true,
+    blockerReason: null,
+  });
+  assert.equal(model.activeArtifacts.brief, null);
+  assert.equal(model.historicalArtifacts.briefs.length, 0);
+});
+
+test('view model covers source selected with no candidate stories', () => {
+  const model = deriveProductionViewModel(baseInput());
+
+  assert.equal(model.selectedStorySourceSummary.name, 'Demo Story Sources');
+  assert.equal(model.selectedStorySourceSummary.queryCount, 1);
+  assert.equal(model.currentStage.id, 'discover');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Run source search');
+  assert.equal(model.primaryNextAction.enabled, true);
+});
+
+test('view model covers candidate selected with no research brief', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+  }));
+
+  assert.equal(model.selectedCandidateStorySummary.count, 1);
+  assert.equal(model.selectedCandidateStorySummary.primary.title, candidate.title);
+  assert.equal(model.currentStage.id, 'brief');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Build research brief');
+  assert.equal(model.primaryNextAction.enabled, true);
+});
+
+test('view model covers research brief ready with no script', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+  }));
+
+  assert.equal(model.activeArtifacts.brief.id, 'brief-1');
+  assert.equal(model.latestArtifacts.brief.status, 'ready');
+  assert.equal(model.currentStage.id, 'script');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Generate script draft');
+  assert.equal(model.primaryNextAction.enabled, true);
+});
+
+test('view model covers script ready with required integrity review', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [script],
+    selectedScriptId: 'script-1',
+    selectedScript: script,
+    selectedRevision: missingReviewRevision,
+    selectedRevisions: [missingReviewRevision],
+  }));
+
+  assert.equal(model.activeArtifacts.script.id, 'script-1');
+  assert.equal(model.activeArtifacts.review.status, 'missing');
+  assert.equal(model.currentStage.id, 'review');
+  assert.equal(model.currentStage.status, 'needs-review');
+  assert.equal(model.primaryNextAction.label, 'Run integrity review');
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.ok(model.blockers.some((blocker) => blocker.message.includes('Integrity review has not been run')));
+});
+
+test('view model covers audio produced with cover still active work', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [audioAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1'],
+  }));
+
+  assert.equal(model.activeArtifacts.audioCover.status, 'partial');
+  assert.equal(model.latestArtifacts.audioCover.audio.id, 'asset-audio-1');
+  assert.equal(model.latestArtifacts.audioCover.cover, null);
+  assert.equal(model.currentStage.id, 'production');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Create missing cover art');
+  assert.equal(model.primaryNextAction.enabled, true);
+});
+
+test('view model covers publish blocked with concrete blocker reason', () => {
+  const model = deriveProductionViewModel(baseInput({
+    feeds: [],
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.currentStage.status, 'blocked');
+  assert.equal(model.primaryNextAction.label, 'Approve for publishing');
+  assert.equal(model.primaryNextAction.enabled, false);
+  assert.match(model.primaryNextAction.blockerReason, /Feed metadata configured/);
+  assert.ok(model.blockers.some((blocker) => blocker.stage === 'feed'));
+});
+
+test('view model separates active artifacts from historical artifacts', () => {
+  const olderBrief = {
+    ...readyBrief,
+    id: 'brief-old',
+    title: 'Older brief',
+    createdAt: '2026-04-26T10:00:00.000Z',
+    updatedAt: '2026-04-26T10:00:00.000Z',
+  };
+  const olderScript = {
+    ...approvedScript,
+    id: 'script-old',
+    title: 'Older script',
+    researchPacketId: 'brief-old',
+    approvedRevisionId: 'revision-old',
+    createdAt: '2026-04-26T11:00:00.000Z',
+    updatedAt: '2026-04-26T11:00:00.000Z',
+  };
+  const olderRevision = {
+    ...passedReviewRevision,
+    id: 'revision-old',
+    scriptId: 'script-old',
+    createdAt: '2026-04-26T11:00:00.000Z',
+    updatedAt: '2026-04-26T11:00:00.000Z',
+  };
+  const olderAudio = {
+    ...audioAsset,
+    id: 'asset-audio-old',
+    createdAt: '2026-04-26T12:00:00.000Z',
+    updatedAt: '2026-04-26T12:00:00.000Z',
+  };
+  const olderEpisode = {
+    ...episode,
+    id: 'episode-old',
+    title: 'Older episode',
+    slug: 'older-episode',
+    status: 'published',
+    createdAt: '2026-04-26T13:00:00.000Z',
+    updatedAt: '2026-04-26T13:00:00.000Z',
+    publishedAt: '2026-04-26T13:05:00.000Z',
+  };
+
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [olderBrief, readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [olderScript, approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [olderRevision, passedReviewRevision],
+    production: { episode, assets: [olderAudio, audioAsset, coverAsset], jobs: [] },
+    episodes: [olderEpisode, episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.activeArtifacts.brief.id, 'brief-1');
+  assert.equal(model.activeArtifacts.script.id, 'script-1');
+  assert.equal(model.activeArtifacts.audioCover.audio.id, 'asset-audio-1');
+  assert.deepEqual(model.historicalArtifacts.briefs.map((item) => item.id), ['brief-old']);
+  assert.deepEqual(model.historicalArtifacts.scripts.map((item) => item.id), ['script-old']);
+  assert.deepEqual(model.historicalArtifacts.reviews.map((item) => item.id), ['revision-old']);
+  assert.deepEqual(model.historicalArtifacts.audioCover.map((item) => item.id), ['asset-audio-old']);
+  assert.deepEqual(model.historicalArtifacts.publishing.map((item) => item.id), ['episode-old']);
+  assert.equal(model.visibility.groups.history, true);
+});

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -414,6 +414,8 @@ test('view model treats publish approval as actionable when prerequisites are re
   assert.equal(model.currentStage.status, 'ready');
   assert.equal(model.primaryNextAction.label, 'Approve for publishing');
   assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.blockers.some((blocker) => blocker.message.includes('Publish approval recorded')), false);
+  assert.ok(model.navigationActions.some((navAction) => navAction.targetStage === 'publishing'));
 });
 
 test('view model blocks publish approval until episode is audio-ready', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -58,6 +58,17 @@ const warningBrief = {
   warnings: [{ code: 'LOW_CORROBORATION', message: 'Needs another independent source.' }],
 };
 
+const notReadyBrief = {
+  ...readyBrief,
+  id: 'brief-not-ready',
+  status: 'ready',
+  content: {
+    readiness: {
+      status: 'needs_more_sources',
+    },
+  },
+};
+
 const script = {
   id: 'script-1',
   researchPacketId: 'brief-1',
@@ -267,6 +278,22 @@ test('view model blocks drafting while research warnings are unresolved', () => 
   assert.equal(model.primaryNextAction.enabled, true);
   assert.equal(model.primaryNextAction.blockerReason, null);
   assert.ok(model.warnings.some((warning) => warning.stage === 'brief'));
+});
+
+test('view model blocks drafting when readiness metadata is not ready', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [notReadyBrief],
+    selectedResearchPacketId: 'brief-not-ready',
+  }));
+
+  assert.equal(model.activeArtifacts.brief.status, 'needs_more_sources');
+  assert.equal(model.currentStage.id, 'brief');
+  assert.equal(model.currentStage.status, 'blocked');
+  assert.equal(model.stages.find((stage) => stage.id === 'script').status, 'blocked');
+  assert.equal(model.primaryNextAction.label, 'Review blocked research brief');
+  assert.ok(model.blockers.some((blocker) => blocker.message.includes('needs_more_sources')));
 });
 
 test('view model covers research brief ready with no script', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -272,6 +272,24 @@ test('view model covers research brief ready with no script', () => {
   assert.equal(model.primaryNextAction.enabled, true);
 });
 
+test('view model recovers downstream workflow when candidate selection is stale', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [],
+    selectedCandidateIds: [],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [script],
+    selectedScriptId: 'script-1',
+    selectedScript: script,
+    selectedRevision: null,
+  }));
+
+  assert.equal(model.stages.find((stage) => stage.id === 'discover').status, 'done');
+  assert.equal(model.stages.find((stage) => stage.id === 'story').status, 'done');
+  assert.equal(model.currentStage.id, 'review');
+  assert.equal(model.primaryNextAction.label, 'Select script revision');
+});
+
 test('view model covers script ready with required integrity review', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -494,6 +494,36 @@ test('view model does not treat private local feed paths as publish targets', ()
   assert.ok(model.blockers.some((blocker) => blocker.stage === 'publishing' && blocker.message.includes('RSS/public target configured')));
 });
 
+test('view model accepts raw rss path with a public asset base as publish target without exposing the path', () => {
+  const localPathFeed = {
+    ...feed,
+    rssFeedPath: '/private/demo.xml',
+    publicFeedUrl: '',
+    publicBaseUrl: 'https://podcasts.example.com/assets/',
+  };
+  const model = deriveProductionViewModel(baseInput({
+    feeds: [localPathFeed],
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.primaryNextAction.label, 'Approve for publishing');
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), false);
+});
+
 test('view model deduplicates overlapping recent and production jobs', () => {
   const recentJob = {
     id: 'job-1',
@@ -589,7 +619,7 @@ test('view model separates active artifacts from historical artifacts', () => {
     publishedAt: '2026-04-26T13:05:00.000Z',
   };
 
-  const model = deriveProductionViewModel(baseInput({
+  const input = baseInput({
     storyCandidates: [candidate],
     selectedCandidateIds: ['candidate-1'],
     researchPackets: [olderBrief, readyBrief],
@@ -602,16 +632,22 @@ test('view model separates active artifacts from historical artifacts', () => {
     production: { episode, assets: [olderAudio, audioAsset, coverAsset], jobs: [] },
     episodes: [olderEpisode, episode],
     selectedEpisodeId: 'episode-1',
+  });
+  const selectedModel = deriveProductionViewModel({
+    ...input,
     selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
-  }));
+  });
+  const defaultModel = deriveProductionViewModel(input);
 
-  assert.equal(model.activeArtifacts.brief.id, 'brief-1');
-  assert.equal(model.activeArtifacts.script.id, 'script-1');
-  assert.equal(model.activeArtifacts.audioCover.audio.id, 'asset-audio-1');
-  assert.deepEqual(model.historicalArtifacts.briefs.map((item) => item.id), ['brief-old']);
-  assert.deepEqual(model.historicalArtifacts.scripts.map((item) => item.id), ['script-old']);
-  assert.deepEqual(model.historicalArtifacts.reviews.map((item) => item.id), ['revision-old']);
-  assert.deepEqual(model.historicalArtifacts.audioCover.map((item) => item.id), ['asset-audio-old']);
-  assert.deepEqual(model.historicalArtifacts.publishing.map((item) => item.id), ['episode-old']);
-  assert.equal(model.visibility.groups.history, true);
+  for (const model of [selectedModel, defaultModel]) {
+    assert.equal(model.activeArtifacts.brief.id, 'brief-1');
+    assert.equal(model.activeArtifacts.script.id, 'script-1');
+    assert.equal(model.activeArtifacts.audioCover.audio.id, 'asset-audio-1');
+    assert.deepEqual(model.historicalArtifacts.briefs.map((item) => item.id), ['brief-old']);
+    assert.deepEqual(model.historicalArtifacts.scripts.map((item) => item.id), ['script-old']);
+    assert.deepEqual(model.historicalArtifacts.reviews.map((item) => item.id), ['revision-old']);
+    assert.deepEqual(model.historicalArtifacts.audioCover.map((item) => item.id), ['asset-audio-old']);
+    assert.deepEqual(model.historicalArtifacts.publishing.map((item) => item.id), ['episode-old']);
+    assert.equal(model.visibility.groups.history, true);
+  }
 });

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -300,6 +300,7 @@ test('view model recovers downstream workflow when candidate selection is stale'
   assert.equal(model.stages.find((stage) => stage.id === 'discover').status, 'done');
   assert.equal(model.stages.find((stage) => stage.id === 'story').status, 'done');
   assert.equal(model.currentStage.id, 'review');
+  assert.equal(model.currentStage.status, 'ready');
   assert.equal(model.primaryNextAction.label, 'Select script revision');
   assert.equal(model.primaryNextAction.enabled, true);
 });
@@ -551,6 +552,37 @@ test('view model accepts metadata output path with a public asset base as publis
   }));
 
   assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), false);
+});
+
+test('view model falls back only to an unambiguous selected-show feed', () => {
+  const otherShowFeed = {
+    ...feed,
+    id: 'feed-other-show',
+    showId: 'show-other',
+    rssFeedPath: '',
+    publicFeedUrl: '',
+    publicBaseUrl: '',
+  };
+  const episodeWithoutFeed = { ...episode, feedId: null };
+  const model = deriveProductionViewModel(baseInput({
+    feeds: [otherShowFeed, feed],
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode: episodeWithoutFeed, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episodeWithoutFeed],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
   assert.equal(model.primaryNextAction.enabled, true);
   assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), false);
 });

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -494,6 +494,31 @@ test('view model covers publish blocked with concrete blocker reason', () => {
   assert.ok(model.blockers.some((blocker) => blocker.stage === 'publishing'));
 });
 
+test('view model keeps approved publish action scoped to RSS blockers', () => {
+  const approvedEpisode = { ...episode, status: 'approved-for-publish' };
+  const model = deriveProductionViewModel(baseInput({
+    feeds: [],
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode: approvedEpisode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [approvedEpisode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.primaryNextAction.label, 'Publish to RSS');
+  assert.equal(model.primaryNextAction.enabled, false);
+  assert.match(model.primaryNextAction.blockerReason, /Feed metadata configured/);
+  assert.doesNotMatch(model.primaryNextAction.blockerReason, /audio-ready/);
+});
+
 test('view model does not treat private local feed paths as publish targets', () => {
   const localPathFeed = {
     ...feed,

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -602,7 +602,7 @@ test('view model accepts raw rss path with a public asset base as publish target
   assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), false);
 });
 
-test('view model accepts metadata output path with a public asset base as publish target', () => {
+test('view model blocks metadata output path without rss feed path as publish target', () => {
   const metadataOutputFeed = {
     ...feed,
     rssFeedPath: '',
@@ -629,8 +629,10 @@ test('view model accepts metadata output path with a public asset base as publis
   }));
 
   assert.equal(model.currentStage.id, 'publishing');
-  assert.equal(model.primaryNextAction.enabled, true);
-  assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), false);
+  assert.equal(model.currentStage.status, 'blocked');
+  assert.equal(model.primaryNextAction.enabled, false);
+  assert.match(model.primaryNextAction.blockerReason, /RSS\/public target configured/);
+  assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), true);
 });
 
 test('view model falls back only to an unambiguous selected-show feed', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -290,6 +290,25 @@ test('view model recovers downstream workflow when candidate selection is stale'
   assert.equal(model.primaryNextAction.label, 'Select script revision');
 });
 
+test('view model uses selected script provenance over stale selected brief', () => {
+  const scriptFromWarningBrief = { ...approvedScript, researchPacketId: 'brief-warning' };
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief, warningBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [scriptFromWarningBrief],
+    selectedScriptId: 'script-1',
+    selectedScript: scriptFromWarningBrief,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+  }));
+
+  assert.equal(model.activeArtifacts.brief.id, 'brief-warning');
+  assert.equal(model.primaryNextAction.label, 'Resolve research warnings');
+  assert.equal(model.primaryNextAction.enabled, false);
+});
+
 test('view model covers script ready with required integrity review', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -89,6 +89,17 @@ const passedReviewRevision = {
   updatedAt: '2026-04-27T14:00:00.000Z',
 };
 
+const failedReviewRevision = {
+  ...missingReviewRevision,
+  metadata: {
+    integrityReview: {
+      status: 'fail',
+      reviewedAt: '2026-04-27T14:00:00.000Z',
+    },
+  },
+  updatedAt: '2026-04-27T14:00:00.000Z',
+};
+
 const approvedScript = {
   ...script,
   status: 'approved-for-audio',
@@ -207,6 +218,8 @@ test('view model covers source selected with no candidate stories', () => {
 
   assert.equal(model.selectedStorySourceSummary.name, 'Demo Story Sources');
   assert.equal(model.selectedStorySourceSummary.queryCount, 1);
+  assert.equal(model.stages.find((stage) => stage.id === 'source').artifact.queryCount, 1);
+  assert.equal(model.stages.find((stage) => stage.id === 'source').artifact.enabledQueryCount, 1);
   assert.equal(model.currentStage.id, 'discover');
   assert.equal(model.currentStage.status, 'ready');
   assert.equal(model.primaryNextAction.label, 'Run source search');
@@ -288,6 +301,7 @@ test('view model recovers downstream workflow when candidate selection is stale'
   assert.equal(model.stages.find((stage) => stage.id === 'story').status, 'done');
   assert.equal(model.currentStage.id, 'review');
   assert.equal(model.primaryNextAction.label, 'Select script revision');
+  assert.equal(model.primaryNextAction.enabled, true);
 });
 
 test('view model uses selected script provenance over stale selected brief', () => {
@@ -329,6 +343,27 @@ test('view model covers script ready with required integrity review', () => {
   assert.equal(model.primaryNextAction.label, 'Run integrity review');
   assert.equal(model.primaryNextAction.enabled, true);
   assert.ok(model.blockers.some((blocker) => blocker.message.includes('Integrity review has not been run')));
+});
+
+test('view model keeps failed integrity review retry actionable', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [script],
+    selectedScriptId: 'script-1',
+    selectedScript: script,
+    selectedRevision: failedReviewRevision,
+    selectedRevisions: [failedReviewRevision],
+  }));
+
+  assert.equal(model.activeArtifacts.review.status, 'fail');
+  assert.equal(model.currentStage.id, 'review');
+  assert.equal(model.currentStage.status, 'needs-review');
+  assert.equal(model.primaryNextAction.label, 'Rerun integrity review');
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.ok(model.blockers.some((blocker) => blocker.message.includes('Integrity review failed')));
 });
 
 test('view model covers audio produced with cover still active work', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -677,6 +677,7 @@ test('view model separates active artifacts from historical artifacts', () => {
     ...audioAsset,
     id: 'asset-script-old',
     type: 'script',
+    metadata: { warnings: [{ code: 'legacy-script-warning', message: 'Ignore non-production warning.' }] },
     createdAt: '2026-04-26T12:30:00.000Z',
     updatedAt: '2026-04-26T12:30:00.000Z',
   };
@@ -719,6 +720,9 @@ test('view model separates active artifacts from historical artifacts', () => {
     assert.deepEqual(model.historicalArtifacts.scripts.map((item) => item.id), ['script-old']);
     assert.deepEqual(model.historicalArtifacts.reviews.map((item) => item.id), ['revision-old']);
     assert.deepEqual(model.historicalArtifacts.audioCover.map((item) => item.id), ['asset-audio-old']);
+    assert.equal(model.historicalArtifacts.audioCover[0].stage, 'production');
+    assert.equal(model.historicalArtifacts.audioCover[0].productionKind, 'audio');
+    assert.ok(!model.warnings.some((warning) => warning.message.includes('non-production')));
     assert.deepEqual(model.historicalArtifacts.publishing.map((item) => item.id), ['episode-old']);
     assert.equal(model.visibility.groups.history, true);
   }

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -411,11 +411,17 @@ test('view model covers publish blocked with concrete blocker reason', () => {
 });
 
 test('view model deduplicates overlapping recent and production jobs', () => {
-  const duplicateJob = {
+  const recentJob = {
     id: 'job-1',
     type: 'production.audio',
-    status: 'succeeded',
+    status: 'running',
     createdAt: '2026-04-27T14:20:00.000Z',
+    updatedAt: '2026-04-27T14:30:00.000Z',
+    summary: { warnings: [{ message: 'Stale warning.' }] },
+  };
+  const duplicateJob = {
+    ...recentJob,
+    status: 'succeeded',
     updatedAt: '2026-04-27T14:45:00.000Z',
     summary: { warnings: [{ message: 'Preview asset needs review.' }] },
   };
@@ -430,7 +436,7 @@ test('view model deduplicates overlapping recent and production jobs', () => {
     selectedScript: approvedScript,
     selectedRevision: passedReviewRevision,
     selectedRevisions: [passedReviewRevision],
-    recentJobs: [duplicateJob],
+    recentJobs: [recentJob],
     production: { episode, assets: [audioAsset, coverAsset], jobs: [duplicateJob] },
     episodes: [episode],
     selectedEpisodeId: 'episode-1',
@@ -439,7 +445,9 @@ test('view model deduplicates overlapping recent and production jobs', () => {
   }));
 
   assert.equal(model.latestActionResult.job.id, 'job-1');
+  assert.equal(model.latestActionResult.status, 'succeeded');
   assert.equal(model.warnings.filter((warning) => warning.message === 'Preview asset needs review.').length, 1);
+  assert.equal(model.warnings.filter((warning) => warning.message === 'Stale warning.').length, 0);
 });
 
 test('view model keeps latest artifacts independent from active selection', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -182,6 +182,20 @@ test('view model covers no show selected', () => {
   assert.equal(model.historicalArtifacts.briefs.length, 0);
 });
 
+test('view model marks source choice ready after show selection', () => {
+  const model = deriveProductionViewModel(baseInput({
+    selectedProfileId: '',
+    profiles: [],
+    queries: [],
+  }));
+
+  assert.equal(model.selectedShowSummary.slug, 'demo-show');
+  assert.equal(model.currentStage.id, 'source');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Choose story source');
+  assert.equal(model.primaryNextAction.enabled, true);
+});
+
 test('view model covers source selected with no candidate stories', () => {
   const model = deriveProductionViewModel(baseInput());
 
@@ -190,6 +204,19 @@ test('view model covers source selected with no candidate stories', () => {
   assert.equal(model.currentStage.id, 'discover');
   assert.equal(model.currentStage.status, 'ready');
   assert.equal(model.primaryNextAction.label, 'Run source search');
+  assert.equal(model.primaryNextAction.enabled, true);
+});
+
+test('view model covers candidates loaded but no story selected', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: [],
+  }));
+
+  assert.equal(model.selectedCandidateStorySummary.count, 0);
+  assert.equal(model.currentStage.id, 'story');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Pick or cluster story');
   assert.equal(model.primaryNextAction.enabled, true);
 });
 
@@ -268,6 +295,29 @@ test('view model covers audio produced with cover still active work', () => {
   assert.equal(model.currentStage.id, 'production');
   assert.equal(model.currentStage.status, 'ready');
   assert.equal(model.primaryNextAction.label, 'Create missing cover art');
+  assert.equal(model.primaryNextAction.enabled, true);
+});
+
+test('view model treats publish approval as actionable when prerequisites are ready', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Approve for publishing');
   assert.equal(model.primaryNextAction.enabled, true);
 });
 

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -524,6 +524,37 @@ test('view model accepts raw rss path with a public asset base as publish target
   assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), false);
 });
 
+test('view model accepts metadata output path with a public asset base as publish target', () => {
+  const metadataOutputFeed = {
+    ...feed,
+    rssFeedPath: '',
+    publicFeedUrl: '',
+    publicBaseUrl: 'https://podcasts.example.com/assets/',
+    metadata: { outputPath: 'feeds/demo.xml' },
+    storageConfig: {},
+  };
+  const model = deriveProductionViewModel(baseInput({
+    feeds: [metadataOutputFeed],
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.blockers.some((blocker) => blocker.message.includes('RSS/public target configured')), false);
+});
+
 test('view model deduplicates overlapping recent and production jobs', () => {
   const recentJob = {
     id: 'job-1',


### PR DESCRIPTION
## Summary
- Adds a pure static-frontend `deriveProductionViewModel(input)` contract for Produce workflow state.
- Derives selected show/source/story summaries, current stage, active/latest/historical artifacts, next action, warnings/blockers, action result, and visibility grouping hints.
- Wires the derived model into the existing static UI debug state and serves the new module route.
- Adds deterministic Node test fixtures for the required PF3-01 states.

Closes #75

## Verification
- `node --test scripts/ui-production-view-model.test.mjs`
- `npm run check`
- `git diff --check`

## Notes
- Static frontend stack preserved; no React/Next/Vite/build pipeline added.
- No live provider/model/network calls added to tests.
- `.codex` remains untracked in the worktree and was not committed.