### PR TITLE
PF3-04 separate active and historical production artifacts

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -436,7 +436,7 @@ Recommended order:
 1. #75 — PF3-01 Define Produce workspace view-model contract and fixtures ✅ merged (#83)
 2. #76 — PF3-02 Render sticky Production Command Bar from view-model ✅ merged (#84)
 3. #77 — PF3-03 Render compact 8-stage tracker and expand only current stage ✅ merged (#85)
-4. #78 — PF3-04 Separate active production artifacts from historical/archive artifacts — active/next
+4. #78 — PF3-04 Separate active production artifacts from historical/archive artifacts — PR open (#86), review gate pending
 5. #79 — PF3-05 Redesign Story Sources selector and source search controls
 6. #80 — PF3-06 Move action feedback and job result summaries into workflow context
 7. #81 — PF3-07 Replace ambiguous workflow labels and improve accessibility semantics

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -360,6 +360,41 @@ button:disabled {
   text-transform: uppercase;
 }
 
+.artifact-scope-panel {
+  background: #eef6f2;
+  border: 1px solid #9ac8aa;
+  border-radius: 6px;
+  display: grid;
+  gap: 0.2rem;
+  grid-column: 1 / -1;
+  padding: 0.65rem 0.75rem;
+}
+
+.artifact-scope-panel.warning {
+  background: #fff7ed;
+  border-color: #e2c391;
+}
+
+.artifact-scope-panel span {
+  color: #687486;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.artifact-scope-panel strong {
+  color: #1f2937;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.artifact-scope-panel p {
+  color: #586575;
+  font-size: 0.86rem;
+  margin: 0;
+}
+
 .workflow-context-item strong {
   color: #20242c;
   font-size: 0.95rem;
@@ -1141,6 +1176,35 @@ textarea {
   gap: 0.4rem;
   grid-template-columns: minmax(0, 1fr) auto;
   padding: 0.65rem 0.75rem;
+}
+
+.active-artifact {
+  border-color: #9ac8aa;
+}
+
+.archive-artifact {
+  border-color: #d8dde5;
+  opacity: 0.84;
+}
+
+.scope-pill {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  margin-left: 0.45rem;
+  padding: 0.12rem 0.4rem;
+  vertical-align: middle;
+}
+
+.scope-pill.active {
+  background: #e8f6ef;
+  color: #1d6b43;
+}
+
+.scope-pill.archive {
+  background: #f1f5f9;
+  color: #586575;
 }
 
 .production-row strong,

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -395,6 +395,17 @@ button:disabled {
   margin: 0;
 }
 
+.artifact-scope-warning-list {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.artifact-scope-warning-list p {
+  background: rgba(255, 255, 255, 0.54);
+  border-radius: 4px;
+  padding: 0.3rem 0.4rem;
+}
+
 .workflow-context-item strong {
   color: #20242c;
   font-size: 0.95rem;

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -361,8 +361,9 @@ function episodeMatchesPath(episode, activeBrief, activeScript) {
   return true;
 }
 
-function activePathWarning(label, title) {
-  return `${label}${title ? ` "${title}"` : ''} is not part of current production for the selected candidate story.`;
+function activePathWarning(label, title, hasCandidateSelection) {
+  const pathDescription = hasCandidateSelection ? 'the selected candidate story' : 'the current production path';
+  return `${label}${title ? ` "${title}"` : ''} is not part of current production for ${pathDescription}.`;
 }
 
 function productionWarnings(episode, assets, jobs) {
@@ -785,28 +786,32 @@ export function deriveProductionViewModel(input = {}) {
     episodeId: activeEpisode?.id || null,
     assetIds: activeArtifactAssetIds,
   };
+  const hasCandidateSelection = selectedCandidateIds.size > 0;
+  const inactiveArtifactReason = hasCandidateSelection
+    ? 'Not part of current production for the selected candidate story.'
+    : 'Not part of current production path.';
   const inactiveSelectedArtifacts = [
     selectedBrief && selectedBrief.id !== activeIds.briefId ? {
       stage: 'brief',
-      message: activePathWarning('Research brief', selectedBrief.title),
-      source: markArtifact(summarizeBrief(selectedBrief), 'archive', 'Not part of current production for the selected candidate story.'),
+      message: activePathWarning('Research brief', selectedBrief.title, hasCandidateSelection),
+      source: markArtifact(summarizeBrief(selectedBrief), 'archive', inactiveArtifactReason),
     } : null,
     selectedScript && selectedScript.id !== activeIds.scriptId ? {
       stage: 'script',
-      message: activePathWarning('Script draft', selectedScript.title),
-      source: markArtifact(summarizeScript(selectedScript, selectedRevision), 'archive', 'Not part of current production for the selected candidate story.'),
+      message: activePathWarning('Script draft', selectedScript.title, hasCandidateSelection),
+      source: markArtifact(summarizeScript(selectedScript, selectedRevision), 'archive', inactiveArtifactReason),
     } : null,
     selectedEpisode && selectedEpisode.id !== activeIds.episodeId ? {
       stage: 'publishing',
-      message: activePathWarning('Episode', selectedEpisode.title || selectedEpisode.slug),
-      source: markArtifact(summarizeEpisode(selectedEpisode), 'archive', 'Not part of current production for the selected candidate story.'),
+      message: activePathWarning('Episode', selectedEpisode.title || selectedEpisode.slug, hasCandidateSelection),
+      source: markArtifact(summarizeEpisode(selectedEpisode), 'archive', inactiveArtifactReason),
     } : null,
     ...pathAssets
       .filter((asset) => !activeIds.assetIds.has(asset.id) && isAudioCoverAsset(asset))
       .map((asset) => ({
         stage: 'production',
-        message: activePathWarning('Production asset', asset.label || asset.type),
-        source: markArtifact(summarizeAsset(asset), 'archive', 'Not part of current production for the selected candidate story.'),
+        message: activePathWarning('Production asset', asset.label || asset.type, hasCandidateSelection),
+        source: markArtifact(summarizeAsset(asset), 'archive', inactiveArtifactReason),
       })),
   ].filter(Boolean);
   const activeArtifacts = {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -339,7 +339,7 @@ function packetMatchesCandidateSelection(packet, selectedCandidateIds) {
   }
 
   const packetIds = new Set(packetCandidateIds(packet));
-  return packetIds.size === 0 || [...selectedCandidateIds].every((id) => packetIds.has(id));
+  return packetIds.size > 0 && [...selectedCandidateIds].every((id) => packetIds.has(id));
 }
 
 function episodeMatchesPath(episode, activeBrief, activeScript) {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -731,6 +731,7 @@ export function deriveProductionViewModel(input = {}) {
   const selectedShow = shows.find((show) => show.slug === input.selectedShowSlug) || null;
   const selectedSource = profiles.find((profile) => profile.id === input.selectedProfileId) || null;
   const selectedCandidateIds = new Set(asArray(input.selectedCandidateIds));
+  const hasCandidateSelection = selectedCandidateIds.size > 0;
   const selectedCandidates = candidates.filter((candidate) => selectedCandidateIds.has(candidate.id));
   const selectedScript = input.selectedScript || scripts.find((script) => script.id === input.selectedScriptId) || null;
   const selectedScriptBrief = selectedScript?.researchPacketId ? packets.find((packet) => packet.id === selectedScript.researchPacketId) : null;
@@ -746,7 +747,9 @@ export function deriveProductionViewModel(input = {}) {
   const activeRevision = activeScript && selectedRevision?.scriptId === activeScript.id ? selectedRevision : null;
   const selectedEpisode = production.episode || episodes.find((episode) => episode.id === input.selectedEpisodeId) || null;
   const latestMatchingEpisode = activeBrief ? latest(episodes.filter((episode) => episodeMatchesPath(episode, activeBrief, activeScript))) : null;
-  const activeEpisode = episodeMatchesPath(selectedEpisode, activeBrief, activeScript) ? selectedEpisode : latestMatchingEpisode;
+  const activeEpisode = !activeBrief && hasCandidateSelection
+    ? null
+    : (episodeMatchesPath(selectedEpisode, activeBrief, activeScript) ? selectedEpisode : latestMatchingEpisode);
   const selectedAssetIds = new Set(asArray(input.selectedAssetIds));
   const selectedAssets = productionAssets.filter((asset) => selectedAssetIds.has(asset.id));
   const pathAssets = selectedAssetIds.size > 0 && selectedAssets.length > 0
@@ -786,7 +789,6 @@ export function deriveProductionViewModel(input = {}) {
     episodeId: activeEpisode?.id || null,
     assetIds: activeArtifactAssetIds,
   };
-  const hasCandidateSelection = selectedCandidateIds.size > 0;
   const inactiveArtifactReason = hasCandidateSelection
     ? 'Not part of current production for the selected candidate story.'
     : 'Not part of current production path.';

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -339,7 +339,7 @@ function packetMatchesCandidateSelection(packet, selectedCandidateIds) {
   }
 
   const packetIds = new Set(packetCandidateIds(packet));
-  return packetIds.size > 0 && [...selectedCandidateIds].every((id) => packetIds.has(id));
+  return packetIds.size === selectedCandidateIds.size && [...selectedCandidateIds].every((id) => packetIds.has(id));
 }
 
 function episodeMatchesPath(episode, activeBrief, activeScript) {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -751,7 +751,7 @@ export function deriveProductionViewModel(input = {}) {
   const pathAssets = selectedAssetIds.size > 0 && selectedAssets.length > 0
     ? selectedAssets
     : productionAssets;
-  const activeAssets = activeEpisode ? pathAssets.filter((asset) => asset.episodeId === activeEpisode.id || !asset.episodeId) : [];
+  const activeAssets = activeEpisode ? pathAssets.filter((asset) => asset.episodeId === activeEpisode.id) : [];
   const feed = selectedFeed(feeds, activeEpisode, selectedShow);
   const sourceQueries = selectedSource ? queries.filter((query) => !query.sourceProfileId || query.sourceProfileId === selectedSource.id) : [];
   const context = {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -166,6 +166,19 @@ function summarizeBrief(packet) {
   });
 }
 
+function markArtifact(summary, state, reason = '') {
+  if (!summary) {
+    return null;
+  }
+
+  return compactObject({
+    ...summary,
+    artifactState: state,
+    stateLabel: state === 'active' ? 'Active/current' : 'History/archive',
+    stateWarning: reason || undefined,
+  });
+}
+
 function summarizeScript(script, revision = null) {
   if (!script) {
     return null;
@@ -304,6 +317,52 @@ function summarizeJob(job) {
 
 function unresolvedResearchWarnings(packet) {
   return asArray(packet?.warnings).filter((warning) => !warning.override);
+}
+
+function packetCandidateIds(packet) {
+  const content = asObject(packet?.content);
+  return [
+    ...asArray(content.candidateIds),
+    ...asArray(content.selectedCandidateIds),
+    content.candidateId,
+    packet?.storyCandidateId,
+  ].filter((id) => typeof id === 'string' && id.trim());
+}
+
+function packetMatchesCandidateSelection(packet, selectedCandidateIds) {
+  if (!packet) {
+    return false;
+  }
+
+  if (selectedCandidateIds.size === 0) {
+    return true;
+  }
+
+  const packetIds = new Set(packetCandidateIds(packet));
+  return packetIds.size === 0 || [...selectedCandidateIds].every((id) => packetIds.has(id));
+}
+
+function episodeMatchesPath(episode, activeBrief, activeScript) {
+  if (!episode) {
+    return false;
+  }
+
+  if (activeScript) {
+    const scriptId = episode.metadata?.scriptId;
+    if (scriptId && scriptId !== activeScript.id) {
+      return false;
+    }
+  }
+
+  if (activeBrief) {
+    return episode.researchPacketId === activeBrief.id || episode.metadata?.researchPacketId === activeBrief.id;
+  }
+
+  return true;
+}
+
+function activePathWarning(label, title) {
+  return `${label}${title ? ` "${title}"` : ''} is not part of current production for the selected candidate story.`;
 }
 
 function productionWarnings(episode, assets, jobs) {
@@ -586,7 +645,16 @@ function checklistStage(key) {
   }[key] || 'publishing';
 }
 
-function deriveWarningsAndBlockers({ activeBrief, activeRevision, activeEpisode, assets, jobs, checklist, selectedCandidates }) {
+function deriveWarningsAndBlockers({
+  activeBrief,
+  activeRevision,
+  activeEpisode,
+  assets,
+  jobs,
+  checklist,
+  selectedCandidates,
+  inactiveSelectedArtifacts = [],
+}) {
   const warnings = [];
   const blockers = [];
   const integrity = integrityReviewState(activeRevision);
@@ -623,16 +691,25 @@ function deriveWarningsAndBlockers({ activeBrief, activeRevision, activeEpisode,
     }
   }
 
+  for (const item of inactiveSelectedArtifacts) {
+    warnings.push(warningItem(
+      item.stage || 'production',
+      item.message || 'Loaded artifact is not part of current production.',
+      item.source || null,
+      'warning',
+    ));
+  }
+
   return { warnings, blockers };
 }
 
 function deriveHistoricalArtifacts({ activeIds, packets, scripts, revisions, assets, episodes }) {
   return {
-    briefs: newest(packets).filter((packet) => packet.id !== activeIds.briefId).map(summarizeBrief),
-    scripts: newest(scripts).filter((script) => script.id !== activeIds.scriptId).map((script) => summarizeScript(script)),
-    reviews: newest(revisions).filter((revision) => revision.id !== activeIds.revisionId).map(summarizeReview),
-    audioCover: newest(assets).filter((asset) => !activeIds.assetIds.has(asset.id) && isAudioCoverAsset(asset)).map(summarizeAsset),
-    publishing: newest(episodes).filter((episode) => episode.id !== activeIds.episodeId).map(summarizeEpisode),
+    briefs: newest(packets).filter((packet) => packet.id !== activeIds.briefId).map((packet) => markArtifact(summarizeBrief(packet), 'archive')),
+    scripts: newest(scripts).filter((script) => script.id !== activeIds.scriptId).map((script) => markArtifact(summarizeScript(script), 'archive')),
+    reviews: newest(revisions).filter((revision) => revision.id !== activeIds.revisionId).map((revision) => markArtifact(summarizeReview(revision), 'archive')),
+    audioCover: newest(assets).filter((asset) => !activeIds.assetIds.has(asset.id) && isAudioCoverAsset(asset)).map((asset) => markArtifact(summarizeAsset(asset), 'archive')),
+    publishing: newest(episodes).filter((episode) => episode.id !== activeIds.episodeId).map((episode) => markArtifact(summarizeEpisode(episode), 'archive')),
   };
 }
 
@@ -654,17 +731,27 @@ export function deriveProductionViewModel(input = {}) {
   const selectedSource = profiles.find((profile) => profile.id === input.selectedProfileId) || null;
   const selectedCandidateIds = new Set(asArray(input.selectedCandidateIds));
   const selectedCandidates = candidates.filter((candidate) => selectedCandidateIds.has(candidate.id));
-  const activeScript = input.selectedScript || scripts.find((script) => script.id === input.selectedScriptId) || null;
-  const activeBrief = (activeScript?.researchPacketId ? packets.find((packet) => packet.id === activeScript.researchPacketId) : null)
-    || packets.find((packet) => packet.id === input.selectedResearchPacketId)
-    || null;
-  const activeRevision = input.selectedRevision || revisions[0] || null;
-  const activeEpisode = production.episode || episodes.find((episode) => episode.id === input.selectedEpisodeId) || null;
+  const selectedScript = input.selectedScript || scripts.find((script) => script.id === input.selectedScriptId) || null;
+  const selectedScriptBrief = selectedScript?.researchPacketId ? packets.find((packet) => packet.id === selectedScript.researchPacketId) : null;
+  const selectedBrief = packets.find((packet) => packet.id === input.selectedResearchPacketId) || null;
+  const latestMatchingBrief = latest(packets.filter((packet) => packetMatchesCandidateSelection(packet, selectedCandidateIds)));
+  const pathBrief = [selectedScriptBrief, selectedBrief, latestMatchingBrief]
+    .find((packet) => packetMatchesCandidateSelection(packet, selectedCandidateIds));
+  const activeBrief = pathBrief || null;
+  const selectedScriptMatchesBrief = Boolean(selectedScript && activeBrief && selectedScript.researchPacketId === activeBrief.id);
+  const latestMatchingScript = activeBrief ? latest(scripts.filter((script) => script.researchPacketId === activeBrief.id)) : null;
+  const activeScript = selectedScriptMatchesBrief ? selectedScript : latestMatchingScript;
+  const selectedRevision = input.selectedRevision || revisions[0] || null;
+  const activeRevision = activeScript && selectedRevision?.scriptId === activeScript.id ? selectedRevision : null;
+  const selectedEpisode = production.episode || episodes.find((episode) => episode.id === input.selectedEpisodeId) || null;
+  const latestMatchingEpisode = activeBrief ? latest(episodes.filter((episode) => episodeMatchesPath(episode, activeBrief, activeScript))) : null;
+  const activeEpisode = episodeMatchesPath(selectedEpisode, activeBrief, activeScript) ? selectedEpisode : latestMatchingEpisode;
   const selectedAssetIds = new Set(asArray(input.selectedAssetIds));
   const selectedAssets = productionAssets.filter((asset) => selectedAssetIds.has(asset.id));
-  const activeAssets = selectedAssetIds.size > 0 && selectedAssets.length > 0
+  const pathAssets = selectedAssetIds.size > 0 && selectedAssets.length > 0
     ? selectedAssets
     : productionAssets;
+  const activeAssets = activeEpisode ? pathAssets.filter((asset) => asset.episodeId === activeEpisode.id || !asset.episodeId) : [];
   const feed = selectedFeed(feeds, activeEpisode, selectedShow);
   const sourceQueries = selectedSource ? queries.filter((query) => !query.sourceProfileId || query.sourceProfileId === selectedSource.id) : [];
   const context = {
@@ -698,19 +785,43 @@ export function deriveProductionViewModel(input = {}) {
     episodeId: activeEpisode?.id || null,
     assetIds: activeArtifactAssetIds,
   };
+  const inactiveSelectedArtifacts = [
+    selectedBrief && selectedBrief.id !== activeIds.briefId ? {
+      stage: 'brief',
+      message: activePathWarning('Research brief', selectedBrief.title),
+      source: markArtifact(summarizeBrief(selectedBrief), 'archive', 'Not part of current production for the selected candidate story.'),
+    } : null,
+    selectedScript && selectedScript.id !== activeIds.scriptId ? {
+      stage: 'script',
+      message: activePathWarning('Script draft', selectedScript.title),
+      source: markArtifact(summarizeScript(selectedScript, selectedRevision), 'archive', 'Not part of current production for the selected candidate story.'),
+    } : null,
+    selectedEpisode && selectedEpisode.id !== activeIds.episodeId ? {
+      stage: 'publishing',
+      message: activePathWarning('Episode', selectedEpisode.title || selectedEpisode.slug),
+      source: markArtifact(summarizeEpisode(selectedEpisode), 'archive', 'Not part of current production for the selected candidate story.'),
+    } : null,
+    ...pathAssets
+      .filter((asset) => !activeIds.assetIds.has(asset.id) && isAudioCoverAsset(asset))
+      .map((asset) => ({
+        stage: 'production',
+        message: activePathWarning('Production asset', asset.label || asset.type),
+        source: markArtifact(summarizeAsset(asset), 'archive', 'Not part of current production for the selected candidate story.'),
+      })),
+  ].filter(Boolean);
   const activeArtifacts = {
-    brief: summarizeBrief(activeBrief),
-    script: summarizeScript(activeScript, activeRevision),
-    review: summarizeReview(activeRevision),
-    audioCover: activeArtifactAudioCover,
-    publishing: summarizeEpisode(activeEpisode),
+    brief: markArtifact(summarizeBrief(activeBrief), 'active'),
+    script: markArtifact(summarizeScript(activeScript, activeRevision), 'active'),
+    review: markArtifact(summarizeReview(activeRevision), 'active'),
+    audioCover: markArtifact(activeArtifactAudioCover, 'active'),
+    publishing: markArtifact(summarizeEpisode(activeEpisode), 'active'),
   };
   const latestArtifacts = {
-    brief: summarizeBrief(latest(packets)),
-    script: summarizeScript(latest(scripts)),
-    review: summarizeReview(latest(revisions)),
-    audioCover: summarizeAudioCover(productionAssets),
-    publishing: summarizeEpisode(latest(episodes)),
+    brief: markArtifact(summarizeBrief(latest(packets)), 'archive'),
+    script: markArtifact(summarizeScript(latest(scripts)), 'archive'),
+    review: markArtifact(summarizeReview(latest(revisions)), 'archive'),
+    audioCover: markArtifact(summarizeAudioCover(productionAssets), 'archive'),
+    publishing: markArtifact(summarizeEpisode(latest(episodes)), 'archive'),
   };
   const historicalArtifacts = deriveHistoricalArtifacts({
     activeIds,
@@ -728,6 +839,7 @@ export function deriveProductionViewModel(input = {}) {
     jobs,
     checklist,
     selectedCandidates,
+    inactiveSelectedArtifacts,
   });
 
   return {
@@ -744,6 +856,7 @@ export function deriveProductionViewModel(input = {}) {
     activeArtifacts,
     latestArtifacts,
     historicalArtifacts,
+    artifactScopeWarnings: inactiveSelectedArtifacts,
     primaryNextAction,
     secondaryActions,
     navigationActions,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1878,11 +1878,22 @@ function renderPipeline() {
   scopeLabel.textContent = scopeWarnings.length > 0 ? 'Current production warning' : 'Artifact scope';
   const scopeText = document.createElement('strong');
   scopeText.textContent = scopeWarnings.length > 0
-    ? scopeWarnings[0].message
+    ? `${scopeWarnings.length} artifact${scopeWarnings.length === 1 ? '' : 's'} not part of current production.`
     : archiveCount > 0 ? `${archiveCount} history/archive artifact${archiveCount === 1 ? '' : 's'} kept out of active state.` : 'Only active/current artifacts are shown as production state.';
   const scopeDetail = document.createElement('p');
   scopeDetail.textContent = 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.';
-  scopePanel.append(scopeLabel, scopeText, scopeDetail);
+  scopePanel.append(scopeLabel, scopeText);
+  if (scopeWarnings.length > 0) {
+    const warningList = document.createElement('div');
+    warningList.className = 'artifact-scope-warning-list';
+    scopeWarnings.forEach((warning) => {
+      const warningItem = document.createElement('p');
+      warningItem.textContent = warning.message;
+      warningList.append(warningItem);
+    });
+    scopePanel.append(warningList);
+  }
+  scopePanel.append(scopeDetail);
   els.workflowContext.append(scopePanel);
 
   const stages = buildPipelineStages();
@@ -3337,10 +3348,12 @@ function renderScripts() {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = `profile-button ${scope.className}-artifact${script.id === state.selectedScriptId ? ' active' : ''}`;
-    button.innerHTML = `<strong></strong><span></span>`;
-    button.querySelector('strong').textContent = script.title;
-    appendScopePill(button.querySelector('strong'), scope);
-    button.querySelector('span').textContent = `${scope.label} | ${script.format} | ${script.status} | updated ${new Date(script.updatedAt).toLocaleString()}`;
+    const title = document.createElement('strong');
+    title.textContent = script.title;
+    appendScopePill(title, scope);
+    const meta = document.createElement('span');
+    meta.textContent = `${scope.label} | ${script.format} | ${script.status} | updated ${new Date(script.updatedAt).toLocaleString()}`;
+    button.append(title, meta);
     button.addEventListener('click', async () => {
       await loadScript(script.id);
       savePipelineState();

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -3050,17 +3050,56 @@ function latestJob(type) {
   return state.production.jobs.find((job) => job.type === type);
 }
 
-function latestAsset(type) {
-  return state.production.assets.find((asset) => asset.type === type);
+function renderProductionArchiveAssets(archivedAssets) {
+  if (archivedAssets.length === 0) {
+    return;
+  }
+
+  const heading = document.createElement('div');
+  heading.className = 'production-row archive-artifact';
+  const headingTitle = document.createElement('strong');
+  headingTitle.textContent = 'History/archive production assets';
+  const headingMeta = document.createElement('span');
+  headingMeta.textContent = 'Kept for audit only; not used by production or publishing actions.';
+  heading.append(headingTitle, headingMeta);
+  els.productionAssets.append(heading);
+
+  for (const asset of archivedAssets) {
+    const row = document.createElement('div');
+    row.className = 'production-row archive-artifact';
+    const title = document.createElement('strong');
+    title.textContent = `History/archive ${asset.type || asset.productionKind || 'asset'}`;
+    const meta = document.createElement('span');
+    meta.textContent = asset.url || asset.mimeType || asset.status || 'Asset recorded; local path hidden';
+    row.append(title, meta);
+    els.productionAssets.append(row);
+  }
 }
 
 function renderProduction() {
+  const viewModel = currentProductionViewModel();
+  const archivedAssets = asArray(viewModel.historicalArtifacts?.audioCover);
   const script = activeSelectedScript();
   const revision = activeSelectedRevision();
   const hasScript = Boolean(script && revision);
-  els.productionPanel.hidden = !hasScript;
+  els.productionPanel.hidden = !hasScript && archivedAssets.length === 0;
+
+  els.productionJobs.innerHTML = '';
+  els.productionAssets.innerHTML = '';
 
   if (!hasScript) {
+    els.generateAudioPreview.disabled = true;
+    els.generateCoverArt.disabled = true;
+    els.productionMeta.textContent = archivedAssets.length > 0
+      ? 'No active/current script is selected. History/archive production assets below are retained for audit only.'
+      : 'No active/current script is selected for production.';
+    if (archivedAssets.length > 0) {
+      const empty = document.createElement('div');
+      empty.className = 'empty';
+      empty.textContent = 'No active/current production jobs. Generate or select an active script before creating new audio or cover assets.';
+      els.productionJobs.append(empty);
+      renderProductionArchiveAssets(archivedAssets);
+    }
     return;
   }
 
@@ -3114,27 +3153,28 @@ function renderProduction() {
   }
 
   els.productionAssets.innerHTML = '';
-  const assets = [latestAsset('audio-preview'), latestAsset('cover-art')].filter(Boolean);
+  const assets = selectedAssets();
   if (assets.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
     empty.textContent = readyForProduction
-      ? 'No audio or cover assets recorded yet. Next action: create missing preview audio and cover art.'
-      : 'No audio or cover assets recorded yet. Next action: complete script approval and integrity review before production.';
+      ? 'No active/current audio or cover assets recorded yet. Next action: create missing preview audio and cover art.'
+      : 'No active/current audio or cover assets recorded yet. Next action: complete script approval and integrity review before production.';
     els.productionAssets.append(empty);
-    return;
+  } else {
+    for (const asset of assets) {
+      const row = document.createElement('div');
+      row.className = 'production-row active-artifact';
+      const title = document.createElement('strong');
+      title.textContent = `Active/current ${asset.label || asset.type}`;
+      const meta = document.createElement('span');
+      meta.textContent = asset.publicUrl || asset.objectKey || asset.mimeType || 'Asset recorded; local path hidden';
+      row.append(title, meta);
+      els.productionAssets.append(row);
+    }
   }
 
-  for (const asset of assets) {
-    const row = document.createElement('div');
-    row.className = 'production-row active-artifact';
-    const title = document.createElement('strong');
-    title.textContent = `Active/current ${asset.label || asset.type}`;
-    const meta = document.createElement('span');
-    meta.textContent = asset.publicUrl || asset.objectKey || asset.mimeType || 'Asset recorded; local path hidden';
-    row.append(title, meta);
-    els.productionAssets.append(row);
-  }
+  renderProductionArchiveAssets(archivedAssets);
 }
 
 function renderJobRuns() {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -408,19 +408,81 @@ function selectedCandidateAnalysis() {
 }
 
 function selectedResearchPacket() {
-  return state.researchPackets.find((packet) => packet.id === state.selectedResearchPacketId);
+  const activeId = currentProductionViewModel().activeArtifacts?.brief?.id;
+  if (activeId) {
+    return state.researchPackets.find((packet) => packet.id === activeId);
+  }
+  return state.selectedCandidateIds.length > 0 ? undefined : state.researchPackets.find((packet) => packet.id === state.selectedResearchPacketId);
+}
+
+function activeSelectedScript() {
+  const activeId = currentProductionViewModel().activeArtifacts?.script?.id;
+  return activeId && state.selectedScript?.id === activeId ? state.selectedScript : null;
+}
+
+function activeSelectedRevision() {
+  const activeId = currentProductionViewModel().activeArtifacts?.review?.id;
+  return activeId && state.selectedRevision?.id === activeId ? state.selectedRevision : null;
 }
 
 function selectedEpisode() {
-  return state.production.episode
+  const activeId = currentProductionViewModel().activeArtifacts?.publishing?.id;
+  if (activeId) {
+    return (state.production.episode?.id === activeId ? state.production.episode : null)
+      || state.episodes.find((episode) => episode.id === activeId)
+      || null;
+  }
+  return state.selectedCandidateIds.length > 0 ? null : state.production.episode
     || state.episodes.find((episode) => episode.id === state.selectedEpisodeId)
     || null;
 }
 
 function selectedAssets() {
+  const activeAudioCover = currentProductionViewModel().activeArtifacts?.audioCover;
+  const activeAssetIds = new Set([
+    activeAudioCover?.audio?.id,
+    activeAudioCover?.cover?.id,
+  ].filter(Boolean));
+  if (activeAssetIds.size > 0) {
+    return state.production.assets.filter((asset) => activeAssetIds.has(asset.id));
+  }
+  if (state.selectedCandidateIds.length > 0 && !currentProductionViewModel().activeArtifacts?.publishing) {
+    return [];
+  }
   const selected = new Set(state.selectedAssetIds);
   const assets = state.production.assets.filter((asset) => selected.has(asset.id));
   return assets.length > 0 ? assets : state.production.assets;
+}
+
+function currentProductionViewModel() {
+  return state.productionViewModel || deriveProductionViewModel(state);
+}
+
+function artifactScope(kind, id) {
+  const viewModel = currentProductionViewModel();
+  const active = viewModel.activeArtifacts?.[kind];
+  if (id && active?.id === id) {
+    return {
+      label: active.stateLabel || 'Active/current',
+      className: 'active',
+      warning: '',
+    };
+  }
+
+  const historyKey = kind === 'brief' ? 'briefs' : kind === 'script' ? 'scripts' : kind === 'publishing' ? 'publishing' : kind;
+  const archived = asArray(viewModel.historicalArtifacts?.[historyKey]).find((artifact) => artifact.id === id);
+  return {
+    label: archived?.stateLabel || 'History/archive',
+    className: 'archive',
+    warning: archived?.stateWarning || 'Not part of current production.',
+  };
+}
+
+function appendScopePill(container, scope) {
+  const pill = document.createElement('span');
+  pill.className = `scope-pill ${scope.className}`;
+  pill.textContent = scope.label;
+  container.append(pill);
 }
 
 function researchReadinessStatus(packet) {
@@ -581,8 +643,8 @@ function renderCoverageSummary(summary) {
 
 function publishChecklistState() {
   const packet = selectedResearchPacket();
-  const script = state.selectedScript;
-  const revision = state.selectedRevision;
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
   const episode = selectedEpisode();
   const assets = selectedAssets();
   const feed = selectedFeed();
@@ -1331,7 +1393,7 @@ function stageCard(stage, currentStageId = '') {
   artifacts.className = 'pipeline-artifacts';
   const artifactLabel = document.createElement('span');
   artifactLabel.className = 'pipeline-label';
-  artifactLabel.textContent = 'Latest artifact';
+  artifactLabel.textContent = 'Active/current artifact';
   const artifactText = document.createElement('p');
   artifactText.textContent = stage.artifact;
   artifacts.append(artifactLabel, artifactText);
@@ -1418,19 +1480,21 @@ function latestCandidateText() {
 
 function latestResearchText(packet) {
   if (!packet) {
-    return state.researchPackets[0]?.title || 'No research brief selected yet.';
+    return 'No active/current research brief selected yet.';
   }
 
   const warningCount = packet.warnings?.length || 0;
-  return `${packet.title} (${packet.status}, ${warningCount} warning${warningCount === 1 ? '' : 's'})`;
+  return `Active/current: ${packet.title} (${packet.status}, ${warningCount} warning${warningCount === 1 ? '' : 's'})`;
 }
 
 function latestScriptText() {
-  if (!state.selectedScript || !state.selectedRevision) {
-    return state.scripts[0]?.title || 'No script draft selected yet.';
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
+    return 'No active/current script draft selected yet.';
   }
 
-  return `${state.selectedScript.title} (revision ${state.selectedRevision.version}, ${state.selectedScript.status})`;
+  return `Active/current: ${script.title} (revision ${revision.version}, ${script.status})`;
 }
 
 function latestProductionText() {
@@ -1440,10 +1504,10 @@ function latestProductionText() {
   const art = assets.find((asset) => asset.type === 'cover-art');
 
   if (!episode) {
-    return 'No episode or production assets selected yet.';
+    return 'No active/current episode or production assets selected yet.';
   }
 
-  return `${episode.title} (${episode.status}) | audio ${audio ? 'ready' : 'missing'} | cover ${art ? 'ready' : 'missing'}`;
+  return `Active/current: ${episode.title} (${episode.status}) | audio ${audio ? 'ready' : 'missing'} | cover ${art ? 'ready' : 'missing'}`;
 }
 
 function workflowStoryContext() {
@@ -1469,11 +1533,13 @@ function workflowRevisionContext() {
   const episode = selectedEpisode();
 
   if (episode) {
-    return `${episode.title} (${episode.status})`;
+    return `Active/current: ${episode.title} (${episode.status})`;
   }
 
-  if (state.selectedScript && state.selectedRevision) {
-    return `${state.selectedScript.title} | revision ${state.selectedRevision.version}`;
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (script && revision) {
+    return `Active/current: ${script.title} | revision ${revision.version}`;
   }
 
   const packet = selectedResearchPacket();
@@ -1490,14 +1556,16 @@ function buildPipelineStages() {
   const candidates = selectedCandidates();
   const candidateAnalysis = selectedCandidateAnalysis();
   const packet = selectedResearchPacket();
-  const latestPacket = packet || state.researchPackets[0];
+  const latestPacket = packet;
   const episode = selectedEpisode();
   const assets = selectedAssets();
   const audioAsset = assets.find((asset) => asset.type === 'audio-preview' || asset.type === 'audio-final');
   const coverAsset = assets.find((asset) => asset.type === 'cover-art');
-  const scriptApproved = state.selectedScript?.status === 'approved-for-audio'
-    && state.selectedScript?.approvedRevisionId === state.selectedRevision?.id;
-  const integrity = integrityReviewState(state.selectedRevision);
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  const scriptApproved = script?.status === 'approved-for-audio'
+    && script?.approvedRevisionId === revision?.id;
+  const integrity = integrityReviewState(revision);
   const scriptReadyForProduction = Boolean(scriptApproved && !integrity.blocking);
   const productionRunning = state.production.jobs.some((job) => !isTerminalJob(job));
   const discoverRunning = isActionRunning('discover');
@@ -1522,10 +1590,10 @@ function buildPipelineStages() {
       ? ['Select at least one candidate story before building a research brief.']
       : [];
   const productionBlockers = [
-    !state.selectedScript || !state.selectedRevision ? 'Generate or select a script draft.' : '',
-    state.selectedRevision && integrity.status === 'missing' ? 'Run the integrity reviewer before production.' : '',
-    state.selectedRevision && integrity.status === 'fail' ? 'Resolve the failed integrity review or record an explicit override reason.' : '',
-    state.selectedScript && state.selectedRevision && !scriptApproved ? 'Approve the selected script revision for audio.' : '',
+    !script || !revision ? 'Generate or select a script draft.' : '',
+    revision && integrity.status === 'missing' ? 'Run the integrity reviewer before production.' : '',
+    revision && integrity.status === 'fail' ? 'Resolve the failed integrity review or record an explicit override reason.' : '',
+    script && revision && !scriptApproved ? 'Approve the selected script revision for audio.' : '',
   ].filter(Boolean);
 
   return [
@@ -1653,27 +1721,27 @@ function buildPipelineStages() {
       id: 'script',
       number: 5,
       title: 'Generate script',
-      status: scriptRunning ? 'running' : state.selectedScript ? 'done' : packet && !packetBlocked ? 'ready' : 'blocked',
+      status: scriptRunning ? 'running' : script ? 'done' : packet && !packetBlocked ? 'ready' : 'blocked',
       artifact: latestScriptText(),
-      next: state.selectedScript
+      next: script
         ? 'Review the draft and continue to integrity review before production.'
         : packet && !packetBlocked ? 'Generate an episode draft from the selected research brief.' : 'Select a ready research brief first.',
       actionReason: scriptRunning
         ? 'A script draft is already being generated; wait for the task run to finish or inspect progress.'
-        : state.selectedScript
+        : script
           ? 'Script selected; review it, run integrity review, and approve a revision before audio.'
           : packet && !packetBlocked
             ? 'Ready: generate a script from the selected research brief.'
             : packetBlocked
               ? 'Blocked: resolve or override research warnings before drafting.'
               : 'Blocked: build or select an evidence brief before generating a script.',
-      blockers: !state.selectedScript && (!packet || packetBlocked)
+      blockers: !script && (!packet || packetBlocked)
         ? [packetBlocked ? 'Resolve or override research warnings before drafting.' : 'Build or select an evidence brief.']
         : [],
-      actionLabel: state.selectedScript ? 'Review Draft' : 'Generate Script Draft',
-      action: state.selectedScript ? focusScriptEditor : generateScriptFromSelectedResearch,
-      disabled: scriptRunning || (!state.selectedScript && (!packet || packetBlocked)),
-      active: Boolean(state.selectedScript),
+      actionLabel: script ? 'Review Draft' : 'Generate Script Draft',
+      action: script ? focusScriptEditor : generateScriptFromSelectedResearch,
+      disabled: scriptRunning || (!script && (!packet || packetBlocked)),
+      active: Boolean(script),
       targetId: 'scriptPanel',
       jobTypes: ['script.generate'],
     },
@@ -1681,36 +1749,36 @@ function buildPipelineStages() {
       id: 'review',
       number: 6,
       title: 'Integrity review',
-      status: integrityRunning || approvalsRunning ? 'running' : scriptReadyForProduction ? 'done' : state.selectedScript && state.selectedRevision ? 'ready' : 'blocked',
-      artifact: state.selectedRevision
+      status: integrityRunning || approvalsRunning ? 'running' : scriptReadyForProduction ? 'done' : script && revision ? 'ready' : 'blocked',
+      artifact: revision
         ? `Integrity review ${integrityReviewLabel(integrity.status)}${scriptApproved ? ' | script approved for audio' : ''}`
         : 'No script revision selected yet.',
-      next: !state.selectedScript || !state.selectedRevision
+      next: !script || !revision
         ? 'Generate or select a script draft first.'
         : integrity.blocking
           ? 'Run the integrity reviewer or record an explicit override before production.'
           : scriptApproved ? 'Integrity and script approval gates are complete.' : 'Approve the reviewed script revision for audio.',
       actionReason: integrityRunning || approvalsRunning
         ? 'Review or approval is already running; wait for it to finish.'
-        : !state.selectedScript || !state.selectedRevision
+        : !script || !revision
           ? 'Blocked: generate or select a script draft before the integrity gate.'
           : integrity.blocking
             ? (integrity.status === 'fail' ? 'Blocked: resolve the failed integrity review or record an explicit override reason.' : 'Blocked: run the integrity reviewer before production.')
             : scriptApproved ? 'Integrity review and script approval are complete.' : 'Ready: approve the reviewed script revision for audio.',
-      blockers: !state.selectedScript || !state.selectedRevision
+      blockers: !script || !revision
         ? ['Generate or select a script draft.']
         : integrity.blocking
           ? [integrity.status === 'fail' ? 'Resolve the failed integrity review or record an explicit override reason.' : 'Run the integrity reviewer before production.']
           : !scriptApproved ? ['Approve the reviewed script revision for audio.'] : [],
-      actionLabel: !state.selectedScript || !state.selectedRevision
+      actionLabel: !script || !revision
         ? 'Open Scripts'
         : integrity.blocking ? 'Run Integrity Review' : scriptApproved ? 'Open Review Gates' : 'Approve Script for Audio',
-      action: !state.selectedScript || !state.selectedRevision
+      action: !script || !revision
         ? () => scrollToPanel('scriptPanel')
         : integrity.blocking ? runSelectedIntegrityReview : scriptApproved ? () => scrollToPanel('reviewPanel') : approveSelectedScript,
       disabled: integrityRunning || approvalsRunning,
-      active: Boolean(state.selectedRevision && !integrity.blocking),
-      targetId: !state.selectedScript || !state.selectedRevision ? 'scriptPanel' : 'reviewPanel',
+      active: Boolean(revision && !integrity.blocking),
+      targetId: !script || !revision ? 'scriptPanel' : 'reviewPanel',
     },
     {
       id: 'production',
@@ -1800,6 +1868,22 @@ function renderPipeline() {
     item.append(itemLabel, itemValue);
     els.workflowContext.append(item);
   }
+
+  const scopeWarnings = asArray(viewModel.artifactScopeWarnings);
+  const archiveCounts = viewModel.historicalArtifacts || {};
+  const archiveCount = Object.values(archiveCounts).reduce((total, items) => total + asArray(items).length, 0);
+  const scopePanel = document.createElement('div');
+  scopePanel.className = `artifact-scope-panel${scopeWarnings.length > 0 ? ' warning' : ''}`;
+  const scopeLabel = document.createElement('span');
+  scopeLabel.textContent = scopeWarnings.length > 0 ? 'Current production warning' : 'Artifact scope';
+  const scopeText = document.createElement('strong');
+  scopeText.textContent = scopeWarnings.length > 0
+    ? scopeWarnings[0].message
+    : archiveCount > 0 ? `${archiveCount} history/archive artifact${archiveCount === 1 ? '' : 's'} kept out of active state.` : 'Only active/current artifacts are shown as production state.';
+  const scopeDetail = document.createElement('p');
+  scopeDetail.textContent = 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.';
+  scopePanel.append(scopeLabel, scopeText, scopeDetail);
+  els.workflowContext.append(scopePanel);
 
   const stages = buildPipelineStages();
   pruneExpandedPipelineStages(stages);
@@ -2181,20 +2265,24 @@ function renderResearchBriefs() {
   }
 
   for (const packet of state.researchPackets) {
+    const scope = artifactScope('brief', packet.id);
     const row = document.createElement('article');
-    row.className = `record-row${packet.id === state.selectedResearchPacketId ? ' selected' : ''}`;
+    row.className = `record-row ${scope.className}-artifact${packet.id === state.selectedResearchPacketId ? ' selected' : ''}`;
 
     const title = document.createElement('strong');
     title.textContent = packet.title;
+    appendScopePill(title, scope);
 
     const warningCount = packet.warnings?.length || 0;
     const meta = document.createElement('span');
     meta.textContent = `${packet.status} | ${packet.citations?.length || 0} citation${packet.citations?.length === 1 ? '' : 's'} | ${warningCount} warning${warningCount === 1 ? '' : 's'}`;
 
     const summary = document.createElement('p');
-    summary.textContent = warningCount > 0
-      ? 'Review warnings before drafting or approving production.'
-      : 'Ready for script drafting when the editor is comfortable with the source mix.';
+    summary.textContent = scope.className === 'archive'
+      ? 'History/archive research brief. Not part of current production for the selected candidate story.'
+      : warningCount > 0
+        ? 'Active/current research brief. Review warnings before drafting or approving production.'
+        : 'Active/current research brief. Ready for script drafting when the editor is comfortable with the source mix.';
 
     const actions = document.createElement('div');
     actions.className = 'actions inline row-actions';
@@ -2234,18 +2322,22 @@ function renderEpisodes() {
   }
 
   for (const episode of state.episodes) {
+    const scope = artifactScope('publishing', episode.id);
     const row = document.createElement('article');
-    row.className = `record-row${episode.id === state.selectedEpisodeId ? ' selected' : ''}`;
+    row.className = `record-row ${scope.className}-artifact${episode.id === state.selectedEpisodeId ? ' selected' : ''}`;
 
     const title = document.createElement('strong');
     title.textContent = episode.episodeNumber ? `EP${episode.episodeNumber}: ${episode.title}` : episode.title;
+    appendScopePill(title, scope);
 
     const meta = document.createElement('span');
     const published = episode.publishedAt ? ` | published ${new Date(episode.publishedAt).toLocaleString()}` : '';
     meta.textContent = `${episode.status} | ${episode.slug}${published}`;
 
     const summary = document.createElement('p');
-    summary.textContent = episode.feedGuid || episode.metadata?.publicAudioUrl || episode.description || 'No publish metadata recorded.';
+    summary.textContent = scope.className === 'archive'
+      ? 'History/archive episode. Not part of current production for the selected candidate story.'
+      : episode.feedGuid || episode.metadata?.publicAudioUrl || episode.description || 'Active/current episode has no publish metadata recorded yet.';
 
     const select = document.createElement('button');
     select.type = 'button';
@@ -2953,16 +3045,18 @@ function latestAsset(type) {
 }
 
 function renderProduction() {
-  const hasScript = Boolean(state.selectedScript && state.selectedRevision);
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  const hasScript = Boolean(script && revision);
   els.productionPanel.hidden = !hasScript;
 
   if (!hasScript) {
     return;
   }
 
-  const approved = state.selectedScript.status === 'approved-for-audio'
-    && state.selectedScript.approvedRevisionId === state.selectedRevision.id;
-  const integrity = integrityReviewState();
+  const approved = script.status === 'approved-for-audio'
+    && script.approvedRevisionId === revision.id;
+  const integrity = integrityReviewState(revision);
   const readyForProduction = approved && !integrity.blocking;
   const audioJob = latestJob('audio.preview');
   const artJob = latestJob('art.generate');
@@ -3023,9 +3117,9 @@ function renderProduction() {
 
   for (const asset of assets) {
     const row = document.createElement('div');
-    row.className = 'production-row';
+    row.className = 'production-row active-artifact';
     const title = document.createElement('strong');
-    title.textContent = asset.label || asset.type;
+    title.textContent = `Active/current ${asset.label || asset.type}`;
     const meta = document.createElement('span');
     meta.textContent = asset.publicUrl || asset.objectKey || asset.mimeType || 'Asset recorded; local path hidden';
     row.append(title, meta);
@@ -3239,12 +3333,14 @@ function renderScripts() {
   }
 
   for (const script of state.scripts) {
+    const scope = artifactScope('script', script.id);
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = `profile-button${script.id === state.selectedScriptId ? ' active' : ''}`;
+    button.className = `profile-button ${scope.className}-artifact${script.id === state.selectedScriptId ? ' active' : ''}`;
     button.innerHTML = `<strong></strong><span></span>`;
     button.querySelector('strong').textContent = script.title;
-    button.querySelector('span').textContent = `${script.format} | ${script.status} | updated ${new Date(script.updatedAt).toLocaleString()}`;
+    appendScopePill(button.querySelector('strong'), scope);
+    button.querySelector('span').textContent = `${scope.label} | ${script.format} | ${script.status} | updated ${new Date(script.updatedAt).toLocaleString()}`;
     button.addEventListener('click', async () => {
       await loadScript(script.id);
       savePipelineState();
@@ -3253,12 +3349,14 @@ function renderScripts() {
     els.scriptList.append(button);
   }
 
-  els.scriptEditForm.hidden = !state.selectedScript || !state.selectedRevision;
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  els.scriptEditForm.hidden = !script || !revision;
 
-  if (state.selectedScript && state.selectedRevision) {
-    els.scriptTitle.value = state.selectedRevision.title;
-    els.scriptBody.value = state.selectedRevision.body;
-    els.approveScript.disabled = state.selectedScript.approvedRevisionId === state.selectedRevision.id;
+  if (script && revision) {
+    els.scriptTitle.value = revision.title;
+    els.scriptBody.value = revision.body;
+    els.approveScript.disabled = script.approvedRevisionId === revision.id;
   }
 
   renderScriptCoachingActions();
@@ -3268,7 +3366,7 @@ function renderScripts() {
 function renderScriptCoachingActions() {
   els.scriptCoachingActions.innerHTML = '';
 
-  if (!state.selectedScript || !state.selectedRevision) {
+  if (!activeSelectedScript() || !activeSelectedRevision()) {
     return;
   }
 
@@ -3450,8 +3548,8 @@ function renderResearchReview() {
 }
 
 function renderScriptReview() {
-  const script = state.selectedScript;
-  const revision = state.selectedRevision;
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
   els.reviewScript.innerHTML = '';
 
   if (!script || !revision) {
@@ -4018,7 +4116,7 @@ function focusManualStoryForm() {
 }
 
 function focusScriptEditor() {
-  if (state.selectedScript && state.selectedRevision) {
+  if (activeSelectedScript() && activeSelectedRevision()) {
     setActiveSurface('workflow');
     scrollToPanel('scriptPanel');
     els.scriptTitle.focus();
@@ -4177,11 +4275,13 @@ async function generateScriptFromSelectedResearch() {
 }
 
 async function createMissingProductionAssets() {
-  if (!state.selectedScript || !state.selectedRevision) {
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
     return;
   }
 
-  const integrity = integrityReviewState();
+  const integrity = integrityReviewState(revision);
   if (integrity.blocking) {
     setStatus(`Production blocked: integrity review ${integrityReviewLabel(integrity.status)}.`);
     render();
@@ -4197,7 +4297,7 @@ async function createMissingProductionAssets() {
     const hasCover = assets.some((asset) => asset.type === 'cover-art');
 
     if (!hasAudio) {
-      await api(`/scripts/${state.selectedScript.id}/production/audio-preview`, {
+      await api(`/scripts/${script.id}/production/audio-preview`, {
         method: 'POST',
         body: JSON.stringify({ actor: 'local-user' }),
       });
@@ -4207,7 +4307,7 @@ async function createMissingProductionAssets() {
     }
 
     if (!hasCover && !assets.some((asset) => asset.type === 'cover-art')) {
-      await api(`/scripts/${state.selectedScript.id}/production/cover-art`, {
+      await api(`/scripts/${script.id}/production/cover-art`, {
         method: 'POST',
         body: JSON.stringify({ actor: 'local-user' }),
       });
@@ -4990,7 +5090,9 @@ async function saveScriptRevision(event) {
 }
 
 async function runScriptCoachingAction(action) {
-  if (!state.selectedScript || !state.selectedRevision) {
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
     return;
   }
 
@@ -4998,7 +5100,7 @@ async function runScriptCoachingAction(action) {
   setStatus('Creating coached script revision...');
 
   try {
-    const body = await api(`/scripts/${state.selectedScript.id}/revisions/${state.selectedRevision.id}/coach`, {
+    const body = await api(`/scripts/${script.id}/revisions/${revision.id}/coach`, {
       method: 'POST',
       body: JSON.stringify({
         action,
@@ -5023,7 +5125,9 @@ async function runScriptCoachingAction(action) {
 }
 
 async function approveSelectedScript() {
-  if (!state.selectedScript || !state.selectedRevision) {
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
     return;
   }
 
@@ -5031,7 +5135,7 @@ async function approveSelectedScript() {
   setStatus('Saving script approval...');
 
   try {
-    const body = await api(`/scripts/${state.selectedScript.id}/revisions/${state.selectedRevision.id}/approve-for-audio`, {
+    const body = await api(`/scripts/${script.id}/revisions/${revision.id}/approve-for-audio`, {
       method: 'POST',
       body: JSON.stringify({
         actor: 'local-user',
@@ -5054,7 +5158,9 @@ async function approveSelectedScript() {
 }
 
 async function runSelectedIntegrityReview() {
-  if (!state.selectedScript || !state.selectedRevision) {
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
     return;
   }
 
@@ -5062,7 +5168,7 @@ async function runSelectedIntegrityReview() {
   setStatus('Running integrity review...');
 
   try {
-    const body = await api(`/scripts/${state.selectedScript.id}/revisions/${state.selectedRevision.id}/integrity-review`, {
+    const body = await api(`/scripts/${script.id}/revisions/${revision.id}/integrity-review`, {
       method: 'POST',
       body: JSON.stringify({ actor: 'local-user' }),
     });
@@ -5082,7 +5188,9 @@ async function runSelectedIntegrityReview() {
 }
 
 async function overrideSelectedIntegrityReview() {
-  if (!state.selectedScript || !state.selectedRevision) {
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
     return;
   }
 
@@ -5106,7 +5214,7 @@ async function overrideSelectedIntegrityReview() {
   setStatus('Saving integrity review override...');
 
   try {
-    const body = await api(`/scripts/${state.selectedScript.id}/revisions/${state.selectedRevision.id}/integrity-review/override`, {
+    const body = await api(`/scripts/${script.id}/revisions/${revision.id}/integrity-review/override`, {
       method: 'POST',
       body: JSON.stringify({
         actor: 'local-user',
@@ -5217,7 +5325,8 @@ async function approveSelectedResearch() {
 }
 
 async function refreshProductionUntilSettled() {
-  if (!state.selectedScriptId) {
+  const script = activeSelectedScript();
+  if (!script) {
     return;
   }
 
@@ -5245,11 +5354,13 @@ async function refreshProductionUntilSettled() {
 }
 
 async function startAudioPreview() {
-  if (!state.selectedScript) {
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
     return;
   }
 
-  const integrity = integrityReviewState();
+  const integrity = integrityReviewState(revision);
   if (integrity.blocking) {
     setStatus(`Preview audio blocked: integrity review ${integrityReviewLabel(integrity.status)}.`);
     render();
@@ -5260,7 +5371,7 @@ async function startAudioPreview() {
   setStatus('Starting preview audio job...');
 
   try {
-    await api(`/scripts/${state.selectedScript.id}/production/audio-preview`, {
+    await api(`/scripts/${script.id}/production/audio-preview`, {
       method: 'POST',
       body: JSON.stringify({ actor: 'local-user' }),
     });
@@ -5275,11 +5386,13 @@ async function startAudioPreview() {
 }
 
 async function startCoverArt() {
-  if (!state.selectedScript) {
+  const script = activeSelectedScript();
+  const revision = activeSelectedRevision();
+  if (!script || !revision) {
     return;
   }
 
-  const integrity = integrityReviewState();
+  const integrity = integrityReviewState(revision);
   if (integrity.blocking) {
     setStatus(`Cover art blocked: integrity review ${integrityReviewLabel(integrity.status)}.`);
     render();
@@ -5290,7 +5403,7 @@ async function startCoverArt() {
   setStatus('Starting cover art job...');
 
   try {
-    await api(`/scripts/${state.selectedScript.id}/production/cover-art`, {
+    await api(`/scripts/${script.id}/production/cover-art`, {
       method: 'POST',
       body: JSON.stringify({ actor: 'local-user' }),
     });

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -4311,9 +4311,13 @@ async function buildResearchBriefFromSelected() {
 }
 
 async function generateScriptFromSelectedResearch() {
-  const researchPacketId = selectedResearchPacket()?.id || els.scriptResearchPacketId.value.trim();
+  const researchPacketId = selectedResearchPacket()?.id || (state.selectedCandidateIds.length > 0 ? '' : els.scriptResearchPacketId.value.trim());
 
   if (!researchPacketId) {
+    setStatus(state.selectedCandidateIds.length > 0
+      ? 'Script generation blocked: build or select the active/current research brief for this story first.'
+      : 'Choose a research brief before generating a script draft.');
+    render();
     return;
   }
 

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -4310,7 +4310,7 @@ async function buildResearchBriefFromSelected() {
 }
 
 async function generateScriptFromSelectedResearch() {
-  const researchPacketId = state.selectedResearchPacketId || els.scriptResearchPacketId.value.trim();
+  const researchPacketId = selectedResearchPacket()?.id || els.scriptResearchPacketId.value.trim();
 
   if (!researchPacketId) {
     return;

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -2277,7 +2277,8 @@ function renderResearchBriefs() {
   for (const packet of state.researchPackets) {
     const scope = artifactScope('brief', packet.id);
     const row = document.createElement('article');
-    row.className = `record-row ${scope.className}-artifact${packet.id === state.selectedResearchPacketId ? ' selected' : ''}`;
+    const isActiveBrief = currentProductionViewModel().activeArtifacts?.brief?.id === packet.id;
+    row.className = `record-row ${scope.className}-artifact${isActiveBrief ? ' selected' : ''}`;
 
     const title = document.createElement('strong');
     title.textContent = packet.title;
@@ -2299,7 +2300,11 @@ function renderResearchBriefs() {
     const useForScript = document.createElement('button');
     useForScript.type = 'button';
     useForScript.className = 'secondary';
-    useForScript.textContent = packet.id === state.selectedResearchPacketId ? 'Selected for Script' : 'Use for Script';
+    useForScript.textContent = isActiveBrief
+      ? 'Active for Script'
+      : scope.className === 'archive'
+        ? 'Select for Audit Only'
+        : 'Use for Script';
     useForScript.addEventListener('click', () => {
       selectResearchPacket(packet);
     });
@@ -2334,7 +2339,8 @@ function renderEpisodes() {
   for (const episode of state.episodes) {
     const scope = artifactScope('publishing', episode.id);
     const row = document.createElement('article');
-    row.className = `record-row ${scope.className}-artifact${episode.id === state.selectedEpisodeId ? ' selected' : ''}`;
+    const isActiveEpisode = currentProductionViewModel().activeArtifacts?.publishing?.id === episode.id;
+    row.className = `record-row ${scope.className}-artifact${isActiveEpisode ? ' selected' : ''}`;
 
     const title = document.createElement('strong');
     title.textContent = episode.episodeNumber ? `EP${episode.episodeNumber}: ${episode.title}` : episode.title;
@@ -2352,7 +2358,11 @@ function renderEpisodes() {
     const select = document.createElement('button');
     select.type = 'button';
     select.className = 'secondary';
-    select.textContent = episode.id === state.selectedEpisodeId ? 'Selected Episode' : 'Select Episode';
+    select.textContent = isActiveEpisode
+      ? 'Active Episode'
+      : scope.className === 'archive'
+        ? 'Select for Audit Only'
+        : 'Select Episode';
     select.addEventListener('click', () => {
       state.selectedEpisodeId = episode.id;
       savePipelineState();

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -3114,8 +3114,9 @@ function renderProduction() {
 
   els.generateAudioPreview.disabled = !readyForProduction || audioRunning;
   els.generateCoverArt.disabled = !readyForProduction || artRunning;
+  const activeEpisode = selectedEpisode();
   els.productionMeta.textContent = readyForProduction
-    ? (state.production.episode ? `Episode ${state.production.episode.slug}` : 'No audio or cover asset tasks yet.')
+    ? (activeEpisode ? `Episode ${activeEpisode.slug}` : 'No active/current episode yet. Create audio or cover tasks for the active script.')
     : approved
       ? `Integrity gate: ${integrityReviewLabel(integrity.status)}. Run review or override before creating assets.`
       : 'Approval gate: approve the selected revision before creating audio or cover assets.';

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1261,7 +1261,6 @@ function renderProductionCommandBar(viewModel, stages) {
   const showTitle = viewModel.selectedShowSummary?.title || 'No show selected';
   const episodeTitle = viewModel.activeDraftEpisodeSummary?.title
     || viewModel.activeArtifacts?.publishing?.title
-    || viewModel.latestArtifacts?.publishing?.title
     || 'No active episode yet';
   const blockerId = 'production-command-blocker';
   const resultId = 'production-command-result';

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -443,15 +443,7 @@ function selectedAssets() {
     activeAudioCover?.audio?.id,
     activeAudioCover?.cover?.id,
   ].filter(Boolean));
-  if (activeAssetIds.size > 0) {
-    return state.production.assets.filter((asset) => activeAssetIds.has(asset.id));
-  }
-  if (state.selectedCandidateIds.length > 0 && !currentProductionViewModel().activeArtifacts?.publishing) {
-    return [];
-  }
-  const selected = new Set(state.selectedAssetIds);
-  const assets = state.production.assets.filter((asset) => selected.has(asset.id));
-  return assets.length > 0 ? assets : state.production.assets;
+  return state.production.assets.filter((asset) => activeAssetIds.has(asset.id));
 }
 
 function currentProductionViewModel() {
@@ -469,7 +461,15 @@ function artifactScope(kind, id) {
     };
   }
 
-  const historyKey = kind === 'brief' ? 'briefs' : kind === 'script' ? 'scripts' : kind === 'publishing' ? 'publishing' : kind;
+  const historyKey = kind === 'brief'
+    ? 'briefs'
+    : kind === 'script'
+      ? 'scripts'
+      : kind === 'review'
+        ? 'reviews'
+        : kind === 'publishing'
+          ? 'publishing'
+          : kind;
   const archived = asArray(viewModel.historicalArtifacts?.[historyKey]).find((artifact) => artifact.id === id);
   return {
     label: archived?.stateLabel || 'History/archive',

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -264,6 +264,9 @@ test('active artifacts and archive labels are guarded in static UI modules', () 
   assertContains(uiJs, 'currentProductionViewModel().activeArtifacts?.audioCover', 'asset selection should come from active view-model state');
   assertContains(stylesCss, '.artifact-scope-panel.warning', 'mixed artifact warning style');
   assertContains(stylesCss, '.scope-pill.archive', 'archive pill style');
+  assertContains(uiJs, 'function renderProductionArchiveAssets(archivedAssets)', 'archive production assets should render as labeled audit records');
+  assertContains(uiJs, 'History/archive production assets', 'archive production asset heading');
+  assertContains(uiJs, 'Kept for audit only; not used by production or publishing actions.', 'archive production assets should not look actionable');
   assertContains(stylesCss, '.active-artifact', 'active artifact row style');
   assertContains(stylesCss, '.archive-artifact', 'archive artifact row style');
 });

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -132,6 +132,8 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
   assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should render in workflow context');
   assertContains(uiJs, 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.', 'workflow should explain active versus archive state');
+  assertContains(uiJs, 'const researchPacketId = selectedResearchPacket()?.id', 'script generation should use active/current research packet selection');
+  assert.doesNotMatch(uiJs, /const researchPacketId = state\.selectedResearchPacketId/, 'script generation must not post archived saved packet ids');
   assert.doesNotMatch(uiJs, /latestArtifacts\?\.publishing\?\.title/, 'command bar must not present archived/latest episodes as active production context');
 
   for (const checklistItem of [

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -100,6 +100,7 @@ test('stage tracker progressively discloses only the current stage by default', 
   assertContains(uiJs, 'body.append(artifacts, next, button, actionReason)', 'expanded stage body keeps action context');
   assertContains(uiJs, 'els.pipelineStages.append(stageCard(stage, currentStageId))', 'render should pass the current stage into each card');
   assertContains(uiJs, "currentBadge.textContent = 'current'", 'current stage should be called out separately from status');
+  assertContains(uiJs, "artifactLabel.textContent = 'Active/current artifact'", 'expanded stages should not call archived records latest active artifacts');
   assertContains(uiJs, 'function pruneExpandedPipelineStages(stages)', 'expanded stage state should be pruned during render');
   assertContains(uiJs, 'state.expandedPipelineStageIds = []', 'changing workflow context should reset expanded stage state');
 
@@ -129,6 +130,8 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'Stage details', 'command bar stage details button');
   assertContains(uiJs, 'function checklistBlockers(checklist', 'checklist blocker helper');
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
+  assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should render in workflow context');
+  assertContains(uiJs, 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.', 'workflow should explain active versus archive state');
 
   for (const checklistItem of [
     'Research brief approved',
@@ -249,6 +252,19 @@ test('integrity, source coverage, and confirmation safety affordances remain pre
   assertContains(stylesCss, '.confirmation-overlay', 'confirmation overlay styles');
   assertContains(stylesCss, '.confirmation-dialog', 'confirmation dialog styles');
   assert.doesNotMatch(uiJs, /window\.prompt\b/, 'ui.js must not use window.prompt for critical actions');
+});
+
+test('active artifacts and archive labels are guarded in static UI modules', () => {
+  assertContains(uiJs, 'function artifactScope(kind, id)', 'artifact scope helper');
+  assertContains(uiJs, 'Active/current', 'active artifact label');
+  assertContains(uiJs, 'History/archive', 'archive artifact label');
+  assertContains(uiJs, 'Not part of current production', 'archive warning label');
+  assertContains(uiJs, 'activeSelectedScript', 'script actions should use active script state');
+  assertContains(uiJs, 'currentProductionViewModel().activeArtifacts?.audioCover', 'asset selection should come from active view-model state');
+  assertContains(stylesCss, '.artifact-scope-panel.warning', 'mixed artifact warning style');
+  assertContains(stylesCss, '.scope-pill.archive', 'archive pill style');
+  assertContains(stylesCss, '.active-artifact', 'active artifact row style');
+  assertContains(stylesCss, '.archive-artifact', 'archive artifact row style');
 });
 
 test('api helper does not mark empty POSTs as JSON bodies', () => {

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -132,6 +132,7 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
   assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should render in workflow context');
   assertContains(uiJs, 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.', 'workflow should explain active versus archive state');
+  assert.doesNotMatch(uiJs, /latestArtifacts\?\.publishing\?\.title/, 'command bar must not present archived/latest episodes as active production context');
 
   for (const checklistItem of [
     'Research brief approved',

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -510,6 +510,28 @@ test('view model archives production artifacts that do not match the selected ca
   assert.equal(model.primaryNextAction.label, 'Generate script draft');
 });
 
+test('view model does not promote unlinked legacy packets as current for a selected candidate', () => {
+  const legacyBrief = {
+    ...readyBrief,
+    id: 'brief-legacy',
+    title: 'Legacy unlinked brief',
+    content: {},
+    createdAt: '2026-04-27T16:30:00.000Z',
+    updatedAt: '2026-04-27T16:45:00.000Z',
+  };
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [legacyBrief],
+    selectedResearchPacketId: 'brief-legacy',
+  }));
+
+  assert.equal(model.activeArtifacts.brief, null);
+  assert.ok(model.historicalArtifacts.briefs.some((item) => item.id === 'brief-legacy' && item.stateLabel === 'History/archive'));
+  assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+  assert.equal(model.primaryNextAction.label, 'Build research brief');
+});
+
 test('view model treats publish approval as actionable when prerequisites are ready', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -272,12 +272,19 @@ test('view model covers candidate selected with no research brief', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],
     selectedCandidateIds: ['candidate-1'],
+    production: { episode, assets: [audioAsset, coverAsset], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
   }));
 
   assert.equal(model.selectedCandidateStorySummary.count, 1);
   assert.equal(model.selectedCandidateStorySummary.primary.title, candidate.title);
   assert.equal(model.currentStage.id, 'brief');
   assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.activeArtifacts.publishing, null);
+  assert.equal(model.activeArtifacts.audioCover, null);
+  assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-audio-1'));
+  assert.ok(model.artifactScopeWarnings.some((item) => item.stage === 'publishing'));
   assert.equal(model.primaryNextAction.label, 'Build research brief');
   assert.equal(model.primaryNextAction.enabled, true);
 });

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -461,6 +461,29 @@ test('view model falls back to current production assets when saved asset select
   assert.equal(model.currentStage.id, 'publishing');
 });
 
+test('view model keeps unlinked production assets archived instead of active', () => {
+  const unlinkedAudio = { ...audioAsset, id: 'asset-unlinked-audio', episodeId: undefined };
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode, assets: [unlinkedAudio], jobs: [] },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-unlinked-audio'],
+  }));
+
+  assert.equal(model.activeArtifacts.audioCover, null);
+  assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-unlinked-audio' && item.stateLabel === 'History/archive'));
+  assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+});
+
 test('view model archives production artifacts that do not match the selected candidate path', () => {
   const currentBrief = {
     ...readyBrief,

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -41,6 +41,14 @@ const candidate = {
   discoveredAt: '2026-04-27T12:00:00.000Z',
 };
 
+const newerCandidate = {
+  ...candidate,
+  id: 'candidate-2',
+  title: 'New chip export rule takes effect',
+  canonicalUrl: 'https://example.com/chip-rule',
+  discoveredAt: '2026-04-27T16:00:00.000Z',
+};
+
 const readyBrief = {
   id: 'brief-1',
   title: 'AI safety guidance brief',
@@ -48,6 +56,9 @@ const readyBrief = {
   approvedAt: '2026-04-27T13:00:00.000Z',
   warnings: [],
   citations: [{ url: 'https://example.com/ai-safety' }],
+  content: {
+    candidateIds: ['candidate-1'],
+  },
   createdAt: '2026-04-27T12:30:00.000Z',
   updatedAt: '2026-04-27T13:00:00.000Z',
 };
@@ -63,6 +74,7 @@ const notReadyBrief = {
   id: 'brief-not-ready',
   status: 'ready',
   content: {
+    candidateIds: ['candidate-1'],
     readiness: {
       status: 'needs_more_sources',
     },
@@ -120,6 +132,7 @@ const approvedScript = {
 
 const audioAsset = {
   id: 'asset-audio-1',
+  episodeId: 'episode-1',
   type: 'audio-preview',
   status: 'ready',
   mimeType: 'audio/mpeg',
@@ -131,6 +144,7 @@ const audioAsset = {
 
 const coverAsset = {
   id: 'asset-cover-1',
+  episodeId: 'episode-1',
   type: 'cover-art',
   status: 'ready',
   mimeType: 'image/png',
@@ -142,9 +156,13 @@ const coverAsset = {
 const episode = {
   id: 'episode-1',
   feedId: 'feed-1',
+  researchPacketId: 'brief-1',
   title: 'AI safety guidance episode',
   slug: 'ai-safety-guidance',
   status: 'audio-ready',
+  metadata: {
+    scriptId: 'script-1',
+  },
   createdAt: '2026-04-27T14:40:00.000Z',
   updatedAt: '2026-04-27T14:40:00.000Z',
 };
@@ -441,6 +459,55 @@ test('view model falls back to current production assets when saved asset select
   assert.equal(model.activeArtifacts.audioCover.audio.id, 'asset-audio-1');
   assert.equal(model.activeArtifacts.audioCover.cover.id, 'asset-cover-1');
   assert.equal(model.currentStage.id, 'publishing');
+});
+
+test('view model archives production artifacts that do not match the selected candidate path', () => {
+  const currentBrief = {
+    ...readyBrief,
+    id: 'brief-2',
+    title: 'Chip export rule brief',
+    content: {
+      candidateIds: ['candidate-2'],
+    },
+    createdAt: '2026-04-27T16:30:00.000Z',
+    updatedAt: '2026-04-27T16:45:00.000Z',
+  };
+  const oldEpisode = {
+    ...episode,
+    id: 'episode-old',
+    title: 'Older AI safety episode',
+    researchPacketId: 'brief-1',
+    metadata: {
+      scriptId: 'script-1',
+    },
+  };
+  const oldAudio = { ...audioAsset, id: 'asset-old-audio', episodeId: 'episode-old' };
+  const oldCover = { ...coverAsset, id: 'asset-old-cover', episodeId: 'episode-old' };
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [newerCandidate, candidate],
+    selectedCandidateIds: ['candidate-2'],
+    researchPackets: [currentBrief, readyBrief],
+    selectedResearchPacketId: 'brief-2',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: { episode: oldEpisode, assets: [oldAudio, oldCover], jobs: [] },
+    episodes: [oldEpisode],
+    selectedEpisodeId: 'episode-old',
+    selectedAssetIds: ['asset-old-audio', 'asset-old-cover'],
+  }));
+
+  assert.equal(model.activeArtifacts.brief.id, 'brief-2');
+  assert.equal(model.activeArtifacts.script, null);
+  assert.equal(model.activeArtifacts.audioCover, null);
+  assert.equal(model.activeArtifacts.publishing, null);
+  assert.ok(model.historicalArtifacts.scripts.some((item) => item.id === 'script-1' && item.stateLabel === 'History/archive'));
+  assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-old-audio' && item.stateLabel === 'History/archive'));
+  assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+  assert.ok(model.warnings.some((warning) => warning.message.includes('not part of current production')));
+  assert.equal(model.primaryNextAction.label, 'Generate script draft');
 });
 
 test('view model treats publish approval as actionable when prerequisites are ready', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -532,6 +532,30 @@ test('view model does not promote unlinked legacy packets as current for a selec
   assert.equal(model.primaryNextAction.label, 'Build research brief');
 });
 
+test('view model does not promote multi-candidate packets for a narrower selected story', () => {
+  const multiCandidateBrief = {
+    ...readyBrief,
+    id: 'brief-multi',
+    title: 'Multi-story brief',
+    content: {
+      candidateIds: ['candidate-1', 'candidate-2'],
+    },
+    createdAt: '2026-04-27T16:30:00.000Z',
+    updatedAt: '2026-04-27T16:45:00.000Z',
+  };
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate, newerCandidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [multiCandidateBrief],
+    selectedResearchPacketId: 'brief-multi',
+  }));
+
+  assert.equal(model.activeArtifacts.brief, null);
+  assert.ok(model.historicalArtifacts.briefs.some((item) => item.id === 'brief-multi' && item.stateLabel === 'History/archive'));
+  assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+  assert.equal(model.primaryNextAction.label, 'Build research brief');
+});
+
 test('view model treats publish approval as actionable when prerequisites are ready', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],


### PR DESCRIPTION
## Summary
- derives active/current artifacts from the selected candidate production path and marks unrelated selected records as history/archive
- labels active vs archive briefs, scripts, episodes, and production assets in the static UI
- scopes production, review, and publish actions to active/current artifacts only
- adds mixed active-vs-history view-model and smoke coverage

Closes #78

## Verification
- npm run check