### PR TITLE
Add OpenRouter Perplexity source provider

### DIFF
--- a/packages/api/public/ui-formatters.js
+++ b/packages/api/public/ui-formatters.js
@@ -12,7 +12,7 @@ export function listToLines(value) {
 }
 
 export function sourceControlsSupported(type) {
-  return type === 'brave' || type === 'zai-web' || type === 'rss';
+  return type === 'brave' || type === 'zai-web' || type === 'openrouter-perplexity' || type === 'rss';
 }
 
 export function sourceControlHelp(type) {
@@ -22,6 +22,10 @@ export function sourceControlHelp(type) {
 
   if (type === 'zai-web') {
     return 'Freshness and the first include-domain filter are sent to Z.AI Web Search. Domain filters are also enforced after results return.';
+  }
+
+  if (type === 'openrouter-perplexity') {
+    return 'Freshness/domain filters are requested from OpenRouter Perplexity/Sonar and enforced again after curated results return.';
   }
 
   if (type === 'rss') {
@@ -35,6 +39,7 @@ export function sourceProviderLabel(type) {
   return {
     brave: 'Brave',
     'zai-web': 'Z.AI Web Search',
+    'openrouter-perplexity': 'OpenRouter Perplexity/Sonar',
     rss: 'RSS',
     manual: 'Manual URL',
     'local-json': 'Local JSON',
@@ -45,6 +50,7 @@ export function sourceActionLabel(type) {
   return {
     brave: 'Search Brave',
     'zai-web': 'Search Z.AI Web',
+    'openrouter-perplexity': 'Curate with Perplexity/Sonar',
     rss: 'Import RSS Items',
     manual: 'Add Manual URL',
     'local-json': 'Review Local JSON Settings',
@@ -61,6 +67,23 @@ function plural(value, singular, pluralLabel = `${singular}s`) {
 
 function configuredText(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+export function freshnessLabel(value) {
+  return {
+    pd: 'Past day',
+    pw: 'Past week',
+    pm: 'Past month',
+    py: 'Past year',
+    day: 'Past day',
+    week: 'Past week',
+    month: 'Past month',
+    year: 'Past year',
+    oneDay: 'Past day',
+    oneWeek: 'Past week',
+    oneMonth: 'Past month',
+    oneYear: 'Past year',
+  }[configuredText(value)] || configuredText(value);
 }
 
 function configuredList(value) {
@@ -136,7 +159,7 @@ export function sourceConstraintsSummary(profile, queries = []) {
   ]);
 
   if (freshnessValues.size > 0) {
-    items.push(`freshness ${[...freshnessValues].join(', ')}`);
+    items.push(`freshness ${[...freshnessValues].map(freshnessLabel).join(', ')}`);
   }
 
   if (includeDomains.size > 0) {
@@ -172,6 +195,10 @@ export function sourceCredentialSummary(profile) {
     return { status: 'unknown', label: 'Z.AI Web Search credential state not reported by this API response.', required: true };
   }
 
+  if (profile.type === 'openrouter-perplexity') {
+    return { status: 'unknown', label: 'OpenRouter credential state not reported by this API response.', required: true };
+  }
+
   if (profile.type === 'rss') {
     return { status: 'available', label: 'No credential required; feed URL configuration controls availability.', required: false };
   }
@@ -201,7 +228,7 @@ export function sourceDiscoveryBlocker(profile, queries = []) {
     return credential.label;
   }
 
-  if (profile.type === 'brave' || profile.type === 'zai-web') {
+  if (profile.type === 'brave' || profile.type === 'zai-web' || profile.type === 'openrouter-perplexity') {
     return enabledQueries(queries).length > 0 ? '' : 'Add at least one enabled search query before discovery.';
   }
 
@@ -227,6 +254,10 @@ export function sourceActionDescription(profile, queries = []) {
 
   if (profile.type === 'zai-web') {
     return `Search Z.AI Web Search with ${sourceInputSummary(profile, queries)} and apply ${sourceConstraintsSummary(profile, queries)}.`;
+  }
+
+  if (profile.type === 'openrouter-perplexity') {
+    return `Curate Perplexity/Sonar candidates through OpenRouter with ${sourceInputSummary(profile, queries)} and apply ${sourceConstraintsSummary(profile, queries)}.`;
   }
 
   if (profile.type === 'rss') {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -787,7 +787,7 @@ function deriveStages(context) {
   const publishBlocker = checklist.find((item) => !item.passed);
   const publishPrerequisiteBlocker = checklist.find((item) => !item.passed && item.key !== 'publishApproval');
   const publishApprovalReady = activeEpisode?.status === 'audio-ready';
-  const profileSupportsDiscovery = source && ['brave', 'zai-web', 'rss', 'manual'].includes(source.type);
+  const profileSupportsDiscovery = source && ['brave', 'zai-web', 'openrouter-perplexity', 'rss', 'manual'].includes(source.type);
   const sourceBlocker = source ? sourceDiscoveryBlocker(source, sourceQueries) : '';
   const briefBlocked = Boolean(activeBrief && (!briefReady || briefNeedsReview));
 

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -9,6 +9,7 @@ import {
   asObject,
   castToLines,
   formatRole,
+  freshnessLabel,
   linesToCast,
   linesToList,
   listToLines,
@@ -355,6 +356,17 @@ function duplicateValues(values) {
   }
 
   return [...duplicated];
+}
+
+function candidateFreshnessText(candidate) {
+  const metadata = asObject(candidate.metadata);
+  const freshness = asObject(metadata.freshness);
+  const requested = freshnessLabel(freshness.requested || metadata.freshnessRequested || '');
+  if (candidate.publishedAt) {
+    const confidence = freshness.verified === true ? 'verified' : freshness.confidence === 'claimed' ? 'provider-claimed' : 'unverified';
+    return `published ${new Date(candidate.publishedAt).toLocaleString()} (${confidence}${requested ? `, requested ${requested}` : ''})`;
+  }
+  return requested ? `published date unknown (requested ${requested})` : `discovered ${new Date(candidate.discoveredAt).toLocaleString()}`;
 }
 
 function selectedCandidateAnalysis() {
@@ -1913,7 +1925,7 @@ function buildPipelineStages() {
   const productionActionRunning = productionRunning || isActionRunning('production');
   const packetWarningCount = packet?.warnings?.length || 0;
   const packetBlocked = packet?.status === 'blocked';
-  const profileSupportsDiscovery = profile && ['brave', 'zai-web', 'rss'].includes(profile.type);
+  const profileSupportsDiscovery = profile && ['brave', 'zai-web', 'openrouter-perplexity', 'rss'].includes(profile.type);
   const profileDiscoveryBlocker = profile ? sourceDiscoveryBlocker(profile, state.queries) : '';
   const profileActionLabel = profile ? sourceActionLabel(profile.type) : 'Choose Story Source';
   const profileActionDescription = profile ? sourceActionDescription(profile, state.queries) : 'Choose a Story Source/Search Recipe before finding candidate stories.';
@@ -2543,9 +2555,7 @@ function renderStoryCandidates() {
     const url = candidateUrl(candidate);
     const domain = hostnameFor(url);
     const sourceProfile = sourceProfileForCandidate(candidate);
-    const published = candidate.publishedAt
-      ? `published ${new Date(candidate.publishedAt).toLocaleString()}`
-      : `discovered ${new Date(candidate.discoveredAt).toLocaleString()}`;
+    const published = candidateFreshnessText(candidate);
     meta.textContent = [
       candidate.sourceName || domain || 'unknown source',
       domain || 'no source URL',
@@ -4574,7 +4584,7 @@ function syncClusterFormFromInputs() {
 async function runSelectedProfileDiscovery() {
   const profile = selectedProfile();
 
-  if (!profile || !['brave', 'zai-web', 'rss'].includes(profile.type)) {
+  if (!profile || !['brave', 'zai-web', 'openrouter-perplexity', 'rss'].includes(profile.type)) {
     focusManualStoryForm();
     return;
   }

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -361,7 +361,8 @@ function duplicateValues(values) {
 function candidateFreshnessText(candidate) {
   const metadata = asObject(candidate.metadata);
   const freshness = asObject(metadata.freshness);
-  const requested = freshnessLabel(freshness.requested || metadata.freshnessRequested || '');
+  const search = asObject(metadata.search);
+  const requested = freshnessLabel(freshness.requested || metadata.freshnessRequested || search.freshness || search.recency || search.search_recency_filter || '');
   if (candidate.publishedAt) {
     const confidence = freshness.verified === true ? 'verified' : freshness.confidence === 'claimed' ? 'provider-claimed' : 'unverified';
     return `published ${new Date(candidate.publishedAt).toLocaleString()} (${confidence}${requested ? `, requested ${requested}` : ''})`;

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -34,6 +34,7 @@ import type { RssFetch } from './search/rss.js';
 import type { CandidateScorer } from './search/scoring.js';
 import type { SearchJobStore } from './search/store.js';
 import type { ZaiWebFetch } from './search/zai-web.js';
+import type { OpenRouterPerplexityFetch } from './search/openrouter-perplexity.js';
 import type { LlmRuntime } from './llm/types.js';
 import { registerSchedulerRoutes } from './scheduler/routes.js';
 import type { SchedulerStore } from './scheduler/store.js';
@@ -54,8 +55,10 @@ interface BuildAppOptions extends FastifyServerOptions {
     & Partial<SchedulerStore>;
   braveApiKey?: string;
   zaiApiKey?: string;
+  openRouterApiKey?: string;
   fetchImpl?: BraveFetch;
   zaiFetchImpl?: ZaiWebFetch;
+  openRouterPerplexityFetchImpl?: OpenRouterPerplexityFetch;
   rssFetchImpl?: RssFetch;
   candidateScorer?: CandidateScorer;
   llmRuntime?: LlmRuntime;
@@ -96,8 +99,10 @@ export function buildApp(options: BuildAppOptions = {}) {
     sourceStore,
     braveApiKey,
     zaiApiKey,
+    openRouterApiKey,
     fetchImpl,
     zaiFetchImpl,
+    openRouterPerplexityFetchImpl,
     rssFetchImpl,
     candidateScorer,
     llmRuntime,
@@ -202,6 +207,7 @@ export function buildApp(options: BuildAppOptions = {}) {
         ?? process.env.ZHIPU_API_KEY
         ?? process.env.ZHIPUAI_API_KEY,
       ),
+      'openrouter-perplexity': Boolean(openRouterApiKey ?? process.env.OPENROUTER_API_KEY),
     },
   });
 
@@ -233,8 +239,10 @@ export function buildApp(options: BuildAppOptions = {}) {
     },
     braveApiKey,
     zaiApiKey,
+    openRouterApiKey,
     fetchImpl,
     zaiFetchImpl,
+    openRouterPerplexityFetchImpl,
     rssFetchImpl,
     candidateScorer,
     llmRuntime,

--- a/packages/api/src/config/types.ts
+++ b/packages/api/src/config/types.ts
@@ -22,7 +22,7 @@ export interface CastMemberConfig {
 
 export interface SourceConfig {
   id: string;
-  type: 'brave' | 'zai-web' | 'rss' | 'manual' | 'local-json';
+  type: 'brave' | 'zai-web' | 'openrouter-perplexity' | 'rss' | 'manual' | 'local-json';
   enabled: boolean;
   weight?: number;
   freshness?: string;

--- a/packages/api/src/search/job.ts
+++ b/packages/api/src/search/job.ts
@@ -4,6 +4,7 @@ import { filterCandidatesForSourceControls, type SourceControlSummary } from './
 import { fetchRssCandidates, type RssFetch } from './rss.js';
 import { scoreCandidateBatch, scoringLimitFromProfile, type CandidateScorer, type CandidateScoringBatchResult } from './scoring.js';
 import { searchZaiWeb, type ZaiWebFetch } from './zai-web.js';
+import { searchOpenRouterPerplexity, type OpenRouterPerplexityFetch } from './openrouter-perplexity.js';
 import type { JobRecord, SearchJobStore, StoryCandidateRecord } from './store.js';
 import type { ResolvedModelProfile } from '../models/resolver.js';
 import type { SourceProfileRecord, SourceQueryRecord, SourceStore } from '../sources/store.js';
@@ -22,6 +23,7 @@ interface RunSourceSearchOptions {
   store: SourceStore & SearchJobStore;
   fetchImpl?: BraveFetch;
   zaiFetchImpl?: ZaiWebFetch;
+  openRouterPerplexityFetchImpl?: OpenRouterPerplexityFetch;
   sleep?: (ms: number) => Promise<void>;
   modelProfile?: ResolvedModelProfile;
   candidateScorer?: CandidateScorer;
@@ -61,7 +63,9 @@ function queryIdFromCandidate(candidate: SourceCandidate): string | null {
 }
 
 function providerLabel(profile: SourceProfileRecord): string {
-  return profile.type === 'zai-web' ? 'Z.AI web' : 'Brave news';
+  if (profile.type === 'zai-web') return 'Z.AI web';
+  if (profile.type === 'openrouter-perplexity') return 'OpenRouter Perplexity';
+  return 'Brave news';
 }
 
 async function searchProviderCandidates(options: RunSourceSearchOptions, query: SourceQueryRecord) {
@@ -71,6 +75,15 @@ async function searchProviderCandidates(options: RunSourceSearchOptions, query: 
       profile: options.profile,
       queries: [query],
       fetchImpl: options.zaiFetchImpl,
+    });
+  }
+
+  if (options.profile.type === 'openrouter-perplexity') {
+    return searchOpenRouterPerplexity({
+      apiKey: options.apiKey,
+      profile: options.profile,
+      queries: [query],
+      fetchImpl: options.openRouterPerplexityFetchImpl,
     });
   }
 

--- a/packages/api/src/search/openrouter-perplexity.test.ts
+++ b/packages/api/src/search/openrouter-perplexity.test.ts
@@ -94,6 +94,6 @@ describe('OpenRouter Perplexity source provider', () => {
     assert.deepEqual(candidates.map((candidate) => candidate.title), ['Anthropic ships Claude Opus 4.7']);
     assert.equal(candidates[0].publishedAt?.toISOString(), '2026-04-28T00:00:00.000Z');
     assert.deepEqual(candidates[0].metadata.freshness, { requested: 'day', confidence: 'claimed', verified: false });
-    assert.deepEqual(candidates[0].metadata.citations, ['1', 'https://www.anthropic.com/news/claude-opus-4-7']);
+    assert.deepEqual(candidates[0].metadata.citations, ['https://www.anthropic.com/news/claude-opus-4-7']);
   });
 });

--- a/packages/api/src/search/openrouter-perplexity.test.ts
+++ b/packages/api/src/search/openrouter-perplexity.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { searchOpenRouterPerplexity, type OpenRouterPerplexityFetch } from './openrouter-perplexity.js';
+import type { SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+
+const profile: SourceProfileRecord = {
+  id: '22222222-2222-4222-8222-222222222222',
+  showId: '11111111-1111-4111-8111-111111111111',
+  slug: 'openrouter-sonar',
+  name: 'OpenRouter Sonar',
+  type: 'openrouter-perplexity',
+  enabled: true,
+  weight: 1,
+  freshness: 'pd',
+  includeDomains: [],
+  excludeDomains: ['youtube.com'],
+  rateLimit: {},
+  config: { model: 'perplexity/sonar', topN: 1 },
+  createdAt: new Date('2026-04-28T00:00:00Z'),
+  updatedAt: new Date('2026-04-28T00:00:00Z'),
+};
+
+const query: SourceQueryRecord = {
+  id: '33333333-3333-4333-8333-333333333333',
+  sourceProfileId: profile.id,
+  query: 'new AI model launched today',
+  enabled: true,
+  weight: 1,
+  region: 'US',
+  language: 'en',
+  freshness: 'pd',
+  includeDomains: [],
+  excludeDomains: [],
+  config: {},
+  createdAt: new Date('2026-04-28T00:00:00Z'),
+  updatedAt: new Date('2026-04-28T00:00:00Z'),
+};
+
+describe('OpenRouter Perplexity source provider', () => {
+  it('uses json_schema, harvests annotations, caps top-N, and filters denied/video sources', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const fetchImpl: OpenRouterPerplexityFetch = async (_url, init) => {
+      requestBody = JSON.parse(init.body) as Record<string, unknown>;
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  candidates: [
+                    {
+                      title: 'Anthropic ships Claude Opus 4.7',
+                      url: 'https://www.anthropic.com/news/claude-opus-4-7',
+                      sourceName: 'Anthropic',
+                      summary: 'Official announcement with model details.',
+                      publishedAt: '2026-04-28',
+                      freshnessConfidence: 'claimed',
+                      citations: ['1'],
+                    },
+                    {
+                      title: 'Aggregator recap',
+                      url: 'https://www.youtube.com/watch?v=example',
+                      summary: 'Video recap that should be denied.',
+                      publishedAt: null,
+                    },
+                  ],
+                }),
+                annotations: [{
+                  type: 'url_citation',
+                  url_citation: {
+                    url: 'https://www.anthropic.com/news/claude-opus-4-7',
+                    title: 'Claude Opus 4.7',
+                    start_index: 0,
+                    end_index: 0,
+                  },
+                }],
+              },
+            }],
+            usage: { cost: 0.005 },
+          };
+        },
+      };
+    };
+
+    const candidates = await searchOpenRouterPerplexity({ apiKey: 'test-key', profile, queries: [query], fetchImpl });
+
+    assert.equal(requestBody?.model, 'perplexity/sonar');
+    assert.equal((requestBody?.response_format as { type?: string }).type, 'json_schema');
+    assert.ok((requestBody?.response_format as { json_schema?: unknown }).json_schema);
+    assert.equal(requestBody?.search_recency_filter, 'day');
+    assert.deepEqual(candidates.map((candidate) => candidate.title), ['Anthropic ships Claude Opus 4.7']);
+    assert.equal(candidates[0].publishedAt?.toISOString(), '2026-04-28T00:00:00.000Z');
+    assert.deepEqual(candidates[0].metadata.freshness, { requested: 'day', confidence: 'claimed', verified: false });
+    assert.deepEqual(candidates[0].metadata.citations, ['1', 'https://www.anthropic.com/news/claude-opus-4-7']);
+  });
+});

--- a/packages/api/src/search/openrouter-perplexity.ts
+++ b/packages/api/src/search/openrouter-perplexity.ts
@@ -1,0 +1,277 @@
+import type { SourceProfileRecord, SourceQueryRecord } from '../sources/store.js';
+import { canonicalizeUrl, cleanText, type SourceCandidate } from './candidate.js';
+
+export interface OpenRouterPerplexityResponse {
+  ok: boolean;
+  status: number;
+  statusText?: string;
+  json(): Promise<unknown>;
+}
+
+export type OpenRouterPerplexityFetch = (
+  url: string,
+  init: { method: 'POST'; headers: Record<string, string>; body: string; signal?: AbortSignal },
+) => Promise<OpenRouterPerplexityResponse>;
+
+export type OpenRouterPerplexityCandidate = SourceCandidate;
+
+type JsonObject = Record<string, unknown>;
+
+interface OpenRouterPerplexitySearchOptions {
+  apiKey: string;
+  profile: SourceProfileRecord;
+  queries: SourceQueryRecord[];
+  fetchImpl?: OpenRouterPerplexityFetch;
+  timeoutMs?: number;
+}
+
+const DEFAULT_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+const DEFAULT_MODEL = 'perplexity/sonar';
+const DEFAULT_TOP_N = 5;
+const DEFAULT_DENY_DOMAINS = ['youtube.com', 'reddit.com', 'facebook.com', 'instagram.com', 'tiktok.com', 'x.com', 'twitter.com'];
+
+function defaultFetch(url: string, init: { method: 'POST'; headers: Record<string, string>; body: string; signal?: AbortSignal }) {
+  return fetch(url, init) as Promise<OpenRouterPerplexityResponse>;
+}
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+
+function asPositiveInteger(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const parsed = Number(value);
+    return parsed > 0 ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function option(query: SourceQueryRecord, profile: SourceProfileRecord, key: string): unknown {
+  return query.config[key] ?? profile.config[key];
+}
+
+function resolveModel(profile: SourceProfileRecord): string {
+  return asString(profile.config.model) ?? asString(profile.config.openrouterModel) ?? DEFAULT_MODEL;
+}
+
+function resolveEndpoint(profile: SourceProfileRecord): string {
+  return asString(profile.config.baseUrl) ?? asString(profile.config.endpoint) ?? process.env.OPENROUTER_BASE_URL ?? DEFAULT_ENDPOINT;
+}
+
+function resolveTopN(query: SourceQueryRecord, profile: SourceProfileRecord): number {
+  return Math.min(asPositiveInteger(option(query, profile, 'topN')) ?? asPositiveInteger(option(query, profile, 'count')) ?? DEFAULT_TOP_N, 10);
+}
+
+function recencyFor(query: SourceQueryRecord, profile: SourceProfileRecord): string | undefined {
+  const value = asString(option(query, profile, 'search_recency_filter')) ?? query.freshness ?? profile.freshness ?? undefined;
+  switch (value) {
+    case 'pd': return 'day';
+    case 'pw': return 'week';
+    case 'pm': return 'month';
+    case 'py': return 'year';
+    default: return value;
+  }
+}
+
+function denyDomainsFor(query: SourceQueryRecord, profile: SourceProfileRecord): string[] {
+  const configured = asStringArray(option(query, profile, 'search_domain_filter'));
+  if (configured.length > 0) return configured;
+  return [...DEFAULT_DENY_DOMAINS, ...profile.excludeDomains, ...query.excludeDomains]
+    .map((domain) => domain.startsWith('-') ? domain : `-${domain}`)
+    .filter(Boolean);
+}
+
+function parsePublishedAt(value: unknown): Date | null {
+  const candidate = asString(value);
+  if (!candidate) return null;
+  const parsed = new Date(candidate);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function hostname(value: string): string | null {
+  try { return new URL(value).hostname.replace(/^www\./, '').toLowerCase(); } catch { return null; }
+}
+
+function isHomepage(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.pathname === '/' || url.pathname === '';
+  } catch {
+    return false;
+  }
+}
+
+function isDeniedUrl(value: string, denied: string[]): boolean {
+  const host = hostname(value);
+  if (!host) return false;
+  return denied
+    .map((domain) => domain.replace(/^-/, '').replace(/^www\./, '').toLowerCase())
+    .some((domain) => host === domain || host.endsWith(`.${domain}`));
+}
+
+function citationUrls(message: JsonObject): Array<{ url: string; title?: string }> {
+  const annotations = Array.isArray(message.annotations) ? message.annotations.map(asObject) : [];
+  return annotations.flatMap((annotation) => {
+    if (annotation.type !== 'url_citation') return [];
+    const citation = asObject(annotation.url_citation);
+    const url = asString(citation.url);
+    return url ? [{ url, title: asString(citation.title) }] : [];
+  });
+}
+
+function buildPrompt(query: SourceQueryRecord, profile: SourceProfileRecord, topN: number): string {
+  return [
+    `Curate at most ${topN} high-signal story candidates for a podcast episode.`,
+    `Search query: ${query.query}`,
+    `Source profile: ${profile.name}`,
+    'Prefer canonical article or official announcement URLs over homepages, social posts, videos, and aggregator list pages.',
+    'Return JSON only matching the schema. Use null when a publication date is not available. Treat freshness as claimed unless independently verified.'
+  ].join('\n');
+}
+
+function responseSchema() {
+  return {
+    name: 'podcast_forge_story_candidates',
+    strict: true,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        candidates: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: true,
+            properties: {
+              title: { type: 'string' },
+              url: { type: 'string' },
+              sourceName: { type: ['string', 'null'] },
+              summary: { type: ['string', 'null'] },
+              publishedAt: { type: ['string', 'null'] },
+              freshnessConfidence: { type: ['string', 'null'] },
+              citations: { type: 'array', items: { type: 'string' } },
+              rationale: { type: ['string', 'null'] }
+            },
+            required: ['title', 'url']
+          }
+        }
+      },
+      required: ['candidates']
+    }
+  };
+}
+
+function parseCandidates(payload: JsonObject): JsonObject[] {
+  const choices = Array.isArray(payload.choices) ? payload.choices.map(asObject) : [];
+  const message = asObject(choices[0]?.message);
+  const content = asString(message.content) ?? '{}';
+  let parsed: JsonObject = {};
+  try {
+    parsed = asObject(JSON.parse(content));
+  } catch {
+    parsed = {};
+  }
+  const candidates = Array.isArray(parsed.candidates) ? parsed.candidates.map(asObject) : [];
+  const annotations = citationUrls(message);
+  return candidates.map((candidate) => ({ ...candidate, __annotations: annotations }));
+}
+
+function mapCandidate(item: JsonObject, query: SourceQueryRecord, profile: SourceProfileRecord, search: JsonObject): OpenRouterPerplexityCandidate | undefined {
+  const title = asString(item.title);
+  const url = asString(item.url) ?? asString(item.canonicalUrl);
+  if (!title || !url) return undefined;
+  const citations = [
+    ...asStringArray(item.citations),
+    ...asStringArray(item.evidenceUrls),
+    ...(Array.isArray(item.__annotations) ? item.__annotations.map(asObject).map((citation) => asString(citation.url)).filter((value): value is string => Boolean(value)) : []),
+  ];
+  return {
+    title: cleanText(title),
+    url,
+    canonicalUrl: canonicalizeUrl(url),
+    sourceName: asString(item.sourceName) ?? asString(item.source) ?? hostname(url),
+    summary: asString(item.summary) ?? asString(item.rationale) ?? null,
+    publishedAt: parsePublishedAt(item.publishedAt ?? item.date ?? item.publicationDate),
+    rawPayload: item,
+    metadata: {
+      provider: 'openrouter-perplexity',
+      freshness: {
+        requested: search.recency ?? null,
+        confidence: asString(item.freshnessConfidence) ?? (parsePublishedAt(item.publishedAt) ? 'claimed' : 'unknown'),
+        verified: false,
+      },
+      citations: [...new Set(citations)],
+      query: {
+        id: query.id,
+        text: query.query,
+        origin: {
+          sourceProfileId: profile.id,
+          sourceProfileSlug: profile.slug,
+          sourceQueryId: query.id,
+        },
+      },
+      search,
+    },
+  };
+}
+
+export async function searchOpenRouterPerplexity(options: OpenRouterPerplexitySearchOptions): Promise<OpenRouterPerplexityCandidate[]> {
+  const fetchImpl = options.fetchImpl ?? defaultFetch;
+  const candidates: OpenRouterPerplexityCandidate[] = [];
+  const model = resolveModel(options.profile);
+  const endpoint = resolveEndpoint(options.profile);
+
+  for (const query of options.queries) {
+    const topN = resolveTopN(query, options.profile);
+    const recency = recencyFor(query, options.profile);
+    const domainFilter = denyDomainsFor(query, options.profile);
+    const body: Record<string, unknown> = {
+      model,
+      messages: [{ role: 'user', content: buildPrompt(query, options.profile, topN) }],
+      temperature: 0.1,
+      max_tokens: asPositiveInteger(option(query, options.profile, 'maxTokens')) ?? 1600,
+      response_format: { type: 'json_schema', json_schema: responseSchema() },
+      search_domain_filter: domainFilter,
+    };
+    if (recency) body.search_recency_filter = recency;
+    const language = query.language ?? asString(option(query, options.profile, 'language'));
+    if (language) body.search_language_filter = [language];
+    const country = query.region ?? asString(option(query, options.profile, 'country'));
+    if (country) body.web_search_options = { user_location: { country } };
+
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${options.apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': asString(options.profile.config.httpReferer) ?? 'http://localhost:3450',
+        'X-Title': asString(options.profile.config.title) ?? 'Podcast Forge',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(options.timeoutMs ?? 20_000),
+    });
+    if (!response.ok) {
+      throw new Error(`OpenRouter Perplexity search failed with HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`);
+    }
+    const payload = asObject(await response.json());
+    const search = { model, topN, recency: recency ?? null, domainFilter, cost: asObject(payload.usage).cost ?? null };
+    const mapped = parseCandidates(payload)
+      .map((item) => mapCandidate(item, query, options.profile, search))
+      .filter((candidate): candidate is OpenRouterPerplexityCandidate => Boolean(candidate))
+      .filter((candidate) => !isHomepage(candidate.canonicalUrl))
+      .filter((candidate) => !isDeniedUrl(candidate.canonicalUrl, domainFilter))
+      .slice(0, topN);
+    candidates.push(...mapped);
+  }
+  return candidates;
+}

--- a/packages/api/src/search/openrouter-perplexity.ts
+++ b/packages/api/src/search/openrouter-perplexity.ts
@@ -63,8 +63,13 @@ function resolveModel(profile: SourceProfileRecord): string {
   return asString(profile.config.model) ?? asString(profile.config.openrouterModel) ?? DEFAULT_MODEL;
 }
 
-function resolveEndpoint(profile: SourceProfileRecord): string {
-  return asString(profile.config.baseUrl) ?? asString(profile.config.endpoint) ?? process.env.OPENROUTER_BASE_URL ?? DEFAULT_ENDPOINT;
+function resolveEndpoint(_profile: SourceProfileRecord): string {
+  const configured = asString(process.env.OPENROUTER_BASE_URL) ?? DEFAULT_ENDPOINT;
+  const url = new URL(configured);
+  if (url.protocol !== 'https:' || url.hostname !== 'openrouter.ai') {
+    throw new Error('OpenRouter Perplexity endpoint must use https://openrouter.ai');
+  }
+  return url.toString();
 }
 
 function resolveTopN(query: SourceQueryRecord, profile: SourceProfileRecord): number {
@@ -82,12 +87,18 @@ function recencyFor(query: SourceQueryRecord, profile: SourceProfileRecord): str
   }
 }
 
+function normalizeDeniedDomain(domain: string): string | undefined {
+  const trimmed = domain.trim();
+  if (!trimmed) return undefined;
+  const denied = trimmed.startsWith('-') ? trimmed.slice(1) : trimmed;
+  const normalized = denied.replace(/^https?:\/\//, '').replace(/^www\./, '').split('/')[0]?.toLowerCase();
+  return normalized ? `-${normalized}` : undefined;
+}
+
 function denyDomainsFor(query: SourceQueryRecord, profile: SourceProfileRecord): string[] {
   const configured = asStringArray(option(query, profile, 'search_domain_filter'));
-  if (configured.length > 0) return configured;
-  return [...DEFAULT_DENY_DOMAINS, ...profile.excludeDomains, ...query.excludeDomains]
-    .map((domain) => domain.startsWith('-') ? domain : `-${domain}`)
-    .filter(Boolean);
+  const domains = configured.length > 0 ? configured : [...DEFAULT_DENY_DOMAINS, ...profile.excludeDomains, ...query.excludeDomains];
+  return [...new Set(domains.map(normalizeDeniedDomain).filter((domain): domain is string => Boolean(domain)))];
 }
 
 function parsePublishedAt(value: unknown): Date | null {
@@ -118,13 +129,22 @@ function isDeniedUrl(value: string, denied: string[]): boolean {
     .some((domain) => host === domain || host.endsWith(`.${domain}`));
 }
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function citationUrls(message: JsonObject): Array<{ url: string; title?: string }> {
   const annotations = Array.isArray(message.annotations) ? message.annotations.map(asObject) : [];
   return annotations.flatMap((annotation) => {
     if (annotation.type !== 'url_citation') return [];
     const citation = asObject(annotation.url_citation);
     const url = asString(citation.url);
-    return url ? [{ url, title: asString(citation.title) }] : [];
+    return url && isHttpUrl(url) ? [{ url, title: asString(citation.title) }] : [];
   });
 }
 
@@ -177,8 +197,9 @@ function parseCandidates(payload: JsonObject): JsonObject[] {
   let parsed: JsonObject = {};
   try {
     parsed = asObject(JSON.parse(content));
-  } catch {
-    parsed = {};
+  } catch (error) {
+    const preview = content.slice(0, 240);
+    throw new Error(`OpenRouter Perplexity returned invalid candidate JSON: ${error instanceof Error ? error.message : 'parse failed'}; preview=${preview}`);
   }
   const candidates = Array.isArray(parsed.candidates) ? parsed.candidates.map(asObject) : [];
   const annotations = citationUrls(message);
@@ -193,7 +214,7 @@ function mapCandidate(item: JsonObject, query: SourceQueryRecord, profile: Sourc
     ...asStringArray(item.citations),
     ...asStringArray(item.evidenceUrls),
     ...(Array.isArray(item.__annotations) ? item.__annotations.map(asObject).map((citation) => asString(citation.url)).filter((value): value is string => Boolean(value)) : []),
-  ];
+  ].filter(isHttpUrl);
   return {
     title: cleanText(title),
     url,

--- a/packages/api/src/search/routes.ts
+++ b/packages/api/src/search/routes.ts
@@ -8,6 +8,7 @@ import { resolveRssFeedRefs, type RssFetch } from './rss.js';
 import { createLlmCandidateScorer, type CandidateScorer } from './scoring.js';
 import type { SearchJobStore } from './store.js';
 import type { ZaiWebFetch } from './zai-web.js';
+import type { OpenRouterPerplexityFetch } from './openrouter-perplexity.js';
 import { createLlmRuntime } from '../llm/runtime.js';
 import type { LlmRuntime } from '../llm/types.js';
 import { hasModelProfileStore, resolveModelProfile } from '../models/resolver.js';
@@ -31,8 +32,10 @@ export interface SearchRoutesOptions {
   getStore(): SourceStore & Partial<SearchJobStore> & Partial<ModelProfileStore> & Partial<PromptTemplateStore>;
   braveApiKey?: string;
   zaiApiKey?: string;
+  openRouterApiKey?: string;
   fetchImpl?: BraveFetch;
   zaiFetchImpl?: ZaiWebFetch;
+  openRouterPerplexityFetchImpl?: OpenRouterPerplexityFetch;
   rssFetchImpl?: RssFetch;
   candidateScorer?: CandidateScorer;
   llmRuntime?: LlmRuntime;
@@ -155,6 +158,10 @@ function resolveZaiApiKey(options: SearchRoutesOptions): string | undefined {
     ?? process.env.ZHIPUAI_API_KEY;
 }
 
+function resolveOpenRouterApiKey(options: SearchRoutesOptions): string | undefined {
+  return options.openRouterApiKey ?? process.env.OPENROUTER_API_KEY;
+}
+
 function searchCredentialForSource(profileType: string, options: SearchRoutesOptions): string {
   if (profileType === 'brave') {
     const apiKey = options.braveApiKey ?? process.env.BRAVE_API_KEY;
@@ -176,7 +183,17 @@ function searchCredentialForSource(profileType: string, options: SearchRoutesOpt
     return apiKey;
   }
 
-  throw new ApiError(400, 'UNSUPPORTED_SOURCE_TYPE', `source.search supports brave and zai-web profiles, not ${profileType}.`);
+  if (profileType === 'openrouter-perplexity') {
+    const apiKey = resolveOpenRouterApiKey(options);
+
+    if (!apiKey) {
+      throw new ApiError(400, 'OPENROUTER_API_KEY_REQUIRED', 'Set OPENROUTER_API_KEY before running an OpenRouter Perplexity source search.');
+    }
+
+    return apiKey;
+  }
+
+  throw new ApiError(400, 'UNSUPPORTED_SOURCE_TYPE', `source.search supports brave, zai-web, and openrouter-perplexity profiles, not ${profileType}.`);
 }
 
 async function resolveShowId(store: SourceStore, showId?: string, showSlug?: string): Promise<string> {
@@ -214,8 +231,8 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
         throw new ApiError(404, 'SOURCE_PROFILE_NOT_FOUND', `Source profile not found: ${request.params.id}`);
       }
 
-      if (profile.type !== 'brave' && profile.type !== 'zai-web') {
-        throw new ApiError(400, 'UNSUPPORTED_SOURCE_TYPE', `source.search supports brave and zai-web profiles, not ${profile.type}.`);
+      if (profile.type !== 'brave' && profile.type !== 'zai-web' && profile.type !== 'openrouter-perplexity') {
+        throw new ApiError(400, 'UNSUPPORTED_SOURCE_TYPE', `source.search supports brave, zai-web, and openrouter-perplexity profiles, not ${profile.type}.`);
       }
 
       if (!profile.enabled) {
@@ -241,6 +258,7 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
         store,
         fetchImpl: options.fetchImpl,
         zaiFetchImpl: options.zaiFetchImpl,
+        openRouterPerplexityFetchImpl: options.openRouterPerplexityFetchImpl,
         sleep: options.sleep,
         modelProfile,
         candidateScorer,

--- a/packages/api/src/shows/routes.ts
+++ b/packages/api/src/shows/routes.ts
@@ -40,10 +40,10 @@ const castSchema = z.array(z.object({
   role: z.string().trim().min(1).optional(),
   voice: z.string().trim().min(1),
 })).default([]);
-const sourceTypeSchema = z.enum(['brave', 'zai-web', 'rss', 'manual', 'local-json']);
+const sourceTypeSchema = z.enum(['brave', 'zai-web', 'openrouter-perplexity', 'rss', 'manual', 'local-json']);
 
 function supportsDiscoveryControls(type: z.infer<typeof sourceTypeSchema>) {
-  return type === 'brave' || type === 'zai-web' || type === 'rss';
+  return type === 'brave' || type === 'zai-web' || type === 'openrouter-perplexity' || type === 'rss';
 }
 
 const feedFieldsSchema = z.object({

--- a/packages/api/src/sources/routes.ts
+++ b/packages/api/src/sources/routes.ts
@@ -12,7 +12,7 @@ import type {
   UpdateSourceQueryInput,
 } from './store.js';
 
-const sourceTypeSchema = z.enum(['brave', 'zai-web', 'rss', 'manual', 'local-json']);
+const sourceTypeSchema = z.enum(['brave', 'zai-web', 'openrouter-perplexity', 'rss', 'manual', 'local-json']);
 const domainListSchema = z.array(z.string().trim().min(1)).default([]);
 const jsonObjectSchema = z.record(z.string(), z.unknown()).default({});
 const nullableTextSchema = z.string().trim().min(1).nullable().default(null);
@@ -88,7 +88,7 @@ class ApiError extends Error {
 }
 
 function supportsDiscoveryControls(type: z.infer<typeof sourceTypeSchema> | undefined): boolean {
-  return type === 'brave' || type === 'zai-web' || type === 'rss';
+  return type === 'brave' || type === 'zai-web' || type === 'openrouter-perplexity' || type === 'rss';
 }
 
 function normalizeProfileCreateInput(body: z.infer<typeof profileCreateSchema>): Omit<CreateSourceProfileInput, 'showId'> {

--- a/packages/api/src/sources/store.ts
+++ b/packages/api/src/sources/store.ts
@@ -1,4 +1,4 @@
-export type SourceType = 'brave' | 'zai-web' | 'rss' | 'manual' | 'local-json';
+export type SourceType = 'brave' | 'zai-web' | 'openrouter-perplexity' | 'rss' | 'manual' | 'local-json';
 export type ShowSetupStatus = 'draft' | 'active';
 
 export interface ShowCastMember {

--- a/packages/db/drizzle/0005_openrouter_perplexity_source_type.sql
+++ b/packages/db/drizzle/0005_openrouter_perplexity_source_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'openrouter-perplexity';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777345000000,
       "tag": "0004_zai_web_source_type",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777348600000,
+      "tag": "0005_openrouter_perplexity_source_type",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -12,7 +12,7 @@ import {
   uuid
 } from 'drizzle-orm/pg-core';
 
-export const sourceType = pgEnum('source_type', ['brave', 'zai-web', 'rss', 'manual', 'local-json']);
+export const sourceType = pgEnum('source_type', ['brave', 'zai-web', 'openrouter-perplexity', 'rss', 'manual', 'local-json']);
 export const showSetupStatus = pgEnum('show_setup_status', ['draft', 'active']);
 export const storyStatus = pgEnum('story_status', ['new', 'shortlisted', 'ignored', 'merged']);
 export const episodeCandidateStatus = pgEnum('episode_candidate_status', ['draft', 'researching', 'ready', 'rejected']);

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -17,7 +17,7 @@ type ExampleConfig = {
   };
   sources: Array<{
     id: string;
-    type: 'brave' | 'zai-web' | 'rss' | 'manual' | 'local-json';
+    type: 'brave' | 'zai-web' | 'openrouter-perplexity' | 'rss' | 'manual' | 'local-json';
     enabled: boolean;
     weight?: number;
     freshness?: string;

--- a/schemas/podcast-forge.config.schema.json
+++ b/schemas/podcast-forge.config.schema.json
@@ -34,7 +34,7 @@
         "required": ["id", "type", "enabled"],
         "properties": {
           "id": { "type": "string" },
-          "type": { "enum": ["brave", "zai-web", "rss", "manual", "local-json"] },
+          "type": { "enum": ["brave", "zai-web", "openrouter-perplexity", "rss", "manual", "local-json"] },
           "enabled": { "type": "boolean" },
           "weight": { "type": "number" },
           "freshness": { "type": "string" },

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -460,7 +460,7 @@ test('story source summaries use editorial labels and hide credential values', (
   assert.equal(zaiModel.selectedStorySourceSummary.nextActionLabel, 'Search Z.AI Web');
   assert.equal(zaiModel.selectedStorySourceSummary.credentialLabel, 'Z.AI Web Search credential configured');
   assert.match(zaiModel.selectedStorySourceSummary.inputSummary, /1 enabled search query/);
-  assert.match(zaiModel.selectedStorySourceSummary.constraintsSummary, /freshness pw/);
+  assert.match(zaiModel.selectedStorySourceSummary.constraintsSummary, /freshness Past week/);
   assert.match(zaiModel.selectedStorySourceSummary.lastSearchResult, /2 inserted, 1 skipped, 1 warning/);
 
   const braveModel = deriveProductionViewModel({


### PR DESCRIPTION
Closes #94\n\n## Summary\n- Adds an openrouter-perplexity source profile type backed by OpenRouter chat completions with Perplexity/Sonar models.\n- Uses json_schema responses, harvested URL citations, deterministic post-filtering/capping, and mocked tests only.\n- Separates requested/claimed/verified freshness metadata and expands UI freshness labels from pd/pw shorthand.\n\n## Verification\n- npm run check\n- git diff --check