### PR TITLE
PF3-05 Redesign story source controls

### DIFF
--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -215,10 +215,11 @@
             <label class="field">
               <span>Type</span>
               <select id="profileType">
-                <option value="brave">brave</option>
-                <option value="rss">rss</option>
-                <option value="manual">manual</option>
-                <option value="local-json">local-json</option>
+                <option value="brave">Brave</option>
+                <option value="zai-web">Z.AI Web Search</option>
+                <option value="rss">RSS</option>
+                <option value="manual">Manual URL</option>
+                <option value="local-json">Local JSON</option>
               </select>
             </label>
             <label class="field">

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -178,9 +178,34 @@ button:disabled {
   box-shadow: inset 3px 0 0 #2468a8;
 }
 
+.profile-button.disabled {
+  background: #f1f3f6;
+}
+
 .profile-button span {
   color: #586575;
   font-size: 0.9rem;
+}
+
+.profile-button .profile-provider {
+  color: #27303b;
+  font-weight: 650;
+}
+
+.profile-button .profile-availability {
+  font-size: 0.82rem;
+}
+
+.profile-button .profile-availability.available {
+  color: #245b37;
+}
+
+.profile-button .profile-availability.missing {
+  color: #7a1f1f;
+}
+
+.profile-button .profile-availability.unknown {
+  color: #675b00;
 }
 
 .workspace {
@@ -411,6 +436,97 @@ button:disabled {
   font-size: 0.95rem;
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.story-source-summary {
+  background: #ffffff;
+  border: 1px solid #ccd6e2;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.75rem;
+  grid-column: 1 / -1;
+  padding: 0.85rem;
+}
+
+.story-source-summary.blocked {
+  border-color: #e2c391;
+}
+
+.story-source-summary-header {
+  align-items: start;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.story-source-summary-header span:first-child {
+  color: #687486;
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.story-source-summary h3,
+.story-source-action,
+.story-source-blocker {
+  margin: 0;
+}
+
+.story-source-summary h3 {
+  font-size: 1rem;
+}
+
+.story-source-metrics {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.story-source-metric {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.story-source-metric span {
+  color: #687486;
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.story-source-metric strong {
+  color: #20242c;
+  font-size: 0.88rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.story-source-metric.available strong {
+  color: #245b37;
+}
+
+.story-source-metric.missing strong {
+  color: #7a1f1f;
+}
+
+.story-source-metric.unknown strong {
+  color: #675b00;
+}
+
+.story-source-action {
+  color: #3f4b5a;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.story-source-blocker {
+  background: #fff7ed;
+  border-radius: 6px;
+  color: #70440f;
+  font-size: 0.88rem;
+  padding: 0.45rem 0.55rem;
 }
 
 .pipeline-grid {
@@ -1631,6 +1747,7 @@ textarea {
   .grid.two,
   .production-command-bar,
   .workflow-context,
+  .story-source-metrics,
   .pipeline-grid,
   .model-grid,
   .episode-plan-grid,

--- a/packages/api/public/ui-formatters.js
+++ b/packages/api/public/ui-formatters.js
@@ -31,6 +31,253 @@ export function sourceControlHelp(type) {
   return 'Freshness and domain filters are not applied for manual or local JSON sources.';
 }
 
+export function sourceProviderLabel(type) {
+  return {
+    brave: 'Brave',
+    'zai-web': 'Z.AI Web Search',
+    rss: 'RSS',
+    manual: 'Manual URL',
+    'local-json': 'Local JSON',
+  }[type] || 'Story Source';
+}
+
+export function sourceActionLabel(type) {
+  return {
+    brave: 'Search Brave',
+    'zai-web': 'Search Z.AI Web',
+    rss: 'Import RSS Items',
+    manual: 'Add Manual URL',
+    'local-json': 'Review Local JSON Settings',
+  }[type] || 'Open Source Settings';
+}
+
+function enabledQueries(queries) {
+  return asArray(queries).filter((query) => query.enabled !== false);
+}
+
+function plural(value, singular, pluralLabel = `${singular}s`) {
+  return `${value} ${value === 1 ? singular : pluralLabel}`;
+}
+
+function configuredText(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function configuredList(value) {
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === 'string' && item.trim());
+  }
+
+  return [];
+}
+
+function rssConfigFeedCount(profile) {
+  const config = asObject(profile?.config);
+  return (configuredText(config.feedUrl) ? 1 : 0) + configuredList(config.feedUrls).length;
+}
+
+function localJsonConfigured(profile) {
+  const config = asObject(profile?.config);
+  return Boolean(
+    configuredText(config.path)
+    || configuredText(config.filePath)
+    || configuredText(config.localPath)
+    || configuredText(config.importPath)
+    || configuredText(config.sourcePath)
+  );
+}
+
+export function sourceInputSummary(profile, queries = []) {
+  if (!profile) {
+    return 'No story source selected.';
+  }
+
+  const activeQueries = enabledQueries(queries);
+  const savedCount = asArray(queries).length;
+
+  if (profile.type === 'rss') {
+    const feedCount = activeQueries.length + rssConfigFeedCount(profile);
+    return feedCount > 0
+      ? `${plural(feedCount, 'feed URL')} ready (${plural(activeQueries.length, 'enabled search query', 'enabled search queries')})`
+      : 'No RSS feed URLs configured yet.';
+  }
+
+  if (profile.type === 'manual') {
+    return 'Manual URL intake; no saved query is required.';
+  }
+
+  if (profile.type === 'local-json') {
+    return localJsonConfigured(profile) ? 'Local JSON import settings are present.' : 'Local JSON import settings are missing.';
+  }
+
+  return activeQueries.length > 0
+    ? `${plural(activeQueries.length, 'enabled search query', 'enabled search queries')} (${plural(savedCount, 'saved query', 'saved queries')})`
+    : `No enabled search queries (${plural(savedCount, 'saved query', 'saved queries')}).`;
+}
+
+export function sourceConstraintsSummary(profile, queries = []) {
+  if (!profile) {
+    return 'No freshness or domain constraints selected.';
+  }
+
+  const items = [];
+  const activeQueries = enabledQueries(queries);
+  const freshnessValues = new Set([
+    configuredText(profile.freshness),
+    ...activeQueries.map((query) => configuredText(query.freshness)),
+  ].filter(Boolean));
+  const includeDomains = new Set([
+    ...configuredList(profile.includeDomains),
+    ...activeQueries.flatMap((query) => configuredList(query.includeDomains)),
+  ]);
+  const excludeDomains = new Set([
+    ...configuredList(profile.excludeDomains),
+    ...activeQueries.flatMap((query) => configuredList(query.excludeDomains)),
+  ]);
+
+  if (freshnessValues.size > 0) {
+    items.push(`freshness ${[...freshnessValues].join(', ')}`);
+  }
+
+  if (includeDomains.size > 0) {
+    items.push(`${plural(includeDomains.size, 'included domain')}`);
+  }
+
+  if (excludeDomains.size > 0) {
+    items.push(`${plural(excludeDomains.size, 'excluded domain')}`);
+  }
+
+  return items.length > 0 ? items.join(' | ') : 'No freshness or domain constraints.';
+}
+
+export function sourceCredentialSummary(profile) {
+  if (!profile) {
+    return { status: 'missing', label: 'No story source selected.' };
+  }
+
+  const explicit = asObject(profile.credentialStatus);
+  if (Object.keys(explicit).length > 0) {
+    return {
+      status: explicit.available === false ? 'missing' : 'available',
+      label: configuredText(explicit.label) || (explicit.available === false ? 'Credential missing.' : 'Credential/config available.'),
+      required: Boolean(explicit.required),
+    };
+  }
+
+  if (profile.type === 'brave') {
+    return { status: 'unknown', label: 'Brave credential state not reported by this API response.', required: true };
+  }
+
+  if (profile.type === 'zai-web') {
+    return { status: 'unknown', label: 'Z.AI Web Search credential state not reported by this API response.', required: true };
+  }
+
+  if (profile.type === 'rss') {
+    return { status: 'available', label: 'No credential required; feed URL configuration controls availability.', required: false };
+  }
+
+  if (profile.type === 'manual') {
+    return { status: 'available', label: 'No credential required; paste a source URL when needed.', required: false };
+  }
+
+  return {
+    status: localJsonConfigured(profile) ? 'available' : 'missing',
+    label: localJsonConfigured(profile) ? 'Local JSON import settings present.' : 'Local JSON import settings missing.',
+    required: false,
+  };
+}
+
+export function sourceDiscoveryBlocker(profile, queries = []) {
+  if (!profile) {
+    return 'Choose a story source/search recipe before discovery.';
+  }
+
+  if (profile.enabled === false) {
+    return 'Enable this story source before discovery.';
+  }
+
+  const credential = sourceCredentialSummary(profile);
+  if (credential.required && credential.status === 'missing') {
+    return credential.label;
+  }
+
+  if (profile.type === 'brave' || profile.type === 'zai-web') {
+    return enabledQueries(queries).length > 0 ? '' : 'Add at least one enabled search query before discovery.';
+  }
+
+  if (profile.type === 'rss') {
+    return enabledQueries(queries).length + rssConfigFeedCount(profile) > 0 ? '' : 'Add at least one RSS feed URL before importing items.';
+  }
+
+  if (profile.type === 'manual') {
+    return '';
+  }
+
+  return 'Local JSON import is not available from the browser workflow yet.';
+}
+
+export function sourceActionDescription(profile, queries = []) {
+  if (!profile) {
+    return 'Choose a Story Source/Search Recipe before finding candidate stories.';
+  }
+
+  if (profile.type === 'brave') {
+    return `Search Brave with ${sourceInputSummary(profile, queries)} and apply ${sourceConstraintsSummary(profile, queries)}.`;
+  }
+
+  if (profile.type === 'zai-web') {
+    return `Search Z.AI Web Search with ${sourceInputSummary(profile, queries)} and apply ${sourceConstraintsSummary(profile, queries)}.`;
+  }
+
+  if (profile.type === 'rss') {
+    return `Import RSS items from ${sourceInputSummary(profile, queries)} and apply ${sourceConstraintsSummary(profile, queries)}.`;
+  }
+
+  if (profile.type === 'manual') {
+    return 'Open manual URL intake to create a candidate story with explicit source provenance.';
+  }
+
+  return 'Review local JSON settings in the admin source editor before importing candidate stories.';
+}
+
+export function sourceLastResultSummary(profile, jobs = []) {
+  if (!profile) {
+    return 'No source run yet.';
+  }
+
+  const selected = asArray(jobs)
+    .filter((job) => ['source.search', 'source.ingest'].includes(job?.type))
+    .filter((job) => {
+      const input = asObject(job.input);
+      return input.sourceProfileId === profile.id || input.sourceProfileSlug === profile.slug;
+    })
+    .sort((left, right) => Date.parse(right.updatedAt || right.finishedAt || right.createdAt || 0) - Date.parse(left.updatedAt || left.finishedAt || left.createdAt || 0))[0];
+
+  if (!selected) {
+    return 'No source run recorded yet.';
+  }
+
+  const output = asObject(selected.output);
+  const parts = [];
+  if (typeof output.inserted === 'number') {
+    parts.push(`${output.inserted} inserted`);
+  }
+  if (typeof output.updated === 'number') {
+    parts.push(`${output.updated} updated`);
+  }
+  if (typeof output.skipped === 'number') {
+    parts.push(`${output.skipped} skipped`);
+  }
+  const warnings = asArray(output.warnings);
+  if (warnings.length > 0) {
+    parts.push(`${warnings.length} warning${warnings.length === 1 ? '' : 's'}`);
+  }
+
+  return parts.length > 0
+    ? `${sourceActionLabel(profile.type)} ${selected.status || 'updated'}: ${parts.join(', ')}.`
+    : `${sourceActionLabel(profile.type)} ${selected.status || 'updated'}.`;
+}
+
 export function applySourceControlState(root, type) {
   const supported = sourceControlsSupported(type);
   const fields = [

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -1,6 +1,14 @@
 import {
   publicAssetBaseForFeed,
   publishTargetConfiguredForFeed,
+  sourceActionDescription,
+  sourceActionLabel,
+  sourceConstraintsSummary,
+  sourceCredentialSummary,
+  sourceDiscoveryBlocker,
+  sourceInputSummary,
+  sourceLastResultSummary,
+  sourceProviderLabel,
   validHttpUrl,
 } from './ui-formatters.js';
 
@@ -88,22 +96,36 @@ function summarizeShow(show) {
   });
 }
 
-function summarizeSource(profile, queries = []) {
+function summarizeSource(profile, queries = [], jobs = []) {
   if (!profile) {
     return null;
   }
 
   const enabledQueries = asArray(queries).filter((query) => query.enabled !== false);
+  const credential = sourceCredentialSummary(profile);
+  const blocker = sourceDiscoveryBlocker(profile, queries);
   return compactObject({
     id: profile.id,
     slug: profile.slug,
     name: profile.name || profile.slug || 'Untitled story source',
     type: profile.type,
+    providerType: sourceProviderLabel(profile.type),
     enabled: profile.enabled !== false,
+    statusLabel: profile.enabled !== false ? 'Enabled' : 'Disabled',
     weight: profile.weight,
     freshness: profile.freshness || null,
     queryCount: asArray(queries).length,
     enabledQueryCount: enabledQueries.length,
+    inputSummary: sourceInputSummary(profile, queries),
+    constraintsSummary: sourceConstraintsSummary(profile, queries),
+    credentialStatus: credential.status,
+    credentialLabel: credential.label,
+    credentialRequired: credential.required,
+    nextActionLabel: sourceActionLabel(profile.type),
+    nextActionDescription: sourceActionDescription(profile, queries),
+    discoveryReady: !blocker,
+    discoveryBlocker: blocker || null,
+    lastSearchResult: sourceLastResultSummary(profile, jobs),
   });
 }
 
@@ -536,11 +558,12 @@ function deriveStages(context) {
   const publishPrerequisiteBlocker = checklist.find((item) => !item.passed && item.key !== 'publishApproval');
   const publishApprovalReady = activeEpisode?.status === 'audio-ready';
   const profileSupportsDiscovery = source && ['brave', 'zai-web', 'rss', 'manual'].includes(source.type);
+  const sourceBlocker = source ? sourceDiscoveryBlocker(source, sourceQueries) : '';
   const briefBlocked = Boolean(activeBrief && (!briefReady || briefNeedsReview));
 
   const stages = [
     makeStage('show', show ? 'done' : 'blocked', summarizeShow(show)),
-    makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source, sourceQueries)),
+    makeStage('source', source ? 'done' : show ? 'ready' : 'blocked', summarizeSource(source, sourceQueries, jobs)),
     makeStage('discover', hasCandidatePool ? 'done' : source && profileSupportsDiscovery ? 'ready' : 'blocked', null),
     makeStage('story', hasStorySelection ? 'done' : hasCandidatePool ? 'ready' : 'blocked', summarizeCandidates(selectedCandidates)),
     makeStage('brief', activeBrief ? (briefNeedsReview ? 'needs-review' : briefReady ? 'done' : 'blocked') : hasStorySelection ? 'ready' : 'blocked', summarizeBrief(activeBrief)),
@@ -556,7 +579,12 @@ function deriveStages(context) {
   } else if (!source) {
     primaryNextAction = action('Choose story source', 'source', true);
   } else if (!hasCandidatePool) {
-    primaryNextAction = action(source.type === 'manual' ? 'Add manual story' : source.type === 'rss' ? 'Import RSS items' : 'Run source search', 'discover', profileSupportsDiscovery, 'Choose a browser-supported story source before discovery.');
+    primaryNextAction = action(
+      sourceActionLabel(source.type),
+      'discover',
+      profileSupportsDiscovery && !sourceBlocker,
+      sourceBlocker || 'Choose a browser-supported story source before discovery.',
+    );
   } else if (!hasStorySelection) {
     primaryNextAction = action('Pick or cluster story', 'story', true);
   } else if (!activeBrief) {
@@ -851,7 +879,7 @@ export function deriveProductionViewModel(input = {}) {
 
   return {
     selectedShowSummary: summarizeShow(selectedShow),
-    selectedStorySourceSummary: summarizeSource(selectedSource, sourceQueries),
+    selectedStorySourceSummary: summarizeSource(selectedSource, sourceQueries, jobs),
     selectedCandidateStorySummary: summarizeCandidates(selectedCandidates),
     activeDraftEpisodeSummary: activeEpisode && activeEpisode.status !== 'published' ? summarizeEpisode(activeEpisode) : null,
     currentStage: {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -23,7 +23,14 @@ import {
   safeVisiblePath,
   sanitizedDebug,
   slugify,
+  sourceActionDescription,
+  sourceActionLabel,
+  sourceConstraintsSummary,
   sourceControlsSupported,
+  sourceCredentialSummary,
+  sourceDiscoveryBlocker,
+  sourceInputSummary,
+  sourceProviderLabel,
   validHttpUrl,
 } from './ui-formatters.js';
 
@@ -870,12 +877,24 @@ function renderProfiles() {
   }
 
   for (const profile of state.profiles) {
+    const profileQueries = profile.id === state.selectedProfileId ? state.queries : [];
+    const credential = sourceCredentialSummary(profile);
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = `profile-button${profile.id === state.selectedProfileId ? ' active' : ''}`;
-    button.innerHTML = `<strong></strong><span></span>`;
+    button.className = `profile-button${profile.id === state.selectedProfileId ? ' active' : ''}${profile.enabled ? '' : ' disabled'}`;
+    button.innerHTML = `
+      <strong></strong>
+      <span class="profile-provider"></span>
+      <span class="profile-summary"></span>
+      <span class="profile-availability"></span>
+    `;
     button.querySelector('strong').textContent = profile.name;
-    button.querySelector('span').textContent = `${profile.type} | ${profile.enabled ? 'enabled' : 'disabled'} | weight ${profile.weight}`;
+    button.querySelector('.profile-provider').textContent = `${sourceProviderLabel(profile.type)} | ${profile.enabled ? 'enabled' : 'disabled'}`;
+    button.querySelector('.profile-summary').textContent = profile.id === state.selectedProfileId
+      ? sourceInputSummary(profile, profileQueries)
+      : 'Select to review search recipe inputs.';
+    button.querySelector('.profile-availability').textContent = credential.label;
+    button.querySelector('.profile-availability').classList.add(credential.status);
     button.addEventListener('click', async () => {
       state.selectedProfileId = profile.id;
       savePipelineState();
@@ -1258,6 +1277,7 @@ function renderProductionCommandBar(viewModel, stages) {
   const warningCount = viewModel.warnings.length;
   const blockerCount = viewModel.blockers.length;
   const result = viewModel.latestActionResult || { status: 'idle', message: 'No action result recorded yet.' };
+  const sourceSummary = viewModel.selectedStorySourceSummary;
   const showTitle = viewModel.selectedShowSummary?.title || 'No show selected';
   const episodeTitle = viewModel.activeDraftEpisodeSummary?.title
     || viewModel.activeArtifacts?.publishing?.title
@@ -1279,6 +1299,7 @@ function renderProductionCommandBar(viewModel, stages) {
   const metrics = document.createElement('div');
   metrics.className = 'command-bar-metrics';
   appendCommandBarMetric(metrics, 'Stage', `${viewModel.currentStage.label} | ${commandBarStatusLabel(viewModel.currentStage.status)}`);
+  appendCommandBarMetric(metrics, 'Story source', sourceSummary ? `${sourceSummary.providerType} | ${sourceSummary.statusLabel}` : 'Choose source');
   appendCommandBarMetric(metrics, 'Warnings', String(warningCount), warningCount > 0 ? 'warning' : '');
   appendCommandBarMetric(metrics, 'Blockers', String(blockerCount), blockerCount > 0 ? 'blocked' : '');
 
@@ -1549,6 +1570,66 @@ function workflowRevisionContext() {
   return 'No active run or revision';
 }
 
+function appendSourceSummaryMetric(container, label, value, className = '') {
+  const item = document.createElement('div');
+  item.className = `story-source-metric${className ? ` ${className}` : ''}`;
+  const itemLabel = document.createElement('span');
+  itemLabel.textContent = label;
+  const itemValue = document.createElement('strong');
+  itemValue.textContent = value;
+  item.append(itemLabel, itemValue);
+  container.append(item);
+}
+
+function renderStorySourceSummary(summary) {
+  const panel = document.createElement('section');
+  panel.className = `story-source-summary${summary?.discoveryReady === false ? ' blocked' : ''}`;
+  panel.setAttribute('aria-label', 'Selected story source summary');
+
+  const header = document.createElement('div');
+  header.className = 'story-source-summary-header';
+  const heading = document.createElement('div');
+  const kicker = document.createElement('span');
+  kicker.textContent = 'Selected Story Source / Search Recipe';
+  const title = document.createElement('h3');
+  title.textContent = summary?.name || 'Choose a story source';
+  heading.append(kicker, title);
+  const badge = document.createElement('span');
+  badge.className = `status-pill ${summary?.enabled ? 'done' : 'blocked'}`;
+  badge.textContent = summary ? summary.statusLabel : 'not selected';
+  header.append(heading, badge);
+
+  const metrics = document.createElement('div');
+  metrics.className = 'story-source-metrics';
+  appendSourceSummaryMetric(metrics, 'Provider', summary?.providerType || 'Choose a source');
+  appendSourceSummaryMetric(metrics, 'Inputs', summary?.inputSummary || 'No input summary yet.');
+  appendSourceSummaryMetric(metrics, 'Constraints', summary?.constraintsSummary || 'No constraints selected.');
+  appendSourceSummaryMetric(
+    metrics,
+    'Credential/config',
+    summary?.credentialLabel || 'No credential/config status yet.',
+    summary?.credentialStatus || '',
+  );
+  appendSourceSummaryMetric(metrics, 'Last result', summary?.lastSearchResult || 'No source run recorded yet.');
+
+  const action = document.createElement('p');
+  action.className = 'story-source-action';
+  action.textContent = summary
+    ? `${summary.nextActionLabel}: ${summary.nextActionDescription}`
+    : 'Choose a Story Source/Search Recipe to see what discovery will do next.';
+
+  if (summary?.discoveryBlocker) {
+    const blocker = document.createElement('p');
+    blocker.className = 'story-source-blocker';
+    blocker.textContent = `Blocked: ${summary.discoveryBlocker}`;
+    panel.append(header, metrics, action, blocker);
+    return panel;
+  }
+
+  panel.append(header, metrics, action);
+  return panel;
+}
+
 function buildPipelineStages() {
   const show = selectedShow();
   const profile = selectedProfile();
@@ -1577,6 +1658,9 @@ function buildPipelineStages() {
   const packetWarningCount = packet?.warnings?.length || 0;
   const packetBlocked = packet?.status === 'blocked';
   const profileSupportsDiscovery = profile && ['brave', 'zai-web', 'rss'].includes(profile.type);
+  const profileDiscoveryBlocker = profile ? sourceDiscoveryBlocker(profile, state.queries) : '';
+  const profileActionLabel = profile ? sourceActionLabel(profile.type) : 'Choose Story Source';
+  const profileActionDescription = profile ? sourceActionDescription(profile, state.queries) : 'Choose a Story Source/Search Recipe before finding candidate stories.';
   const checklist = publishChecklistState();
   const publishChecklistReady = checklist.every((item) => item.passed);
   const publishPreApprovalReady = checklist.filter((item) => item.key !== 'publishApproval').every((item) => item.passed);
@@ -1636,7 +1720,7 @@ function buildPipelineStages() {
         : profile.type === 'manual'
           ? 'Paste a manual source URL below to add a possible story.'
           : profileSupportsDiscovery
-            ? `Run ${profile.type === 'rss' ? 'RSS import' : 'source search'} for the selected story source.`
+            ? profileActionDescription
             : 'This source type is not wired for browser-triggered discovery yet.',
       actionReason: discoverRunning
         ? 'Discovery is already running; wait for the task run to finish or inspect progress.'
@@ -1645,16 +1729,18 @@ function buildPipelineStages() {
           : profile.type === 'manual'
             ? 'Add a manual URL to create a candidate story with explicit source provenance.'
             : profileSupportsDiscovery
-              ? `Ready: run ${profile.type === 'rss' ? 'RSS import' : 'source search'} to load candidate stories.`
+              ? (profileDiscoveryBlocker ? `Blocked: ${profileDiscoveryBlocker}` : `Ready: ${profileActionDescription}`)
               : 'Blocked: this story source type cannot run discovery from the browser; use Brave, Z.AI, RSS, or manual intake.',
       blockers: !profile
         ? ['Choose a story source/search recipe.']
+        : profileDiscoveryBlocker
+          ? [profileDiscoveryBlocker]
         : !profileSupportsDiscovery && profile.type !== 'manual'
           ? ['Choose a Brave, Z.AI, RSS, or manual story source for browser-triggered discovery.']
           : [],
-      actionLabel: !profile ? 'Choose Story Source' : profile.type === 'rss' ? 'Import RSS Items' : ['brave', 'zai-web'].includes(profile.type) ? 'Run Source Search' : profile.type === 'manual' ? 'Add Manual Story' : 'Open Source Settings',
+      actionLabel: profileActionLabel,
       action: !profile ? () => scrollToPanel('settingsPanel') : profileSupportsDiscovery ? runSelectedProfileDiscovery : profile.type === 'manual' ? focusManualStoryForm : () => scrollToPanel('settingsPanel'),
-      disabled: discoverRunning,
+      disabled: discoverRunning || Boolean(profileDiscoveryBlocker),
       active: state.storyCandidates.length > 0,
       targetId: profile?.type === 'manual' ? 'manualStoryPanel' : 'settingsPanel',
       jobTypes: ['source.search', 'source.ingest'],
@@ -1867,6 +1953,8 @@ function renderPipeline() {
     item.append(itemLabel, itemValue);
     els.workflowContext.append(item);
   }
+
+  els.workflowContext.append(renderStorySourceSummary(viewModel.selectedStorySourceSummary));
 
   const scopeWarnings = asArray(viewModel.artifactScopeWarnings);
   const archiveCounts = viewModel.historicalArtifacts || {};
@@ -2583,7 +2671,7 @@ function renderSettingsSources() {
       <div class="grid">
         <label class="field"><span>Name</span><input name="name" type="text" required></label>
         <label class="field"><span>Slug</span><input name="slug" type="text" required></label>
-        <label class="field"><span>Type</span><select name="type"><option value="brave">Brave</option><option value="zai-web">Z.AI Web Search</option><option value="rss">RSS</option><option value="manual">Manual</option><option value="local-json">Local JSON</option></select></label>
+        <label class="field"><span>Type</span><select name="type"><option value="brave">Brave</option><option value="zai-web">Z.AI Web Search</option><option value="rss">RSS</option><option value="manual">Manual URL</option><option value="local-json">Local JSON</option></select></label>
         <label class="field"><span>Weight</span><input name="weight" type="number" min="0" step="0.001" required></label>
         <label class="field"><span>Freshness window</span><input name="freshness" type="text" placeholder="pd, pw, pm"></label>
         <label class="toggle admin-toggle"><input name="enabled" type="checkbox"><span>Enabled</span></label>
@@ -4227,8 +4315,14 @@ async function runSelectedProfileDiscovery() {
     return;
   }
 
+  const blocker = sourceDiscoveryBlocker(profile, state.queries);
+  if (blocker) {
+    setStatus(`${sourceActionLabel(profile.type)} blocked: ${blocker}`, '', 'warning');
+    return;
+  }
+
   setActionRunning('discover', true);
-  setStatus(profile.type === 'rss' ? 'Importing RSS items...' : 'Running source search...');
+  setStatus(`${sourceActionLabel(profile.type)} running...`);
 
   try {
     const path = profile.type === 'rss'
@@ -4238,7 +4332,9 @@ async function runSelectedProfileDiscovery() {
     await loadStoryCandidates();
     await loadJobs();
     render();
-    setStatus(`${profile.type === 'rss' ? 'RSS import' : 'Source search'} complete: ${body.inserted} inserted, ${body.skipped} skipped.`);
+    const warnings = asArray(body.job?.output?.warnings);
+    const warningText = warnings.length > 0 ? `, ${warnings.length} warning${warnings.length === 1 ? '' : 's'}` : '';
+    setStatus(`${sourceActionLabel(profile.type)} complete: ${body.inserted} inserted, ${body.skipped} skipped${warningText}.`);
   } catch (error) {
     reportError(error);
   } finally {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -192,6 +192,17 @@ export function buildApp(options: BuildAppOptions = {}) {
       resolvedSourceStore ??= createDbSourceStore();
       return resolvedSourceStore;
     },
+    sourceCredentialStatus: {
+      brave: Boolean(braveApiKey ?? process.env.BRAVE_API_KEY),
+      'zai-web': Boolean(
+        zaiApiKey
+        ?? process.env.ZAI_API_KEY
+        ?? process.env.GLM_API_KEY
+        ?? process.env.GLM_API
+        ?? process.env.ZHIPU_API_KEY
+        ?? process.env.ZHIPUAI_API_KEY,
+      ),
+    },
   });
 
   registerShowRoutes(app, {

--- a/packages/api/src/sources/routes.ts
+++ b/packages/api/src/sources/routes.ts
@@ -5,7 +5,9 @@ import { normalizeDomainList } from '../search/controls.js';
 import type {
   CreateSourceProfileInput,
   CreateSourceQueryInput,
+  SourceProfileRecord,
   SourceStore,
+  SourceType,
   UpdateSourceProfileInput,
   UpdateSourceQueryInput,
 } from './store.js';
@@ -165,6 +167,7 @@ async function findSourceQueryProfile(store: SourceStore, queryId: string): Prom
 
 export interface SourceRoutesOptions {
   getStore(): SourceStore;
+  sourceCredentialStatus?: Partial<Record<SourceType, boolean>>;
 }
 
 function parseBody<T>(schema: z.ZodType<T>, body: unknown): T {
@@ -181,6 +184,60 @@ function isDatabaseAvailabilityError(error: unknown): boolean {
   }
 
   return ['3D000', '28P01', '42P01', 'ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT'].includes(String(error.code));
+}
+
+function sourceCredentialStatus(profile: SourceProfileRecord, options: SourceRoutesOptions) {
+  if (profile.type === 'brave') {
+    const available = Boolean(options.sourceCredentialStatus?.brave);
+    return {
+      required: true,
+      available,
+      label: available ? 'Brave credential configured' : 'Brave credential missing',
+      provider: 'Brave',
+    };
+  }
+
+  if (profile.type === 'zai-web') {
+    const available = Boolean(options.sourceCredentialStatus?.['zai-web']);
+    return {
+      required: true,
+      available,
+      label: available ? 'Z.AI Web Search credential configured' : 'Z.AI Web Search credential missing',
+      provider: 'Z.AI Web Search',
+    };
+  }
+
+  if (profile.type === 'rss') {
+    return {
+      required: false,
+      available: true,
+      label: 'No credential required; feed URLs are checked from enabled search queries or RSS config.',
+      provider: 'RSS',
+    };
+  }
+
+  if (profile.type === 'manual') {
+    return {
+      required: false,
+      available: true,
+      label: 'No credential required; operators paste source URLs manually.',
+      provider: 'Manual URL',
+    };
+  }
+
+  return {
+    required: false,
+    available: true,
+    label: 'No credential required; local JSON availability depends on configured import settings.',
+    provider: 'Local JSON',
+  };
+}
+
+function withSourceAvailability(profile: SourceProfileRecord, options: SourceRoutesOptions) {
+  return {
+    ...profile,
+    credentialStatus: sourceCredentialStatus(profile, options),
+  };
 }
 
 async function resolveShowId(store: SourceStore, showId?: string, showSlug?: string): Promise<string> {
@@ -265,7 +322,7 @@ export function registerSourceRoutes(app: FastifyInstance, options: SourceRoutes
   app.get<{ Querystring: { showSlug?: string } }>('/source-profiles', async (request, reply) => {
     try {
       const profiles = await getStore().listSourceProfiles({ showSlug: request.query.showSlug });
-      return { ok: true, sourceProfiles: profiles };
+      return { ok: true, sourceProfiles: profiles.map((profile) => withSourceAvailability(profile, options)) };
     } catch (error) {
       return sendError(reply, error);
     }
@@ -282,7 +339,7 @@ export function registerSourceRoutes(app: FastifyInstance, options: SourceRoutes
       };
       const profile = await store.createSourceProfile(input);
 
-      return reply.code(201).send({ ok: true, sourceProfile: profile });
+      return reply.code(201).send({ ok: true, sourceProfile: withSourceAvailability(profile, options) });
     } catch (error) {
       return sendError(reply, error);
     }
@@ -322,7 +379,7 @@ export function registerSourceRoutes(app: FastifyInstance, options: SourceRoutes
           })));
       }
 
-      return { ok: true, sourceProfile: profile };
+      return { ok: true, sourceProfile: withSourceAvailability(profile, options) };
     } catch (error) {
       return sendError(reply, error);
     }

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -192,7 +192,7 @@ test('production command bar view-model fixtures expose primary action and block
   });
 
   assert.equal(readyModel.currentStage.label, 'Find story candidates');
-  assert.equal(readyModel.primaryNextAction.label, 'Run source search');
+  assert.equal(readyModel.primaryNextAction.label, 'Search Brave');
   assert.equal(readyModel.primaryNextAction.enabled, true);
   assert.equal(readyModel.latestActionResult.message, 'Source search complete: 3 inserted, 0 skipped.');
 
@@ -212,9 +212,103 @@ test('production command bar view-model fixtures expose primary action and block
     selectedProfileId: 'profile-2',
   });
 
-  assert.equal(blockedModel.primaryNextAction.label, 'Run source search');
+  assert.equal(blockedModel.primaryNextAction.label, 'Review Local JSON Settings');
   assert.equal(blockedModel.primaryNextAction.enabled, false);
-  assert.equal(blockedModel.primaryNextAction.blockerReason, 'Choose a browser-supported story source before discovery.');
+  assert.equal(blockedModel.primaryNextAction.blockerReason, 'Local JSON import is not available from the browser workflow yet.');
+});
+
+test('story source summaries use editorial labels and hide credential values', () => {
+  assertContains(uiJs, 'Selected Story Source / Search Recipe', 'selected story source summary heading');
+  assertContains(uiJs, 'sourceProviderLabel(profile.type)', 'source selector provider labels');
+  assertContains(uiJs, 'Credential/config', 'credential/config summary label');
+  assertContains(uiJs, 'sourceActionDescription(profile, state.queries)', 'source action description');
+
+  const show = {
+    id: 'show-1',
+    slug: 'demo-show',
+    title: 'Demo Show',
+  };
+  const zaiQuery = {
+    id: 'query-zai',
+    sourceProfileId: 'profile-zai',
+    query: 'AI regulation filings',
+    enabled: true,
+    freshness: 'pw',
+    includeDomains: ['example.com'],
+    excludeDomains: ['rumor.example'],
+  };
+  const zaiModel = deriveProductionViewModel({
+    shows: [show],
+    feeds: [],
+    profiles: [{
+      id: 'profile-zai',
+      slug: 'zai-signals',
+      name: 'Policy Signals',
+      type: 'zai-web',
+      enabled: true,
+      credentialStatus: { required: true, available: true, label: 'Z.AI Web Search credential configured' },
+    }],
+    queries: [zaiQuery],
+    storyCandidates: [],
+    researchPackets: [],
+    scripts: [],
+    selectedRevisions: [],
+    production: { episode: null, assets: [], jobs: [] },
+    recentJobs: [{
+      id: 'job-zai',
+      type: 'source.search',
+      status: 'succeeded',
+      input: { sourceProfileId: 'profile-zai', sourceProfileSlug: 'zai-signals' },
+      output: { inserted: 2, skipped: 1, warnings: [{ code: 'DOMAIN_DROPPED' }] },
+      updatedAt: '2026-04-28T12:00:00Z',
+    }],
+    episodes: [],
+    selectedShowSlug: 'demo-show',
+    selectedProfileId: 'profile-zai',
+  });
+
+  assert.equal(zaiModel.selectedStorySourceSummary.providerType, 'Z.AI Web Search');
+  assert.equal(zaiModel.selectedStorySourceSummary.nextActionLabel, 'Search Z.AI Web');
+  assert.equal(zaiModel.selectedStorySourceSummary.credentialLabel, 'Z.AI Web Search credential configured');
+  assert.match(zaiModel.selectedStorySourceSummary.inputSummary, /1 enabled search query/);
+  assert.match(zaiModel.selectedStorySourceSummary.constraintsSummary, /freshness pw/);
+  assert.match(zaiModel.selectedStorySourceSummary.lastSearchResult, /2 inserted, 1 skipped, 1 warning/);
+
+  const braveModel = deriveProductionViewModel({
+    shows: [show],
+    feeds: [],
+    profiles: [{
+      id: 'profile-brave',
+      slug: 'brave-news',
+      name: 'Daily News Search',
+      type: 'brave',
+      enabled: true,
+      config: { ['api' + 'Key']: 'hidden' },
+      credentialStatus: { required: true, available: false, label: 'Brave credential missing' },
+    }],
+    queries: [{
+      id: 'query-brave',
+      sourceProfileId: 'profile-brave',
+      query: 'AI product news',
+      enabled: true,
+    }],
+    storyCandidates: [],
+    researchPackets: [],
+    scripts: [],
+    selectedRevisions: [],
+    production: { episode: null, assets: [], jobs: [] },
+    recentJobs: [],
+    episodes: [],
+    selectedShowSlug: 'demo-show',
+    selectedProfileId: 'profile-brave',
+  });
+
+  assert.equal(braveModel.selectedStorySourceSummary.providerType, 'Brave');
+  assert.equal(braveModel.selectedStorySourceSummary.credentialStatus, 'missing');
+  assert.equal(braveModel.selectedStorySourceSummary.discoveryReady, false);
+  assert.equal(braveModel.primaryNextAction.enabled, false);
+  assert.equal(braveModel.primaryNextAction.blockerReason, 'Brave credential missing');
+  assert.doesNotMatch(JSON.stringify(braveModel.selectedStorySourceSummary), /hidden/);
 });
 
 test('workflow, settings, and debug surfaces stay separated', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -249,9 +249,11 @@ test('view model covers source selected with no candidate stories', () => {
   assert.equal(model.selectedStorySourceSummary.queryCount, 1);
   assert.equal(model.stages.find((stage) => stage.id === 'source').artifact.queryCount, 1);
   assert.equal(model.stages.find((stage) => stage.id === 'source').artifact.enabledQueryCount, 1);
+  assert.equal(model.selectedStorySourceSummary.providerType, 'Brave');
+  assert.match(model.selectedStorySourceSummary.inputSummary, /1 enabled search query/);
   assert.equal(model.currentStage.id, 'discover');
   assert.equal(model.currentStage.status, 'ready');
-  assert.equal(model.primaryNextAction.label, 'Run source search');
+  assert.equal(model.primaryNextAction.label, 'Search Brave');
   assert.equal(model.primaryNextAction.enabled, true);
 });
 


### PR DESCRIPTION
## Summary
- Redesigns story source controls for the Production Cockpit flow.
- Adds provider/input/credential readiness summaries without exposing credential values.
- Keeps advanced source configuration separated from the guided source-selection workflow.

## Verification
- `git diff --check origin/main...HEAD`
- secret scan for assigned credential literals: 0 findings
- `npm run check`

## Copilot review experiment
This PR was opened after removing `.github/workflows/copilot-review.yml` from `main` in `27024f6`, so Copilot should only be requested by the repository ruleset.

Closes #79
