### PR TITLE
PF3-06 Move action feedback into workflow context

### DIFF
--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -313,9 +313,21 @@ button:disabled {
   border-color: #c55353;
 }
 
+.command-bar-result.blocked {
+  background: #fff1df;
+  border-color: #e2c391;
+}
+
 .command-bar-result.warning {
   background: #fff9d9;
   border-color: #d8cf73;
+}
+
+.command-bar-result.succeeded,
+.command-bar-result.completed,
+.command-bar-result.done {
+  background: #eef6f2;
+  border-color: #9ac8aa;
 }
 
 .command-bar-controls {
@@ -436,6 +448,101 @@ button:disabled {
   font-size: 0.95rem;
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.workflow-feedback-panel {
+  background: #ffffff;
+  border: 1px solid #ccd6e2;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.45rem;
+  grid-column: 1 / -1;
+  padding: 0.75rem 0.85rem;
+}
+
+.workflow-feedback-panel.compact {
+  border-radius: 6px;
+  padding: 0.65rem 0.75rem;
+}
+
+.workflow-feedback-panel.succeeded,
+.workflow-feedback-panel.completed,
+.workflow-feedback-panel.done {
+  background: #eef6f2;
+  border-color: #9ac8aa;
+}
+
+.workflow-feedback-panel.warning {
+  background: #fff9d9;
+  border-color: #d8cf73;
+}
+
+.workflow-feedback-panel.blocked {
+  background: #fff1df;
+  border-color: #e2c391;
+}
+
+.workflow-feedback-panel.error,
+.workflow-feedback-panel.failed {
+  background: #fff4f4;
+  border-color: #c55353;
+}
+
+.workflow-feedback-heading {
+  align-items: baseline;
+  display: flex;
+  gap: 0.55rem;
+  justify-content: space-between;
+}
+
+.workflow-feedback-heading span {
+  color: #687486;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.workflow-feedback-heading strong,
+.workflow-feedback-panel p {
+  margin: 0;
+}
+
+.workflow-feedback-heading strong {
+  color: #20242c;
+  font-size: 0.95rem;
+}
+
+.workflow-feedback-panel p {
+  color: #3f4b5a;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.workflow-feedback-panel .workflow-feedback-next {
+  color: #27303b;
+  font-weight: 650;
+}
+
+.workflow-feedback-details {
+  color: #3f4b5a;
+  font-size: 0.86rem;
+}
+
+.workflow-feedback-details summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.workflow-feedback-details pre {
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(104, 116, 134, 0.25);
+  border-radius: 6px;
+  margin: 0.5rem 0 0;
+  max-height: 14rem;
+  overflow: auto;
+  padding: 0.65rem;
+  white-space: pre-wrap;
 }
 
 .story-source-summary {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -332,9 +332,235 @@ function summarizeJob(job) {
     status: job.status,
     progress: job.progress,
     message: job.error || job.summary?.message || job.summary?.status || null,
+    warningCount: [
+      ...asArray(job.summary?.warnings),
+      ...asArray(job.output?.warnings),
+    ].length,
     updatedAt: job.updatedAt,
     createdAt: job.createdAt,
   });
+}
+
+function jobWarnings(job) {
+  return [
+    ...asArray(job?.summary?.warnings),
+    ...asArray(job?.output?.warnings),
+  ].filter(Boolean);
+}
+
+function jobResultStage(job) {
+  return {
+    'source.search': 'discover',
+    'source.ingest': 'discover',
+    'research.packet': 'brief',
+    'script.generate': 'script',
+    'script.integrity_review': 'review',
+    'audio.preview': 'production',
+    'art.generate': 'production',
+    'publish.rss': 'publishing',
+  }[job?.type] || 'workflow';
+}
+
+function jobResultLabel(job) {
+  return {
+    'source.search': 'Source search',
+    'source.ingest': 'RSS import',
+    'research.packet': 'Research brief build',
+    'script.generate': 'Script generation',
+    'script.integrity_review': 'Integrity review',
+    'audio.preview': 'Preview audio',
+    'art.generate': 'Cover art',
+    'publish.rss': 'RSS publishing',
+  }[job?.type] || job?.type || 'Task run';
+}
+
+function jobResultStatus(job) {
+  if (!job) {
+    return 'idle';
+  }
+
+  if (job.status === 'failed') {
+    return 'failed';
+  }
+
+  if (job.status === 'cancelled') {
+    return 'warning';
+  }
+
+  if (jobWarnings(job).length > 0 && ['succeeded', 'completed', 'done'].includes(job.status)) {
+    return 'warning';
+  }
+
+  return job.status || 'updated';
+}
+
+function jobCountParts(job) {
+  const output = asObject(job?.output);
+  const parts = [];
+  if (typeof output.inserted === 'number') {
+    parts.push(`${output.inserted} inserted`);
+  }
+  if (typeof output.updated === 'number') {
+    parts.push(`${output.updated} updated`);
+  }
+  if (typeof output.skipped === 'number') {
+    parts.push(`${output.skipped} skipped`);
+  }
+  const warnings = jobWarnings(job);
+  if (warnings.length > 0) {
+    parts.push(`${warnings.length} warning${warnings.length === 1 ? '' : 's'}`);
+  }
+  return parts;
+}
+
+function jobResultMessage(job) {
+  const label = jobResultLabel(job);
+  const status = job?.status || 'updated';
+  const parts = jobCountParts(job);
+
+  if (parts.length > 0) {
+    return `${label} ${status}: ${parts.join(', ')}.`;
+  }
+
+  const message = firstPresent(
+    job?.summary?.message,
+    job?.summary?.status,
+    job?.summary?.failure?.message,
+    job?.error,
+  );
+  return message ? `${label} ${status}: ${message}` : `${label} ${status}.`;
+}
+
+function jobResultNextStep(job) {
+  if (!job) {
+    return '';
+  }
+
+  const warnings = jobWarnings(job);
+  if (job.status === 'failed') {
+    return {
+      'source.search': 'Check the story source credential/config and enabled search queries before retrying discovery.',
+      'source.ingest': 'Check RSS feed URLs and source settings before retrying import.',
+      'research.packet': 'Review selected candidate stories and source availability before rebuilding the research brief.',
+      'script.generate': 'Select a ready research brief and review task details before retrying script generation.',
+      'script.integrity_review': 'Inspect review details, revise unsupported claims, then rerun the integrity reviewer.',
+      'audio.preview': 'Review the selected approved script and provider details before retrying preview audio.',
+      'art.generate': 'Review cover prompt/provider details before retrying cover art.',
+      'publish.rss': 'Complete publish approval, asset, and public URL checks before retrying RSS publishing.',
+    }[job.type] || 'Open task details for logs and retry guidance.';
+  }
+
+  if (warnings.length > 0) {
+    return 'Open task details to inspect the full warning records before relying on this output.';
+  }
+
+  if (job.type === 'source.search' || job.type === 'source.ingest') {
+    return 'Review candidate stories and select the strongest sourced item for the episode.';
+  }
+
+  if (job.type === 'research.packet') {
+    return 'Review citations and warnings, then approve the research brief before drafting.';
+  }
+
+  if (job.type === 'script.generate') {
+    return 'Review the draft, run integrity review, and approve a revision before production.';
+  }
+
+  if (job.type === 'audio.preview' || job.type === 'art.generate') {
+    return 'Review active audio and cover assets before publish approval.';
+  }
+
+  if (job.type === 'publish.rss') {
+    return 'Verify the publishing record and public feed URL.';
+  }
+
+  return '';
+}
+
+function actionResultFromJob(job) {
+  const warnings = jobWarnings(job);
+  return compactObject({
+    id: job?.id ? `job:${job.id}` : undefined,
+    status: jobResultStatus(job),
+    stage: jobResultStage(job),
+    title: jobResultStatus(job) === 'failed' ? 'Latest failure' : 'Latest result',
+    message: jobResultMessage(job),
+    conciseMessage: jobResultMessage(job),
+    nextStep: jobResultNextStep(job),
+    source: 'job',
+    job: summarizeJob(job),
+    warnings: warnings.length > 0 ? warnings : undefined,
+    detailLabel: warnings.length > 0 || job?.error ? 'Task warnings and logs remain available in Jobs / Debug.' : 'Task details are available in Jobs / Debug.',
+  });
+}
+
+function actionResultFromExplicit(input, primaryNextAction, currentStage) {
+  const explicit = asObject(input.latestActionResult);
+  if (typeof explicit.message !== 'string' || !explicit.message.trim()) {
+    return null;
+  }
+
+  return compactObject({
+    id: explicit.id || 'ui:latest',
+    status: explicit.status || 'info',
+    stage: explicit.stage || primaryNextAction?.targetStage || currentStage?.id || 'workflow',
+    title: explicit.status === 'error' || explicit.status === 'failed' ? 'Latest failure' : 'Latest result',
+    message: explicit.message.trim(),
+    conciseMessage: explicit.message.trim(),
+    nextStep: explicit.nextStep || null,
+    source: explicit.source || 'ui',
+    debugDetails: explicit.debugDetails || null,
+  });
+}
+
+function actionResultFromBlockedAction(primaryNextAction) {
+  if (!primaryNextAction || primaryNextAction.enabled) {
+    return null;
+  }
+
+  const reason = primaryNextAction.blockerReason || 'The current workflow state blocks this action.';
+  return {
+    id: `blocked:${primaryNextAction.targetStage}`,
+    status: 'blocked',
+    stage: primaryNextAction.targetStage,
+    title: 'Action blocked',
+    message: `${primaryNextAction.label} blocked: ${reason}`,
+    conciseMessage: `${primaryNextAction.label} blocked.`,
+    nextStep: reason,
+    source: 'workflow',
+  };
+}
+
+function deriveWorkflowActionFeedback(input, jobs, currentStage, primaryNextAction) {
+  const explicit = actionResultFromExplicit(input, primaryNextAction, currentStage);
+  if (explicit) {
+    return explicit;
+  }
+
+  const latestJob = latest(jobs.filter((job) => jobResultStage(job) !== 'workflow')) || latest(jobs);
+  if (latestJob && ['failed', 'warning'].includes(jobResultStatus(latestJob))) {
+    return actionResultFromJob(latestJob);
+  }
+
+  const blocked = actionResultFromBlockedAction(primaryNextAction);
+  if (blocked) {
+    return blocked;
+  }
+
+  if (latestJob) {
+    return actionResultFromJob(latestJob);
+  }
+
+  return {
+    id: 'idle',
+    status: 'idle',
+    stage: currentStage?.id || 'workflow',
+    title: 'Latest result',
+    message: 'No action result recorded yet.',
+    conciseMessage: 'No action result recorded yet.',
+    nextStep: primaryNextAction?.enabled ? primaryNextAction.label : primaryNextAction?.blockerReason || '',
+    source: 'view-model',
+  };
 }
 
 function unresolvedResearchWarnings(packet) {
@@ -629,33 +855,6 @@ function deriveStages(context) {
   return { stages, currentStage, primaryNextAction, checklist };
 }
 
-function deriveLatestActionResult(input, jobs) {
-  const explicit = asObject(input.latestActionResult);
-  if (typeof explicit.message === 'string' && explicit.message.trim()) {
-    return {
-      status: explicit.status || 'info',
-      message: explicit.message.trim(),
-      source: explicit.source || 'ui',
-    };
-  }
-
-  const latestJob = latest(jobs);
-  if (latestJob) {
-    return {
-      status: latestJob.status || 'unknown',
-      message: `${latestJob.type || 'Task run'} ${latestJob.status || 'updated'}`,
-      source: 'job',
-      job: summarizeJob(latestJob),
-    };
-  }
-
-  return {
-    status: 'idle',
-    message: 'No action result recorded yet.',
-    source: 'view-model',
-  };
-}
-
 function warningItem(stage, message, source = null, severity = 'warning') {
   return compactObject({ stage, severity, message, source });
 }
@@ -801,6 +1000,7 @@ export function deriveProductionViewModel(input = {}) {
     sourceQueries,
   };
   const { stages, currentStage, primaryNextAction, checklist } = deriveStages(context);
+  const workflowActionFeedback = deriveWorkflowActionFeedback(input, jobs, currentStage, primaryNextAction);
   const navigationActions = stages.map((stage) => action(`Open ${stage.label}`, stage.id, true));
   const secondaryActions = stages
     .filter((stage) => stage.id === currentStage.id && stage.id !== primaryNextAction.targetStage)
@@ -895,7 +1095,8 @@ export function deriveProductionViewModel(input = {}) {
     primaryNextAction,
     secondaryActions,
     navigationActions,
-    latestActionResult: deriveLatestActionResult(input, jobs),
+    latestActionResult: workflowActionFeedback,
+    workflowActionFeedback,
     warnings,
     blockers,
     visibility: {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -538,11 +538,15 @@ function deriveWorkflowActionFeedback(input, jobs, currentStage, primaryNextActi
   }
 
   const latestJob = latest(jobs.filter((job) => jobResultStage(job) !== 'workflow')) || latest(jobs);
+  const blocked = actionResultFromBlockedAction(primaryNextAction);
+  if (blocked && (!latestJob || blocked.stage === jobResultStage(latestJob))) {
+    return blocked;
+  }
+
   if (latestJob && ['failed', 'warning'].includes(jobResultStatus(latestJob))) {
     return actionResultFromJob(latestJob);
   }
 
-  const blocked = actionResultFromBlockedAction(primaryNextAction);
   if (blocked) {
     return blocked;
   }

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -2031,7 +2031,7 @@ function renderPipeline() {
 
   els.workflowContext.append(renderStorySourceSummary(viewModel.selectedStorySourceSummary));
 
-  if (viewModel.workflowActionFeedback) {
+  if (viewModel.workflowActionFeedback && viewModel.workflowActionFeedback.status !== 'idle') {
     els.workflowContext.append(renderWorkflowFeedbackPanel(viewModel.workflowActionFeedback));
   }
 

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1276,7 +1276,7 @@ function renderProductionCommandBar(viewModel, stages) {
   const detailsTarget = commandBarDetailsTarget(viewModel.currentStage.id, stages);
   const warningCount = viewModel.warnings.length;
   const blockerCount = viewModel.blockers.length;
-  const result = viewModel.latestActionResult || { status: 'idle', message: 'No action result recorded yet.' };
+  const result = viewModel.latestActionResult || viewModel.workflowActionFeedback || { status: 'idle', message: 'No action result recorded yet.' };
   const sourceSummary = viewModel.selectedStorySourceSummary;
   const showTitle = viewModel.selectedShowSummary?.title || 'No show selected';
   const episodeTitle = viewModel.activeDraftEpisodeSummary?.title
@@ -1310,7 +1310,7 @@ function renderProductionCommandBar(viewModel, stages) {
   const feedbackLabel = document.createElement('span');
   feedbackLabel.textContent = result.status === 'error' || result.status === 'failed' ? 'Latest failure' : 'Latest result';
   const feedbackMessage = document.createElement('strong');
-  feedbackMessage.textContent = result.message || 'No action result recorded yet.';
+  feedbackMessage.textContent = result.conciseMessage || result.message || 'No action result recorded yet.';
   feedback.append(feedbackLabel, feedbackMessage);
 
   const controls = document.createElement('div');
@@ -1352,6 +1352,77 @@ function renderProductionCommandBar(viewModel, stages) {
   if (activeCommandControl) {
     els.productionCommandBar.querySelector(`[data-command-control="${activeCommandControl}"]`)?.focus();
   }
+}
+
+function workflowFeedbackLegacyStageId(stageId) {
+  return stageId === 'source' ? 'show' : stageId;
+}
+
+function attachWorkflowFeedback(stages, viewModel, currentStageId) {
+  const feedback = viewModel?.workflowActionFeedback || viewModel?.latestActionResult;
+  if (!feedback || feedback.status === 'idle') {
+    return stages;
+  }
+
+  const feedbackStageId = workflowFeedbackLegacyStageId(feedback.stage || viewModel?.currentStage?.id || currentStageId);
+  const target = stages.find((stage) => stage.id === feedbackStageId)
+    || stages.find((stage) => stage.id === currentStageId);
+  if (target) {
+    target.feedback = feedback;
+  }
+  return stages;
+}
+
+function workflowFeedbackDetailText(feedback) {
+  const details = {
+    status: feedback.status,
+    stage: feedback.stage,
+    source: feedback.source,
+    nextStep: feedback.nextStep || null,
+    job: feedback.job || null,
+    warnings: asArray(feedback.warnings),
+    debugDetails: feedback.debugDetails || null,
+  };
+  return JSON.stringify(sanitizedDebug(details), null, 2);
+}
+
+function renderWorkflowFeedbackPanel(feedback, { compact = false } = {}) {
+  const panel = document.createElement('section');
+  panel.className = `workflow-feedback-panel ${statusClass(feedback?.status || 'idle')}${compact ? ' compact' : ''}`;
+  panel.setAttribute('aria-label', compact ? 'Current stage action result' : 'Workflow action result');
+  panel.setAttribute('aria-live', 'polite');
+
+  const heading = document.createElement('div');
+  heading.className = 'workflow-feedback-heading';
+  const label = document.createElement('span');
+  label.textContent = compact ? 'Current stage result' : 'Action result';
+  const title = document.createElement('strong');
+  title.textContent = feedback?.title || (feedback?.status === 'blocked' ? 'Action blocked' : 'Latest result');
+  heading.append(label, title);
+
+  const message = document.createElement('p');
+  message.textContent = feedback?.message || 'No action result recorded yet.';
+  panel.append(heading, message);
+
+  if (feedback?.nextStep) {
+    const next = document.createElement('p');
+    next.className = 'workflow-feedback-next';
+    next.textContent = `Next: ${feedback.nextStep}`;
+    panel.append(next);
+  }
+
+  if (!compact && (feedback?.detailLabel || feedback?.job || asArray(feedback?.warnings).length > 0 || feedback?.debugDetails)) {
+    const details = document.createElement('details');
+    details.className = 'workflow-feedback-details';
+    const summary = document.createElement('summary');
+    summary.textContent = feedback.detailLabel || 'Details';
+    const body = document.createElement('pre');
+    body.textContent = workflowFeedbackDetailText(feedback);
+    details.append(summary, body);
+    panel.append(details);
+  }
+
+  return panel;
 }
 
 function stageCard(stage, currentStageId = '') {
@@ -1436,6 +1507,10 @@ function stageCard(stage, currentStageId = '') {
       blockers.append(item);
     }
     body.append(blockers);
+  }
+
+  if (stage.feedback) {
+    body.append(renderWorkflowFeedbackPanel(stage.feedback, { compact: true }));
   }
 
   const button = document.createElement('button');
@@ -1956,6 +2031,10 @@ function renderPipeline() {
 
   els.workflowContext.append(renderStorySourceSummary(viewModel.selectedStorySourceSummary));
 
+  if (viewModel.workflowActionFeedback) {
+    els.workflowContext.append(renderWorkflowFeedbackPanel(viewModel.workflowActionFeedback));
+  }
+
   const scopeWarnings = asArray(viewModel.artifactScopeWarnings);
   const archiveCounts = viewModel.historicalArtifacts || {};
   const archiveCount = Object.values(archiveCounts).reduce((total, items) => total + asArray(items).length, 0);
@@ -1986,6 +2065,7 @@ function renderPipeline() {
   const stages = buildPipelineStages();
   pruneExpandedPipelineStages(stages);
   const currentStageId = currentPipelineStageId(viewModel, stages);
+  attachWorkflowFeedback(stages, viewModel, currentStageId);
   renderProductionCommandBar(viewModel, stages);
   els.pipelineStages.innerHTML = '';
 

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -119,6 +119,7 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'viewModel.primaryNextAction', 'command bar primary action from view model');
   assertContains(uiJs, 'viewModel.latestActionResult', 'command bar latest result from view model');
   assertContains(uiJs, 'viewModel.workflowActionFeedback', 'command bar workflow feedback from view model');
+  assertContains(uiJs, "viewModel.workflowActionFeedback.status !== 'idle'", 'idle workflow feedback should not render as a persistent panel');
   assertContains(uiJs, 'viewModel.warnings.length', 'command bar warning count from view model');
   assertContains(uiJs, 'action: legacyStage?.disabled ? null : legacyStage?.action || null', 'command bar primary action should invoke available stage actions');
   assertContains(uiJs, 'commandBarStatusLabel(viewModel.currentStage.status)', 'command bar stage status should stay aligned to the view model');
@@ -242,7 +243,14 @@ test('workflow action feedback view-model covers success warnings and blockers',
       enabled: true,
       credentialStatus: { required: true, available: false, label: 'Brave credential missing' },
     }],
-    recentJobs: [],
+    recentJobs: [{
+      id: 'job-stale-warning',
+      type: 'source.search',
+      status: 'succeeded',
+      input: { sourceProfileId: 'profile-1', sourceProfileSlug: 'demo-sources' },
+      output: { inserted: 0, warnings: [{ code: 'STALE', message: 'Previous search warning.' }] },
+      updatedAt: '2026-04-28T12:10:00Z',
+    }],
   });
 
   assert.equal(blockedModel.workflowActionFeedback.status, 'blocked');

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -118,6 +118,7 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'function renderProductionCommandBar(viewModel, stages)', 'production command bar renderer');
   assertContains(uiJs, 'viewModel.primaryNextAction', 'command bar primary action from view model');
   assertContains(uiJs, 'viewModel.latestActionResult', 'command bar latest result from view model');
+  assertContains(uiJs, 'viewModel.workflowActionFeedback', 'command bar workflow feedback from view model');
   assertContains(uiJs, 'viewModel.warnings.length', 'command bar warning count from view model');
   assertContains(uiJs, 'action: legacyStage?.disabled ? null : legacyStage?.action || null', 'command bar primary action should invoke available stage actions');
   assertContains(uiJs, 'commandBarStatusLabel(viewModel.currentStage.status)', 'command bar stage status should stay aligned to the view model');
@@ -128,6 +129,13 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, "dataset.commandControl", 'command bar focus restoration control marker');
   assertContains(uiJs, 'Latest failure', 'command bar failure summary label');
   assertContains(uiJs, 'Stage details', 'command bar stage details button');
+  assertContains(uiJs, 'function renderWorkflowFeedbackPanel(feedback', 'workflow feedback panel renderer');
+  assertContains(uiJs, 'function attachWorkflowFeedback(stages, viewModel, currentStageId)', 'stage feedback attachment helper');
+  assertContains(uiJs, "label.textContent = compact ? 'Current stage result' : 'Action result'", 'current stage result label');
+  assertContains(uiJs, 'workflowFeedbackDetailText(feedback)', 'feedback details keep warning/debug data available');
+  assertContains(stylesCss, '.workflow-feedback-panel.warning', 'workflow feedback warning style');
+  assertContains(stylesCss, '.workflow-feedback-panel.blocked', 'workflow feedback blocked style');
+  assertContains(stylesCss, '.workflow-feedback-details pre', 'workflow feedback detail style');
   assertContains(uiJs, 'function checklistBlockers(checklist', 'checklist blocker helper');
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
   assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should render in workflow context');
@@ -160,6 +168,123 @@ test('production command bar and concrete blocker copy remain present', () => {
   ]) {
     assertContains(uiJs, reason, `blocker reason ${reason}`);
   }
+});
+
+test('workflow action feedback view-model covers success warnings and blockers', () => {
+  const show = {
+    id: 'show-1',
+    slug: 'demo-show',
+    title: 'Demo Show',
+  };
+  const query = {
+    id: 'query-1',
+    sourceProfileId: 'profile-1',
+    query: 'AI policy',
+    enabled: true,
+  };
+  const baseState = {
+    shows: [show],
+    feeds: [],
+    profiles: [{ id: 'profile-1', slug: 'demo-sources', name: 'Demo Story Sources', type: 'brave', enabled: true }],
+    queries: [query],
+    storyCandidates: [],
+    researchPackets: [],
+    scripts: [],
+    selectedRevisions: [],
+    production: { episode: null, assets: [], jobs: [] },
+    episodes: [],
+    selectedShowSlug: 'demo-show',
+    selectedProfileId: 'profile-1',
+  };
+
+  const successModel = deriveProductionViewModel({
+    ...baseState,
+    recentJobs: [{
+      id: 'job-search-ok',
+      type: 'source.search',
+      status: 'succeeded',
+      input: { sourceProfileId: 'profile-1', sourceProfileSlug: 'demo-sources' },
+      output: { inserted: 3, updated: 1, skipped: 2 },
+      updatedAt: '2026-04-28T12:00:00Z',
+    }],
+  });
+
+  assert.equal(successModel.workflowActionFeedback.status, 'succeeded');
+  assert.equal(successModel.workflowActionFeedback.stage, 'discover');
+  assert.match(successModel.workflowActionFeedback.message, /3 inserted, 1 updated, 2 skipped/);
+  assert.match(successModel.latestActionResult.conciseMessage, /Source search succeeded/);
+  assert.match(successModel.workflowActionFeedback.nextStep, /Review candidate stories/);
+
+  const warningModel = deriveProductionViewModel({
+    ...baseState,
+    recentJobs: [{
+      id: 'job-search-warning',
+      type: 'source.search',
+      status: 'succeeded',
+      input: { sourceProfileId: 'profile-1', sourceProfileSlug: 'demo-sources' },
+      output: { inserted: 2, skipped: 1, warnings: [{ code: 'DOMAIN_DROPPED', message: 'Filtered one blocked domain.' }] },
+      updatedAt: '2026-04-28T12:05:00Z',
+    }],
+  });
+
+  assert.equal(warningModel.workflowActionFeedback.status, 'warning');
+  assert.equal(warningModel.workflowActionFeedback.warnings.length, 1);
+  assert.match(warningModel.workflowActionFeedback.message, /1 warning/);
+  assert.match(warningModel.workflowActionFeedback.nextStep, /full warning records/);
+
+  const blockedModel = deriveProductionViewModel({
+    ...baseState,
+    profiles: [{
+      id: 'profile-1',
+      slug: 'demo-sources',
+      name: 'Demo Story Sources',
+      type: 'brave',
+      enabled: true,
+      credentialStatus: { required: true, available: false, label: 'Brave credential missing' },
+    }],
+    recentJobs: [],
+  });
+
+  assert.equal(blockedModel.workflowActionFeedback.status, 'blocked');
+  assert.equal(blockedModel.workflowActionFeedback.stage, 'discover');
+  assert.match(blockedModel.workflowActionFeedback.message, /Search Brave blocked: Brave credential missing/);
+  assert.equal(blockedModel.workflowActionFeedback.nextStep, 'Brave credential missing');
+});
+
+test('workflow action feedback gives failure next-step guidance for jobs', () => {
+  const show = {
+    id: 'show-1',
+    slug: 'demo-show',
+    title: 'Demo Show',
+  };
+  const failureModel = deriveProductionViewModel({
+    shows: [show],
+    feeds: [],
+    profiles: [{ id: 'profile-1', slug: 'demo-sources', name: 'Demo Story Sources', type: 'brave', enabled: true }],
+    queries: [{ id: 'query-1', sourceProfileId: 'profile-1', query: 'AI policy', enabled: true }],
+    storyCandidates: [{ id: 'candidate-1', title: 'Policy Story', status: 'selected', canonicalUrl: 'https://example.com/story' }],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [],
+    scripts: [],
+    selectedRevisions: [],
+    production: { episode: null, assets: [], jobs: [] },
+    recentJobs: [{
+      id: 'job-brief-failed',
+      type: 'research.packet',
+      status: 'failed',
+      error: 'Source fetch failed',
+      updatedAt: '2026-04-28T13:00:00Z',
+    }],
+    episodes: [],
+    selectedShowSlug: 'demo-show',
+    selectedProfileId: 'profile-1',
+  });
+
+  assert.equal(failureModel.workflowActionFeedback.status, 'failed');
+  assert.equal(failureModel.workflowActionFeedback.stage, 'brief');
+  assert.match(failureModel.workflowActionFeedback.message, /Research brief build failed: Source fetch failed/);
+  assert.match(failureModel.workflowActionFeedback.nextStep, /source availability before rebuilding/);
+  assert.equal(failureModel.workflowActionFeedback.job.id, 'job-brief-failed');
 });
 
 test('production command bar view-model fixtures expose primary action and blocker state', () => {

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -846,7 +846,7 @@ test('view model deduplicates overlapping recent and production jobs', () => {
   }));
 
   assert.equal(model.latestActionResult.job.id, 'job-1');
-  assert.equal(model.latestActionResult.status, 'succeeded');
+  assert.equal(model.latestActionResult.status, 'warning');
   assert.equal(model.warnings.filter((warning) => warning.message === 'Preview asset needs review.').length, 1);
   assert.equal(model.warnings.filter((warning) => warning.message === 'Stale warning.').length, 0);
 });


### PR DESCRIPTION
## Summary\n- Derive workflow action feedback from explicit UI results, blocked actions, and recent jobs in the Produce view model.\n- Render success/warning/blocked/failed feedback in the Production Cockpit command bar and relevant workflow stage context.\n- Add static UI smoke/view-model regression coverage for job summaries, warnings, blockers, and failure guidance.\n\n## Verification\n- npm run check\n- git diff --check\n\nCloses #80