### PR TITLE
PF3-06B Make generated assets accessible locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,16 @@ curl -X POST http://localhost:3450/scripts/:id/production/cover-art \
 curl http://localhost:3450/scripts/:id/production
 ```
 
+Local UI playback uses an episode-scoped asset content route instead of
+exposing local filesystem paths. The route only serves generated audio or cover
+asset records whose local files resolve under the show's configured production
+asset roots.
+
+```sh
+curl http://localhost:3450/episodes/:episodeId/assets/:assetId/content
+curl -OJ "http://localhost:3450/episodes/:episodeId/assets/:assetId/content?download=1"
+```
+
 If no cover prompt is provided and an LLM runtime plus `cover_prompt_writer`
 profile is configured, the cover-art job uses the prompt registry and stores the
 prompt-writer output and invocation metadata with the job and asset. Otherwise
@@ -587,6 +597,7 @@ packet context.
 Production endpoints:
 
 - `GET /scripts/:id/production`
+- `GET /episodes/:episodeId/assets/:assetId/content`
 - `POST /scripts/:id/production/audio-preview`
 - `POST /scripts/:id/production/cover-art`
 

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -1363,8 +1363,39 @@ textarea {
   max-width: 100%;
 }
 
+.production-row audio {
+  grid-column: 1 / -1;
+  margin-top: 0.25rem;
+  width: 100%;
+}
+
 .asset-preview img {
   border-radius: 6px;
+}
+
+.asset-access-warning {
+  color: #8a4d0a;
+  font-size: 0.88rem;
+  margin: 0.45rem 0 0;
+}
+
+.asset-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  grid-column: 1 / -1;
+  margin-top: 0.35rem;
+}
+
+.asset-link-button {
+  background: white;
+  border: 1px solid #c9ced6;
+  border-radius: 6px;
+  color: #27303b;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0.48rem 0.65rem;
+  text-decoration: none;
 }
 
 .checklist-item {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -466,10 +466,6 @@ function isAudioAsset(asset) {
   return asset?.type === 'audio-preview' || asset?.type === 'audio-final' || asset?.mimeType?.startsWith('audio/');
 }
 
-function isCoverAsset(asset) {
-  return asset?.type === 'cover-art' || asset?.mimeType?.startsWith('image/');
-}
-
 function isLocalUiHost() {
   const hostname = window.location.hostname.toLowerCase();
   const privateLanPattern = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/;

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -453,6 +453,140 @@ function selectedAssets() {
   return state.production.assets.filter((asset) => activeAssetIds.has(asset.id));
 }
 
+function productionAssetContentUrl(asset, download = false) {
+  if (!asset?.id || !asset?.episodeId) {
+    return '';
+  }
+
+  const url = `/episodes/${encodeURIComponent(asset.episodeId)}/assets/${encodeURIComponent(asset.id)}/content`;
+  return download ? `${url}?download=1` : url;
+}
+
+function isAudioAsset(asset) {
+  return asset?.type === 'audio-preview' || asset?.type === 'audio-final' || asset?.mimeType?.startsWith('audio/');
+}
+
+function isCoverAsset(asset) {
+  return asset?.type === 'cover-art' || asset?.mimeType?.startsWith('image/');
+}
+
+function publicAssetWarning(asset, hasLocalAccess) {
+  if (!asset) {
+    return '';
+  }
+
+  if (!asset.publicUrl) {
+    return hasLocalAccess ? 'No public asset URL is recorded; using the local API asset route.' : 'No public or local asset URL is available.';
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(asset.publicUrl, window.location.origin);
+  } catch (_error) {
+    return hasLocalAccess
+      ? 'The recorded public asset URL is not usable; using the local API asset route.'
+      : 'The recorded public asset URL is not usable from the browser.';
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return hasLocalAccess
+      ? 'The recorded public asset URL is not http(s); using the local API asset route.'
+      : 'The recorded public asset URL is not http(s).';
+  }
+
+  if (hasLocalAccess && parsed.origin !== window.location.origin) {
+    return 'Public asset host may be unavailable in local runs; Play, Open, and Download use the local API asset route.';
+  }
+
+  return '';
+}
+
+function assetAccessUrl(asset) {
+  return productionAssetContentUrl(asset) || asset?.publicUrl || '';
+}
+
+function appendAssetAccessControls(container, asset, options = {}) {
+  const localUrl = productionAssetContentUrl(asset);
+  const accessUrl = localUrl || asset?.publicUrl || '';
+  const downloadUrl = localUrl ? productionAssetContentUrl(asset, true) : asset?.publicUrl || '';
+  const warning = publicAssetWarning(asset, Boolean(localUrl));
+
+  if (warning) {
+    const note = document.createElement('p');
+    note.className = 'asset-access-warning';
+    note.textContent = warning;
+    container.append(note);
+  }
+
+  if (options.audio && accessUrl) {
+    const player = document.createElement('audio');
+    player.controls = true;
+    player.preload = 'metadata';
+    player.src = accessUrl;
+    player.addEventListener('error', () => {
+      const note = document.createElement('p');
+      note.className = 'asset-access-warning';
+      note.textContent = 'Audio playback failed from the selected URL. Use Open or Download, or regenerate the local asset.';
+      if (!container.querySelector('.asset-playback-error')) {
+        note.classList.add('asset-playback-error');
+        container.append(note);
+      }
+    }, { once: true });
+    container.append(player);
+  }
+
+  if (options.image && accessUrl) {
+    const image = document.createElement('img');
+    image.src = accessUrl;
+    image.alt = asset.label || 'Cover art preview';
+    image.addEventListener('error', () => {
+      const note = document.createElement('p');
+      note.className = 'asset-access-warning asset-image-error';
+      note.textContent = 'Cover art preview failed from the selected URL. Use Open or Download, or regenerate the local asset.';
+      if (!container.querySelector('.asset-image-error')) {
+        container.append(note);
+      }
+    }, { once: true });
+    container.append(image);
+  }
+
+  const controls = document.createElement('div');
+  controls.className = 'asset-actions';
+
+  if (isAudioAsset(asset) && accessUrl && !options.audio) {
+    const play = document.createElement('a');
+    play.className = 'asset-link-button';
+    play.href = accessUrl;
+    play.target = '_blank';
+    play.rel = 'noopener';
+    play.textContent = 'Play';
+    controls.append(play);
+  }
+
+  if (accessUrl) {
+    const open = document.createElement('a');
+    open.className = 'asset-link-button';
+    open.href = accessUrl;
+    open.target = '_blank';
+    open.rel = 'noopener';
+    open.textContent = 'Open';
+    controls.append(open);
+  }
+
+  if (downloadUrl) {
+    const download = document.createElement('a');
+    download.className = 'asset-link-button';
+    download.href = downloadUrl;
+    download.download = '';
+    download.textContent = 'Download';
+    controls.append(download);
+  }
+
+  if (controls.childElementCount > 0) {
+    container.append(controls);
+  }
+}
+
 function currentProductionViewModel() {
   return state.productionViewModel || deriveProductionViewModel(state);
 }
@@ -3347,8 +3481,9 @@ function renderProduction() {
       const title = document.createElement('strong');
       title.textContent = `Active/current ${asset.label || asset.type}`;
       const meta = document.createElement('span');
-      meta.textContent = asset.publicUrl || asset.objectKey || asset.mimeType || 'Asset recorded; local path hidden';
+      meta.textContent = asset.objectKey || asset.publicUrl || asset.mimeType || 'Asset recorded; local path hidden';
       row.append(title, meta);
+      appendAssetAccessControls(row, asset, { audio: isAudioAsset(asset) });
       els.productionAssets.append(row);
     }
   }
@@ -3890,14 +4025,11 @@ function renderProductionReview() {
   const audioTitle = document.createElement('strong');
   audioTitle.textContent = 'Audio preview';
   audioBox.append(audioTitle);
-  if (audioAsset?.publicUrl) {
-    const player = document.createElement('audio');
-    player.controls = true;
-    player.src = audioAsset.publicUrl;
-    audioBox.append(player);
+  if (audioAsset && assetAccessUrl(audioAsset)) {
+    appendAssetAccessControls(audioBox, audioAsset, { audio: true });
   } else {
     const empty = document.createElement('p');
-    empty.textContent = audioAsset ? 'Audio asset recorded without a public preview URL.' : 'No audio asset recorded.';
+    empty.textContent = audioAsset ? 'Audio asset recorded without a usable local or public preview URL.' : 'No audio asset recorded.';
     audioBox.append(empty);
   }
   const coverBox = document.createElement('div');
@@ -3905,14 +4037,11 @@ function renderProductionReview() {
   const coverTitle = document.createElement('strong');
   coverTitle.textContent = 'Cover art';
   coverBox.append(coverTitle);
-  if (coverAsset?.publicUrl) {
-    const image = document.createElement('img');
-    image.src = coverAsset.publicUrl;
-    image.alt = coverAsset.label || 'Cover art preview';
-    coverBox.append(image);
+  if (coverAsset && assetAccessUrl(coverAsset)) {
+    appendAssetAccessControls(coverBox, coverAsset, { image: true });
   } else {
     const empty = document.createElement('p');
-    empty.textContent = coverAsset ? 'Cover art asset recorded without a public preview URL.' : 'No cover art asset recorded.';
+    empty.textContent = coverAsset ? 'Cover art asset recorded without a usable local or public preview URL.' : 'No cover art asset recorded.';
     coverBox.append(empty);
   }
   media.append(audioBox, coverBox);

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -470,31 +470,52 @@ function isCoverAsset(asset) {
   return asset?.type === 'cover-art' || asset?.mimeType?.startsWith('image/');
 }
 
-function publicAssetWarning(asset, hasLocalAccess) {
+function isLocalUiHost() {
+  const hostname = window.location.hostname.toLowerCase();
+  const privateLanPattern = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/;
+  return hostname === 'localhost'
+    || hostname === '0.0.0.0'
+    || hostname === '::1'
+    || hostname.startsWith('127.')
+    || privateLanPattern.test(hostname);
+}
+
+function assetAccessUrls(asset) {
+  const localUrl = productionAssetContentUrl(asset);
+  const publicUrl = asset?.publicUrl || '';
+  const preferLocal = Boolean(localUrl && isLocalUiHost());
+  const primary = preferLocal ? localUrl : (publicUrl || localUrl);
+  const download = preferLocal || !publicUrl ? productionAssetContentUrl(asset, true) : publicUrl;
+  const fallback = primary === localUrl ? publicUrl : localUrl;
+
+  return { localUrl, publicUrl, primary, download, fallback, preferLocal };
+}
+
+function publicAssetWarning(asset, urls) {
   if (!asset) {
     return '';
   }
 
   if (!asset.publicUrl) {
-    return hasLocalAccess ? 'No public asset URL is recorded; using the local API asset route.' : 'No public or local asset URL is available.';
+    return urls.localUrl ? 'No public asset URL is recorded; using the local API asset route.' : 'No public or local asset URL is available.';
   }
 
   let parsed;
   try {
     parsed = new URL(asset.publicUrl, window.location.origin);
   } catch (_error) {
-    return hasLocalAccess
+    return urls.localUrl
       ? 'The recorded public asset URL is not usable; using the local API asset route.'
       : 'The recorded public asset URL is not usable from the browser.';
   }
 
   if (!['http:', 'https:'].includes(parsed.protocol)) {
-    return hasLocalAccess
+    return urls.localUrl
       ? 'The recorded public asset URL is not http(s); using the local API asset route.'
       : 'The recorded public asset URL is not http(s).';
   }
 
-  if (hasLocalAccess && parsed.origin !== window.location.origin) {
+  if (urls.preferLocal && parsed.origin !== window.location.origin) {
     return 'Public asset host may be unavailable in local runs; Play, Open, and Download use the local API asset route.';
   }
 
@@ -502,14 +523,14 @@ function publicAssetWarning(asset, hasLocalAccess) {
 }
 
 function assetAccessUrl(asset) {
-  return productionAssetContentUrl(asset) || asset?.publicUrl || '';
+  return assetAccessUrls(asset).primary;
 }
 
 function appendAssetAccessControls(container, asset, options = {}) {
-  const localUrl = productionAssetContentUrl(asset);
-  const accessUrl = localUrl || asset?.publicUrl || '';
-  const downloadUrl = localUrl ? productionAssetContentUrl(asset, true) : asset?.publicUrl || '';
-  const warning = publicAssetWarning(asset, Boolean(localUrl));
+  const urls = assetAccessUrls(asset);
+  const accessUrl = urls.primary;
+  const downloadUrl = urls.download;
+  const warning = publicAssetWarning(asset, urls);
 
   if (warning) {
     const note = document.createElement('p');
@@ -571,6 +592,16 @@ function appendAssetAccessControls(container, asset, options = {}) {
     open.rel = 'noopener';
     open.textContent = 'Open';
     controls.append(open);
+  }
+
+  if (urls.fallback) {
+    const fallback = document.createElement('a');
+    fallback.className = 'asset-link-button secondary';
+    fallback.href = urls.fallback;
+    fallback.target = '_blank';
+    fallback.rel = 'noopener';
+    fallback.textContent = urls.fallback === urls.localUrl ? 'Local API' : 'Public URL';
+    controls.append(fallback);
   }
 
   if (downloadUrl) {

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -53,6 +53,9 @@ describe('api config endpoints', () => {
     assert.match(response.body, /workflowStoryContext/);
     assert.match(response.body, /renderProductionCommandBar/);
     assert.match(response.body, /checklistBlockers/);
+    assert.match(response.body, /productionAssetContentUrl/);
+    assert.match(response.body, /appendAssetAccessControls/);
+    assert.match(response.body, /Download/);
     assert.match(response.body, /scrollToPanel/);
     assert.match(response.body, /Claim\/source coverage/);
     assert.match(response.body, /coverageStatusLabel/);

--- a/packages/api/src/production/providers.ts
+++ b/packages/api/src/production/providers.ts
@@ -48,7 +48,7 @@ export interface CoverArtProvider {
   generateCoverArt(context: ProductionProviderContext & { prompt: string }): Promise<GeneratedProductionAsset>;
 }
 
-function localAssetRoot(production: ProductionConfig) {
+export function localAssetRoot(production: ProductionConfig) {
   return production.localAssetDir ?? production.outputDir ?? join('/tmp', 'podcast-forge-production-assets');
 }
 

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -434,6 +434,38 @@ function assetContentType(asset: EpisodeAssetRecord) {
   return 'application/octet-stream';
 }
 
+function normalizedClientIp(ip: string) {
+  const trimmed = ip.trim().replace(/^\[/, '').replace(/\]$/, '');
+  return trimmed.startsWith('::ffff:') ? trimmed.slice('::ffff:'.length) : trimmed;
+}
+
+function isLocalOrPrivateClientIp(ip: string) {
+  const normalized = normalizedClientIp(ip);
+
+  if (normalized === 'localhost' || normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') {
+    return true;
+  }
+
+  const octets = normalized.split('.').map((part) => Number(part));
+  if (octets.length === 4 && octets.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)) {
+    const [first, second] = octets;
+    return first === 10
+      || first === 127
+      || (first === 172 && second >= 16 && second <= 31)
+      || (first === 192 && second === 168)
+      || (first === 169 && second === 254);
+  }
+
+  const lower = normalized.toLowerCase();
+  return lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80:');
+}
+
+function assertLocalAssetRequest(ip: string) {
+  if (!isLocalOrPrivateClientIp(ip)) {
+    throw new ApiError(403, 'ASSET_CONTENT_LOCAL_ONLY', 'Generated asset content is only available to local or private-network clients.');
+  }
+}
+
 function assertApprovedScript(script: ScriptRecord): asserts script is ScriptRecord & { approvedRevisionId: string } {
   if (script.status !== 'approved-for-audio' || !script.approvedRevisionId) {
     throw new ApiError(409, 'SCRIPT_NOT_APPROVED_FOR_AUDIO', 'Script must be approved for audio before production jobs can run.');
@@ -1122,6 +1154,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
     Querystring: { download?: string };
   }>('/episodes/:episodeId/assets/:assetId/content', async (request, reply) => {
     try {
+      assertLocalAssetRequest(request.ip);
       const rawStore = options.getStore();
       const productionStore = requireProductionStore(rawStore);
       const episode = await productionStore.getEpisode(request.params.episodeId);

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
-import { stat } from 'node:fs/promises';
-import { basename, isAbsolute, join, relative, resolve } from 'node:path';
+import { realpath, stat } from 'node:fs/promises';
+import { basename, isAbsolute, relative, resolve } from 'node:path';
 
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { z, ZodError } from 'zod';
@@ -311,9 +311,27 @@ function productionAssetRoots(production: ProductionConfig) {
     localAssetRoot(production),
     production.localAssetDir,
     production.outputDir,
-    join('/tmp', 'podcast-forge-production-assets'),
   ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
     .map((value) => resolve(value)))];
+}
+
+async function realProductionAssetRoots(production: ProductionConfig) {
+  const roots = [];
+
+  for (const root of productionAssetRoots(production)) {
+    try {
+      roots.push(await realpath(root));
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        roots.push(root);
+        continue;
+      }
+
+      throw new ApiError(500, 'ASSET_ROOT_UNAVAILABLE', 'Configured production asset root could not be inspected.');
+    }
+  }
+
+  return [...new Set(roots.map((root) => resolve(root)))];
 }
 
 function isWithinRoot(root: string, candidate: string) {
@@ -340,14 +358,15 @@ function candidatePathFromObjectKey(root: string, objectKey: string | null) {
 
 async function statLocalAsset(candidate: string) {
   try {
-    const details = await stat(candidate);
-    return details.isFile() ? details : null;
+    const realCandidate = await realpath(candidate);
+    const details = await stat(realCandidate);
+    return details.isFile() ? { path: resolve(realCandidate), byteSize: details.size } : null;
   } catch (error) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       return null;
     }
 
-    throw error;
+    throw new ApiError(500, 'ASSET_FILE_UNAVAILABLE', 'Generated asset file could not be inspected.');
   }
 }
 
@@ -356,15 +375,16 @@ async function resolveLocalAssetFile(asset: EpisodeAssetRecord, production: Prod
     throw new ApiError(409, 'ASSET_NOT_STREAMABLE', 'Only generated audio and cover art assets can be opened from the local API.');
   }
 
-  const roots = productionAssetRoots(production);
+  const configuredRoots = productionAssetRoots(production);
+  const roots = await realProductionAssetRoots(production);
   const candidates = [
     asset.localPath ? resolve(asset.localPath) : null,
-    ...roots.map((root) => candidatePathFromObjectKey(root, asset.objectKey)),
+    ...configuredRoots.map((root) => candidatePathFromObjectKey(root, asset.objectKey)),
   ].filter((value): value is string => Boolean(value));
   let blockedPath = false;
 
   for (const candidate of [...new Set(candidates)]) {
-    if (!roots.some((root) => isWithinRoot(root, candidate))) {
+    if (!configuredRoots.some((root) => isWithinRoot(root, candidate))) {
       blockedPath = true;
       continue;
     }
@@ -372,7 +392,12 @@ async function resolveLocalAssetFile(asset: EpisodeAssetRecord, production: Prod
     const details = await statLocalAsset(candidate);
 
     if (details) {
-      return { path: candidate, byteSize: details.size };
+      if (!roots.some((root) => isWithinRoot(root, details.path))) {
+        blockedPath = true;
+        continue;
+      }
+
+      return details;
     }
   }
 
@@ -393,6 +418,20 @@ function assetDownloadName(asset: EpisodeAssetRecord, resolvedPath: string) {
 function contentDisposition(asset: EpisodeAssetRecord, resolvedPath: string, download?: string) {
   const disposition = download === '1' || download === 'true' ? 'attachment' : 'inline';
   return `${disposition}; filename="${assetDownloadName(asset, resolvedPath)}"`;
+}
+
+function assetContentType(asset: EpisodeAssetRecord) {
+  const mimeType = asset.mimeType ?? '';
+
+  if ((asset.type === 'audio-preview' || asset.type === 'audio-final') && mimeType.startsWith('audio/')) {
+    return mimeType;
+  }
+
+  if (asset.type === 'cover-art' && mimeType.startsWith('image/')) {
+    return mimeType;
+  }
+
+  return 'application/octet-stream';
 }
 
 function assertApprovedScript(script: ScriptRecord): asserts script is ScriptRecord & { approvedRevisionId: string } {
@@ -1106,7 +1145,7 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
         .header('x-content-type-options', 'nosniff')
         .header('content-length', String(file.byteSize))
         .header('content-disposition', contentDisposition(asset, file.path, request.query.download))
-        .type(asset.mimeType ?? 'application/octet-stream')
+        .type(assetContentType(asset))
         .send(createReadStream(file.path));
     } catch (error) {
       return sendError(reply, error);

--- a/packages/api/src/production/routes.ts
+++ b/packages/api/src/production/routes.ts
@@ -1,3 +1,7 @@
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { basename, isAbsolute, join, relative, resolve } from 'node:path';
+
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { z, ZodError } from 'zod';
 
@@ -16,6 +20,7 @@ import type { SourceStore, ShowRecord } from '../sources/store.js';
 import {
   deterministicAudioPreviewProvider,
   deterministicCoverArtProvider,
+  localAssetRoot,
   type AudioPreviewProvider,
   type CoverArtProvider,
   type GeneratedProductionAsset,
@@ -297,6 +302,97 @@ function productionConfig(show: ShowRecord): ProductionConfig {
   return settingsProduction && typeof settingsProduction === 'object' && !Array.isArray(settingsProduction)
     ? settingsProduction as ProductionConfig
     : {};
+}
+
+const streamableAssetTypes = new Set<EpisodeAssetRecord['type']>(['audio-preview', 'audio-final', 'cover-art']);
+
+function productionAssetRoots(production: ProductionConfig) {
+  return [...new Set([
+    localAssetRoot(production),
+    production.localAssetDir,
+    production.outputDir,
+    join('/tmp', 'podcast-forge-production-assets'),
+  ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => resolve(value)))];
+}
+
+function isWithinRoot(root: string, candidate: string) {
+  const resolvedRoot = resolve(root);
+  const resolvedCandidate = resolve(candidate);
+  const relativePath = relative(resolvedRoot, resolvedCandidate);
+
+  return relativePath === '' || (relativePath.length > 0 && !relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+function candidatePathFromObjectKey(root: string, objectKey: string | null) {
+  if (!objectKey) {
+    return null;
+  }
+
+  const normalizedKey = objectKey.replace(/\\/g, '/').replace(/^\/+/, '');
+
+  if (!normalizedKey || normalizedKey.split('/').includes('..')) {
+    return null;
+  }
+
+  return resolve(root, normalizedKey);
+}
+
+async function statLocalAsset(candidate: string) {
+  try {
+    const details = await stat(candidate);
+    return details.isFile() ? details : null;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+async function resolveLocalAssetFile(asset: EpisodeAssetRecord, production: ProductionConfig) {
+  if (!streamableAssetTypes.has(asset.type)) {
+    throw new ApiError(409, 'ASSET_NOT_STREAMABLE', 'Only generated audio and cover art assets can be opened from the local API.');
+  }
+
+  const roots = productionAssetRoots(production);
+  const candidates = [
+    asset.localPath ? resolve(asset.localPath) : null,
+    ...roots.map((root) => candidatePathFromObjectKey(root, asset.objectKey)),
+  ].filter((value): value is string => Boolean(value));
+  let blockedPath = false;
+
+  for (const candidate of [...new Set(candidates)]) {
+    if (!roots.some((root) => isWithinRoot(root, candidate))) {
+      blockedPath = true;
+      continue;
+    }
+
+    const details = await statLocalAsset(candidate);
+
+    if (details) {
+      return { path: candidate, byteSize: details.size };
+    }
+  }
+
+  if (blockedPath && candidates.length > 0) {
+    throw new ApiError(403, 'ASSET_PATH_NOT_ALLOWED', 'Asset file is outside the configured local production asset roots.');
+  }
+
+  throw new ApiError(404, 'ASSET_FILE_NOT_FOUND', 'Generated asset file was not found on the local API host.');
+}
+
+function assetDownloadName(asset: EpisodeAssetRecord, resolvedPath: string) {
+  const rawName = basename(asset.objectKey ?? resolvedPath);
+  const safeName = rawName.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+
+  return safeName || `${asset.id}.bin`;
+}
+
+function contentDisposition(asset: EpisodeAssetRecord, resolvedPath: string, download?: string) {
+  const disposition = download === '1' || download === 'true' ? 'attachment' : 'inline';
+  return `${disposition}; filename="${assetDownloadName(asset, resolvedPath)}"`;
 }
 
 function assertApprovedScript(script: ScriptRecord): asserts script is ScriptRecord & { approvedRevisionId: string } {
@@ -977,6 +1073,41 @@ export function registerProductionRoutes(app: FastifyInstance, options: Producti
       const jobs = episode ? await jobStore.listJobs({ episodeId: episode.id, types: ['audio.preview', 'art.generate'] }) : [];
 
       return { ok: true, episode, assets, jobs };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.get<{
+    Params: { episodeId: string; assetId: string };
+    Querystring: { download?: string };
+  }>('/episodes/:episodeId/assets/:assetId/content', async (request, reply) => {
+    try {
+      const rawStore = options.getStore();
+      const productionStore = requireProductionStore(rawStore);
+      const episode = await productionStore.getEpisode(request.params.episodeId);
+
+      if (!episode) {
+        throw new ApiError(404, 'EPISODE_NOT_FOUND', `Episode not found: ${request.params.episodeId}`);
+      }
+
+      const assets = await productionStore.listEpisodeAssets(episode.id);
+      const asset = assets.find((candidate) => candidate.id === request.params.assetId);
+
+      if (!asset) {
+        throw new ApiError(404, 'EPISODE_ASSET_NOT_FOUND', `Episode asset not found: ${request.params.assetId}`);
+      }
+
+      const show = await getShow(rawStore, episode.showId);
+      const file = await resolveLocalAssetFile(asset, productionConfig(show));
+
+      return reply
+        .header('cache-control', 'no-store')
+        .header('x-content-type-options', 'nosniff')
+        .header('content-length', String(file.byteSize))
+        .header('content-disposition', contentDisposition(asset, file.path, request.query.download))
+        .type(asset.mimeType ?? 'application/octet-stream')
+        .send(createReadStream(file.path));
     } catch (error) {
       return sendError(reply, error);
     }

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -2993,6 +2993,55 @@ describe('source profile routes', () => {
       productionBody.jobs.map((job: JobRecord) => job.type).sort(),
       ['art.generate', 'audio.preview'],
     );
+
+    const audioAssetResponse = await app.inject({
+      method: 'GET',
+      url: `/episodes/${audioBody.episode.id}/assets/${audioBody.asset.id}/content`,
+    });
+
+    assert.equal(audioAssetResponse.statusCode, 200);
+    assert.match(String(audioAssetResponse.headers['content-type'] ?? ''), /audio\/mpeg/);
+    assert.match(String(audioAssetResponse.headers['cache-control'] ?? ''), /no-store/);
+    assert.match(String(audioAssetResponse.headers['content-disposition'] ?? ''), /inline; filename="audio-preview\.mp3"/);
+    assert.match(audioAssetResponse.body, /^ID3/);
+    assert.doesNotMatch(JSON.stringify(audioAssetResponse.headers), /tmp\/podcast-forge-production-assets/);
+
+    const downloadResponse = await app.inject({
+      method: 'GET',
+      url: `/episodes/${audioBody.episode.id}/assets/${audioBody.asset.id}/content?download=1`,
+    });
+
+    assert.equal(downloadResponse.statusCode, 200);
+    assert.match(String(downloadResponse.headers['content-disposition'] ?? ''), /attachment; filename="audio-preview\.mp3"/);
+
+    const coverAssetResponse = await app.inject({
+      method: 'GET',
+      url: `/episodes/${audioBody.episode.id}/assets/${artBody.asset.id}/content`,
+    });
+
+    assert.equal(coverAssetResponse.statusCode, 200);
+    assert.match(String(coverAssetResponse.headers['content-type'] ?? ''), /image\/png/);
+
+    const blockedAsset = await store.createEpisodeAsset({
+      episodeId: audioBody.episode.id,
+      type: 'audio-preview',
+      label: 'Blocked audio',
+      localPath: '/etc/passwd',
+      objectKey: null,
+      publicUrl: null,
+      mimeType: 'audio/mpeg',
+      byteSize: 10,
+      durationSeconds: 1,
+      checksum: null,
+      metadata: {},
+    });
+    const blockedResponse = await app.inject({
+      method: 'GET',
+      url: `/episodes/${audioBody.episode.id}/assets/${blockedAsset.id}/content`,
+    });
+
+    assert.equal(blockedResponse.statusCode, 403);
+    assert.equal(blockedResponse.json().code, 'ASSET_PATH_NOT_ALLOWED');
   });
 
   it('rejects RSS publishing until an episode is approved for publish', async () => {

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import { buildApp } from '../app.js';
@@ -3049,7 +3049,7 @@ describe('source profile routes', () => {
     const outsideDir = await mkdtemp(join(tmpdir(), 'podcast-forge-outside-'));
     const outsideFile = join(outsideDir, 'outside.mp3');
     await writeFile(outsideFile, 'outside asset');
-    const symlinkPath = `${audioBody.asset.localPath}.link`;
+    const symlinkPath = join(dirname(audioBody.asset.localPath), `outside-${Date.now()}-${Math.random().toString(36).slice(2)}.mp3.link`);
     await symlink(outsideFile, symlinkPath);
     const symlinkAsset = await store.createEpisodeAsset({
       episodeId: audioBody.episode.id,

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -3025,6 +3025,15 @@ describe('source profile routes', () => {
     assert.equal(coverAssetResponse.statusCode, 200);
     assert.match(String(coverAssetResponse.headers['content-type'] ?? ''), /image\/png/);
 
+    const publicClientResponse = await app.inject({
+      method: 'GET',
+      url: `/episodes/${audioBody.episode.id}/assets/${audioBody.asset.id}/content`,
+      remoteAddress: '203.0.113.10',
+    });
+
+    assert.equal(publicClientResponse.statusCode, 403);
+    assert.equal(publicClientResponse.json().code, 'ASSET_CONTENT_LOCAL_ONLY');
+
     const blockedAsset = await store.createEpisodeAsset({
       episodeId: audioBody.episode.id,
       type: 'audio-preview',

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 
 import { buildApp } from '../app.js';
@@ -3042,6 +3045,53 @@ describe('source profile routes', () => {
 
     assert.equal(blockedResponse.statusCode, 403);
     assert.equal(blockedResponse.json().code, 'ASSET_PATH_NOT_ALLOWED');
+
+    const outsideDir = await mkdtemp(join(tmpdir(), 'podcast-forge-outside-'));
+    const outsideFile = join(outsideDir, 'outside.mp3');
+    await writeFile(outsideFile, 'outside asset');
+    const symlinkPath = `${audioBody.asset.localPath}.link`;
+    await symlink(outsideFile, symlinkPath);
+    const symlinkAsset = await store.createEpisodeAsset({
+      episodeId: audioBody.episode.id,
+      type: 'audio-preview',
+      label: 'Symlink audio',
+      localPath: symlinkPath,
+      objectKey: null,
+      publicUrl: null,
+      mimeType: 'audio/mpeg',
+      byteSize: 13,
+      durationSeconds: 1,
+      checksum: null,
+      metadata: {},
+    });
+    const symlinkResponse = await app.inject({
+      method: 'GET',
+      url: `/episodes/${audioBody.episode.id}/assets/${symlinkAsset.id}/content`,
+    });
+
+    assert.equal(symlinkResponse.statusCode, 403);
+    assert.equal(symlinkResponse.json().code, 'ASSET_PATH_NOT_ALLOWED');
+
+    const htmlMimeAsset = await store.createEpisodeAsset({
+      episodeId: audioBody.episode.id,
+      type: 'audio-preview',
+      label: 'Suspicious MIME audio',
+      localPath: audioBody.asset.localPath,
+      objectKey: null,
+      publicUrl: null,
+      mimeType: 'text/html',
+      byteSize: audioBody.asset.byteSize,
+      durationSeconds: 1,
+      checksum: null,
+      metadata: {},
+    });
+    const htmlMimeResponse = await app.inject({
+      method: 'GET',
+      url: `/episodes/${audioBody.episode.id}/assets/${htmlMimeAsset.id}/content`,
+    });
+
+    assert.equal(htmlMimeResponse.statusCode, 200);
+    assert.match(String(htmlMimeResponse.headers['content-type'] ?? ''), /application\/octet-stream/);
   });
 
   it('rejects RSS publishing until an episode is approved for publish', async () => {

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -171,6 +171,18 @@ test('production command bar and concrete blocker copy remain present', () => {
   }
 });
 
+test('production assets expose local Play Open Download controls', () => {
+  assertContains(uiJs, 'function productionAssetContentUrl(asset', 'local asset route URL helper');
+  assertContains(uiJs, '/episodes/${encodeURIComponent(asset.episodeId)}/assets/${encodeURIComponent(asset.id)}/content', 'asset route should be episode-scoped');
+  assertContains(uiJs, 'function appendAssetAccessControls(container, asset', 'asset control renderer');
+  assertContains(uiJs, "play.textContent = 'Play'", 'audio asset play link');
+  assertContains(uiJs, "open.textContent = 'Open'", 'asset open link');
+  assertContains(uiJs, "download.textContent = 'Download'", 'asset download link');
+  assertContains(uiJs, 'Public asset host may be unavailable in local runs', 'public URL local fallback warning');
+  assertContains(stylesCss, '.asset-actions', 'asset action styles');
+  assertContains(stylesCss, '.asset-access-warning', 'asset warning styles');
+});
+
 test('workflow action feedback view-model covers success warnings and blockers', () => {
   const show = {
     id: 'show-1',


### PR DESCRIPTION
Closes #67

## Summary
- add episode-scoped generated asset content route with local root/path safety checks
- render Play/Open/Download controls and local fallback warnings in the static production UI
- document the local asset access route and add API/UI smoke coverage

## Verification
- npm run check

## Notes
- Implementation agent disconnected after producing a verified diff; watchdog manually ran checks, committed, pushed, and opened this PR.
- No secrets or private filesystem paths are exposed by the route or UI.