### PR TITLE
PF3-03 Render compact 8-stage tracker

### DIFF
--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -369,8 +369,8 @@ button:disabled {
 
 .pipeline-grid {
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 0.55rem;
+  grid-template-columns: 1fr;
 }
 
 .pipeline-card {
@@ -378,12 +378,13 @@ button:disabled {
   border: 1px solid #d8dde5;
   border-radius: 8px;
   display: grid;
-  gap: 0.65rem;
+  gap: 0.55rem;
+  grid-template-columns: minmax(0, 1fr) auto;
   min-width: 0;
-  padding: 0.85rem;
+  padding: 0.7rem 0.8rem;
 }
 
-.pipeline-card.active {
+.pipeline-card.current {
   border-color: #2468a8;
   box-shadow: inset 3px 0 0 #2468a8;
 }
@@ -403,8 +404,22 @@ button:disabled {
   border-color: #9ac8aa;
 }
 
+.pipeline-card.complete {
+  background: #f3faf6;
+  border-color: #9ac8aa;
+}
+
 .pipeline-card.running {
   border-color: #7aa7d7;
+}
+
+.pipeline-card.warning {
+  background: #fbfaf1;
+  border-color: #d8cf73;
+}
+
+.pipeline-card.expanded {
+  gap: 0.7rem;
 }
 
 .pipeline-card h3,
@@ -429,6 +444,32 @@ button:disabled {
   justify-content: space-between;
 }
 
+.pipeline-card .pipeline-top {
+  grid-column: 1;
+}
+
+.pipeline-summary {
+  display: grid;
+  gap: 0.2rem;
+  grid-column: 1;
+}
+
+.pipeline-summary p:first-child {
+  color: #27303b;
+  font-weight: 650;
+}
+
+.pipeline-summary p:last-child {
+  color: #586575;
+  font-size: 0.86rem;
+}
+
+.pipeline-card-body {
+  display: grid;
+  gap: 0.65rem;
+  grid-column: 1 / -1;
+}
+
 .pipeline-step {
   color: #687486;
   font-size: 0.8rem;
@@ -449,6 +490,12 @@ button:disabled {
 
 .status-pill.not-started {
   background: #edf0f4;
+}
+
+.status-pill.current {
+  background: #eef6ff;
+  border-color: #2468a8;
+  color: #1f5b95;
 }
 
 .status-pill.ready {
@@ -499,6 +546,12 @@ button:disabled {
   color: #245b37;
 }
 
+.status-pill.complete {
+  background: #e9f7ee;
+  border-color: #9ac8aa;
+  color: #245b37;
+}
+
 .pipeline-artifacts,
 .pipeline-next {
   display: grid;
@@ -514,6 +567,23 @@ button:disabled {
 .pipeline-card button {
   justify-self: start;
   min-height: 2.4rem;
+}
+
+.pipeline-card.collapsed .pipeline-expand {
+  align-self: center;
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  white-space: nowrap;
+}
+
+.pipeline-blockers {
+  color: #70440f;
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.pipeline-blockers li {
+  margin: 0.15rem 0;
 }
 
 .pipeline-card .pipeline-action-reason,
@@ -1527,6 +1597,15 @@ textarea {
 
   .production-command-bar {
     top: 0.5rem;
+  }
+
+  .pipeline-card {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-card.collapsed .pipeline-expand {
+    grid-column: 1;
+    grid-row: auto;
   }
 
   .command-bar-metrics {

--- a/packages/api/public/ui-state.js
+++ b/packages/api/public/ui-state.js
@@ -47,6 +47,7 @@ export const state = {
   selectedProfileId: '',
   activeSurface: 'workflow',
   activeSettingsTab: 'shows',
+  expandedPipelineStageIds: [],
   showSetupOpen: false,
   runningActions: {},
 };

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1026,6 +1026,61 @@ function stageIsComplete(stage) {
   return stage.status === 'done';
 }
 
+function stageStatusLabel(stage, currentStageId) {
+  if (stage.id === currentStageId) {
+    return 'current';
+  }
+
+  if (stage.status === 'done') {
+    return 'complete';
+  }
+
+  if (stage.status === 'needs review' || stage.status === 'needs-review') {
+    return 'warning';
+  }
+
+  if (stage.status === 'not started') {
+    return 'not started';
+  }
+
+  if (stage.status === 'blocked') {
+    return 'blocked';
+  }
+
+  if (stage.status === 'ready') {
+    return 'ready';
+  }
+
+  return String(stage.status || 'not started');
+}
+
+function currentPipelineStageId(viewModel, stages) {
+  const viewModelStageId = viewModel?.currentStage?.id === 'source'
+    ? 'show'
+    : viewModel?.currentStage?.id;
+
+  if (viewModelStageId && stages.some((stage) => stage.id === viewModelStageId)) {
+    return viewModelStageId;
+  }
+
+  return stages.find((stage) => !stageIsComplete(stage))?.id || stages[stages.length - 1]?.id || '';
+}
+
+function pipelineStageIsExpanded(stage, currentStageId) {
+  return stage.id === currentStageId || state.expandedPipelineStageIds.includes(stage.id);
+}
+
+function setPipelineStageExpanded(stageId, expanded) {
+  const expandedIds = new Set(state.expandedPipelineStageIds);
+  if (expanded) {
+    expandedIds.add(stageId);
+  } else {
+    expandedIds.delete(stageId);
+  }
+  state.expandedPipelineStageIds = [...expandedIds];
+  renderPipeline();
+}
+
 function checklistBlockers(checklist, includePublishApproval = true) {
   return checklist
     .filter((item) => !item.passed && (includePublishApproval || item.key !== 'publishApproval'))
@@ -1215,10 +1270,14 @@ function renderProductionCommandBar(viewModel, stages) {
   }
 }
 
-function stageCard(stage) {
+function stageCard(stage, currentStageId = '') {
+  const statusLabel = stageStatusLabel(stage, currentStageId);
+  const expanded = pipelineStageIsExpanded(stage, currentStageId);
   const card = document.createElement('article');
-  card.className = `pipeline-card ${statusClass(stage.status)}${stage.active ? ' active' : ''}`;
+  card.className = `pipeline-card ${statusClass(statusLabel)}${expanded ? ' expanded' : ' collapsed'}${stage.id === currentStageId ? ' current' : ''}`;
   card.dataset.stage = String(stage.number);
+  card.dataset.stageId = stage.id;
+  card.dataset.stageStatus = statusLabel;
 
   const top = document.createElement('div');
   top.className = 'pipeline-top';
@@ -1230,9 +1289,35 @@ function stageCard(stage) {
   title.textContent = stage.title;
   heading.append(step, title);
   const status = document.createElement('span');
-  status.className = `status-pill ${statusClass(stage.status)}`;
-  status.textContent = stage.status;
+  status.className = `status-pill ${statusClass(statusLabel)}`;
+  status.textContent = statusLabel;
   top.append(heading, status);
+
+  const summary = document.createElement('div');
+  summary.className = 'pipeline-summary';
+  const summaryText = document.createElement('p');
+  summaryText.textContent = stage.artifact;
+  const summaryNext = document.createElement('p');
+  summaryNext.textContent = stage.blockers?.length
+    ? `Blocked: ${stage.blockers[0]}`
+    : stage.next;
+  summary.append(summaryText, summaryNext);
+  card.append(top, summary);
+
+  if (!expanded) {
+    const expandButton = document.createElement('button');
+    expandButton.type = 'button';
+    expandButton.className = 'secondary pipeline-expand';
+    expandButton.textContent = 'Expand stage';
+    expandButton.setAttribute('aria-expanded', 'false');
+    expandButton.setAttribute('aria-label', `Expand ${stage.title}`);
+    expandButton.addEventListener('click', () => setPipelineStageExpanded(stage.id, true));
+    card.append(expandButton);
+    return card;
+  }
+
+  const body = document.createElement('div');
+  body.className = 'pipeline-card-body';
 
   const artifacts = document.createElement('div');
   artifacts.className = 'pipeline-artifacts';
@@ -1252,6 +1337,17 @@ function stageCard(stage) {
   nextText.textContent = stage.next;
   next.append(nextLabel, nextText);
 
+  if (stage.blockers?.length) {
+    const blockers = document.createElement('ul');
+    blockers.className = 'pipeline-blockers';
+    for (const blocker of stage.blockers) {
+      const item = document.createElement('li');
+      item.textContent = blocker;
+      blockers.append(item);
+    }
+    body.append(blockers);
+  }
+
   const button = document.createElement('button');
   button.type = 'button';
   button.className = stage.primary ? '' : 'secondary';
@@ -1266,7 +1362,7 @@ function stageCard(stage) {
   actionReason.className = `pipeline-action-reason${stage.disabled ? ' blocked' : ''}`;
   actionReason.textContent = stage.actionReason || (stage.disabled ? stage.next : `Action available: ${stage.next}`);
 
-  card.append(top, artifacts, next, button, actionReason);
+  body.append(artifacts, next, button, actionReason);
 
   if (stage.targetId && panelIsAvailable(stage.targetId)) {
     const panelButton = document.createElement('button');
@@ -1274,7 +1370,7 @@ function stageCard(stage) {
     panelButton.className = 'secondary';
     panelButton.textContent = 'Open Stage Panel';
     panelButton.addEventListener('click', () => scrollToPanel(stage.targetId));
-    card.append(panelButton);
+    body.append(panelButton);
   }
 
   if (stage.jobTypes?.length) {
@@ -1284,9 +1380,21 @@ function stageCard(stage) {
     jobButton.textContent = 'View Latest Run';
     jobButton.disabled = !latestRunForTypes(stage.jobTypes);
     jobButton.addEventListener('click', () => viewLatestJob(stage.jobTypes));
-    card.append(jobButton);
+    body.append(jobButton);
   }
 
+  if (stage.id !== currentStageId) {
+    const collapseButton = document.createElement('button');
+    collapseButton.type = 'button';
+    collapseButton.className = 'secondary pipeline-expand';
+    collapseButton.textContent = 'Collapse stage';
+    collapseButton.setAttribute('aria-expanded', 'true');
+    collapseButton.setAttribute('aria-label', `Collapse ${stage.title}`);
+    collapseButton.addEventListener('click', () => setPipelineStageExpanded(stage.id, false));
+    body.append(collapseButton);
+  }
+
+  card.append(body);
   return card;
 }
 
@@ -1686,11 +1794,12 @@ function renderPipeline() {
   }
 
   const stages = buildPipelineStages();
+  const currentStageId = currentPipelineStageId(viewModel, stages);
   renderProductionCommandBar(viewModel, stages);
   els.pipelineStages.innerHTML = '';
 
   for (const stage of stages) {
-    els.pipelineStages.append(stageCard(stage));
+    els.pipelineStages.append(stageCard(stage, currentStageId));
   }
 
   els.pipelineDebug.textContent = JSON.stringify(sanitizedDebug({

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -737,6 +737,7 @@ function clearPipelineSelections() {
   state.selectedEpisodeId = '';
   state.selectedAssetIds = [];
   state.production = { episode: null, assets: [], jobs: [] };
+  state.expandedPipelineStageIds = [];
 }
 
 function setActionRunning(action, running) {
@@ -1026,11 +1027,7 @@ function stageIsComplete(stage) {
   return stage.status === 'done';
 }
 
-function stageStatusLabel(stage, currentStageId) {
-  if (stage.id === currentStageId) {
-    return 'current';
-  }
-
+function stageStatusLabel(stage) {
   if (stage.status === 'done') {
     return 'complete';
   }
@@ -1068,6 +1065,11 @@ function currentPipelineStageId(viewModel, stages) {
 
 function pipelineStageIsExpanded(stage, currentStageId) {
   return stage.id === currentStageId || state.expandedPipelineStageIds.includes(stage.id);
+}
+
+function pruneExpandedPipelineStages(stages) {
+  const stageIds = new Set(stages.map((stage) => stage.id));
+  state.expandedPipelineStageIds = state.expandedPipelineStageIds.filter((stageId) => stageIds.has(stageId));
 }
 
 function setPipelineStageExpanded(stageId, expanded) {
@@ -1271,7 +1273,7 @@ function renderProductionCommandBar(viewModel, stages) {
 }
 
 function stageCard(stage, currentStageId = '') {
-  const statusLabel = stageStatusLabel(stage, currentStageId);
+  const statusLabel = stageStatusLabel(stage);
   const expanded = pipelineStageIsExpanded(stage, currentStageId);
   const card = document.createElement('article');
   card.className = `pipeline-card ${statusClass(statusLabel)}${expanded ? ' expanded' : ' collapsed'}${stage.id === currentStageId ? ' current' : ''}`;
@@ -1292,6 +1294,12 @@ function stageCard(stage, currentStageId = '') {
   status.className = `status-pill ${statusClass(statusLabel)}`;
   status.textContent = statusLabel;
   top.append(heading, status);
+  if (stage.id === currentStageId) {
+    const currentBadge = document.createElement('span');
+    currentBadge.className = 'status-pill current';
+    currentBadge.textContent = 'current';
+    top.append(currentBadge);
+  }
 
   const summary = document.createElement('div');
   summary.className = 'pipeline-summary';
@@ -1794,6 +1802,7 @@ function renderPipeline() {
   }
 
   const stages = buildPipelineStages();
+  pruneExpandedPipelineStages(stages);
   const currentStageId = currentPipelineStageId(viewModel, stages);
   renderProductionCommandBar(viewModel, stages);
   els.pipelineStages.innerHTML = '';

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -99,8 +99,11 @@ test('stage tracker progressively discloses only the current stage by default', 
   assertContains(uiJs, "button.textContent = stage.actionLabel", 'existing stage action remains available when expanded');
   assertContains(uiJs, 'body.append(artifacts, next, button, actionReason)', 'expanded stage body keeps action context');
   assertContains(uiJs, 'els.pipelineStages.append(stageCard(stage, currentStageId))', 'render should pass the current stage into each card');
+  assertContains(uiJs, "currentBadge.textContent = 'current'", 'current stage should be called out separately from status');
+  assertContains(uiJs, 'function pruneExpandedPipelineStages(stages)', 'expanded stage state should be pruned during render');
+  assertContains(uiJs, 'state.expandedPipelineStageIds = []', 'changing workflow context should reset expanded stage state');
 
-  for (const status of ['not started', 'current', 'blocked', 'ready', 'complete', 'warning']) {
+  for (const status of ['not started', 'blocked', 'ready', 'complete', 'warning']) {
     assertContains(uiJs, `return '${status}'`, `stage tracker status ${status}`);
   }
 

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -81,10 +81,33 @@ test('editorial stage definitions remain intact and navigable', () => {
 
   const targetIdCount = uiJs.match(/\btargetId:/g)?.length ?? 0;
   assert.ok(targetIdCount >= 8, 'pipeline stages should keep panel target IDs for navigation');
-  assertContains(uiJs, 'function stageCard(stage)', 'stage card renderer');
+  assertContains(uiJs, 'function stageCard(stage', 'stage card renderer');
   assertContains(uiJs, 'scrollToPanel(stage.targetId)', 'stage card panel navigation');
   assertContains(uiJs, 'function scrollToPanel(id)', 'panel scroll helper');
   assertContains(uiJs, "card.dataset.stage", 'stage cards should expose stage numbers');
+});
+
+test('stage tracker progressively discloses only the current stage by default', () => {
+  assertContains(uiJs, 'function currentPipelineStageId(viewModel, stages)', 'current pipeline stage mapper');
+  assertContains(uiJs, "viewModel?.currentStage?.id === 'source'", 'view-model source stage should map into the 8-stage tracker');
+  assertContains(uiJs, 'function pipelineStageIsExpanded(stage, currentStageId)', 'stage expansion helper');
+  assertContains(uiJs, 'stage.id === currentStageId || state.expandedPipelineStageIds.includes(stage.id)', 'current stage should be expanded by default');
+  assertContains(uiJs, 'if (!expanded)', 'collapsed stage branch');
+  assertContains(uiJs, "expandButton.textContent = 'Expand stage'", 'collapsed stages should expose an expand control');
+  assertContains(uiJs, "collapseButton.textContent = 'Collapse stage'", 'expanded non-current stages should expose a collapse control');
+  assertContains(uiJs, "card.className = `pipeline-card ${statusClass(statusLabel)}${expanded ? ' expanded' : ' collapsed'}${stage.id === currentStageId ? ' current' : ''}`", 'stage cards should mark collapsed/current state');
+  assertContains(uiJs, "button.textContent = stage.actionLabel", 'existing stage action remains available when expanded');
+  assertContains(uiJs, 'body.append(artifacts, next, button, actionReason)', 'expanded stage body keeps action context');
+  assertContains(uiJs, 'els.pipelineStages.append(stageCard(stage, currentStageId))', 'render should pass the current stage into each card');
+
+  for (const status of ['not started', 'current', 'blocked', 'ready', 'complete', 'warning']) {
+    assertContains(uiJs, `return '${status}'`, `stage tracker status ${status}`);
+  }
+
+  assertContains(stylesCss, '.pipeline-card.collapsed .pipeline-expand', 'collapsed tracker styles');
+  assertContains(stylesCss, '.pipeline-card-body', 'expanded tracker body styles');
+  assertContains(stylesCss, '.status-pill.current', 'current status style');
+  assertContains(stylesCss, '.status-pill.complete', 'complete status style');
 });
 
 test('production command bar and concrete blocker copy remain present', () => {


### PR DESCRIPTION
Closes #77

## Summary
- render the production pipeline as compact cards with only the current stage expanded by default
- add explicit expand/collapse controls for non-current stages
- preserve stage actions, panel navigation, job links, status summaries, and blocker context inside expanded cards
- add smoke coverage for the progressive-disclosure stage tracker

## Verification
- npm run check