### PR TITLE
Add candidate clear and ignore controls

### DIFF
--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -298,6 +298,9 @@
               <p id="candidateMeta"></p>
               <p class="help">Scores rank fit, significance, novelty, and source quality. Select related possible stories, review the source mix, then build a research brief.</p>
             </div>
+            <div class="actions inline">
+              <button id="clearCandidateQueue" class="secondary danger" type="button">Clear Queue</button>
+            </div>
           </div>
           <form id="candidateClusterForm" class="cluster-panel">
             <div class="cluster-summary">

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -38,6 +38,13 @@ button.secondary {
 button.danger {
   border-color: #9b2c2c;
   background: #b83232;
+  color: white;
+}
+
+button.secondary.danger {
+  border-color: #d6b8b8;
+  background: #fff7f7;
+  color: #9b2c2c;
 }
 
 button:disabled {

--- a/packages/api/public/ui-state.js
+++ b/packages/api/public/ui-state.js
@@ -117,6 +117,7 @@ export const els = {
   selectionCount: document.querySelector('#selectionCount'),
   selectedCandidateSummary: document.querySelector('#selectedCandidateSummary'),
   clearCandidateSelection: document.querySelector('#clearCandidateSelection'),
+  clearCandidateQueue: document.querySelector('#clearCandidateQueue'),
   selectionWarnings: document.querySelector('#selectionWarnings'),
   clusterAngle: document.querySelector('#clusterAngle'),
   clusterNotes: document.querySelector('#clusterNotes'),

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -2522,10 +2522,12 @@ function renderCandidateSelectionPanel() {
 
 function renderStoryCandidates() {
   els.candidateList.innerHTML = '';
-  els.candidateMeta.textContent = `${state.storyCandidates.length} recent candidate stor${state.storyCandidates.length === 1 ? 'y' : 'ies'}`;
+  const visibleCandidates = state.storyCandidates.filter((candidate) => candidate.status !== 'ignored');
+  els.candidateMeta.textContent = `${visibleCandidates.length} active candidate stor${visibleCandidates.length === 1 ? 'y' : 'ies'}${state.storyCandidates.length !== visibleCandidates.length ? ` (${state.storyCandidates.length - visibleCandidates.length} ignored)` : ''}`;
+  els.clearCandidateQueue.disabled = visibleCandidates.length === 0;
   renderCandidateSelectionPanel();
 
-  if (state.storyCandidates.length === 0) {
+  if (visibleCandidates.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'empty';
     empty.textContent = 'No candidate stories yet. Add search queries, import RSS items, run a scheduled pipeline, or submit a manual story URL.';
@@ -2533,7 +2535,7 @@ function renderStoryCandidates() {
     return;
   }
 
-  for (const [index, candidate] of state.storyCandidates.entries()) {
+  for (const [index, candidate] of visibleCandidates.entries()) {
     const row = document.createElement('article');
     const selected = state.selectedCandidateIds.includes(candidate.id);
     row.className = `record-row candidate-row${selected ? ' selected' : ''}`;
@@ -2619,7 +2621,15 @@ function renderStoryCandidates() {
       await createResearchBrief(candidate.id, createBrief);
     });
 
-    actions.append(select, createBrief);
+    const ignore = document.createElement('button');
+    ignore.type = 'button';
+    ignore.className = 'secondary danger';
+    ignore.textContent = 'Ignore';
+    ignore.addEventListener('click', async () => {
+      await ignoreStoryCandidate(candidate.id, ignore);
+    });
+
+    actions.append(select, createBrief, ignore);
     body.append(title, meta, facts);
     if (flags.children.length > 0) {
       body.append(flags);
@@ -4564,6 +4574,59 @@ function selectTopCandidate() {
   setStatus('Top candidate story selected for the research brief.');
 }
 
+async function ignoreStoryCandidate(candidateId, button) {
+  if (!candidateId) {
+    return;
+  }
+  const candidate = state.storyCandidates.find((item) => item.id === candidateId);
+  if (!candidate) {
+    return;
+  }
+
+  button.disabled = true;
+  try {
+    await api(`/story-candidates/${candidateId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'ignored', reason: 'Ignored from candidate review queue' }),
+    });
+    state.selectedCandidateIds = state.selectedCandidateIds.filter((id) => id !== candidateId);
+    await loadStoryCandidates();
+    render();
+    setStatus(`Ignored candidate: ${candidate.title}`);
+  } catch (error) {
+    button.disabled = false;
+    reportError(error);
+  }
+}
+
+async function clearCandidateQueue() {
+  if (!state.selectedShowSlug || state.storyCandidates.length === 0) {
+    return;
+  }
+  const activeCount = state.storyCandidates.filter((candidate) => candidate.status !== 'ignored').length;
+  if (activeCount === 0) {
+    return;
+  }
+  if (!window.confirm(`Ignore all ${activeCount} active candidate stories for this show? Existing research briefs are preserved.`)) {
+    return;
+  }
+
+  els.clearCandidateQueue.disabled = true;
+  try {
+    const body = await api('/story-candidates/clear', {
+      method: 'POST',
+      body: JSON.stringify({ showSlug: state.selectedShowSlug, reason: 'Cleared from candidate review queue' }),
+    });
+    state.selectedCandidateIds = [];
+    await loadStoryCandidates();
+    render();
+    setStatus(`Cleared ${body.updated || 0} candidate stor${body.updated === 1 ? 'y' : 'ies'} from the review queue.`);
+  } catch (error) {
+    els.clearCandidateQueue.disabled = false;
+    reportError(error);
+  }
+}
+
 function clearCandidateSelection() {
   state.selectedCandidateIds = [];
   state.episodePlan = null;
@@ -5935,6 +5998,7 @@ els.candidateClusterForm.addEventListener('submit', async (event) => {
   await buildResearchBriefFromSelected();
 });
 els.clearCandidateSelection.addEventListener('click', clearCandidateSelection);
+els.clearCandidateQueue.addEventListener('click', clearCandidateQueue);
 els.requestEpisodePlan.addEventListener('click', requestEpisodePlanForSelected);
 for (const input of [els.clusterAngle, els.clusterNotes, els.clusterFormat, els.clusterRuntime]) {
   input.addEventListener('input', syncClusterFormFromInputs);

--- a/packages/api/src/scheduler/routes.test.ts
+++ b/packages/api/src/scheduler/routes.test.ts
@@ -85,7 +85,7 @@ class FakeSchedulerStore implements SourceStore, SearchJobStore, SchedulerStore 
     discoveredAt: Date;
     score: number | null;
     scoreBreakdown: Record<string, unknown>;
-    status: 'new';
+    status: 'new' | 'shortlisted' | 'ignored' | 'merged';
     rawPayload: Record<string, unknown>;
     metadata: Record<string, unknown>;
     createdAt: Date;
@@ -240,6 +240,32 @@ class FakeSchedulerStore implements SourceStore, SearchJobStore, SchedulerStore 
     candidate.metadata = input.metadata;
     candidate.updatedAt = new Date();
     return candidate;
+  }
+
+  async updateStoryCandidateStatus(id: string, input: { status: 'new' | 'shortlisted' | 'ignored' | 'merged'; metadata?: Record<string, unknown> }) {
+    const candidate = this.candidates.find((item) => item.id === id);
+    if (!candidate) {
+      return undefined;
+    }
+    candidate.status = input.status;
+    candidate.metadata = { ...candidate.metadata, ...(input.metadata ?? {}) };
+    return candidate;
+  }
+
+  async clearStoryCandidates(input: { showId: string; sourceProfileId?: string; status?: 'ignored'; metadata?: Record<string, unknown> }) {
+    let updated = 0;
+    for (const candidate of this.candidates) {
+      if (candidate.showId !== input.showId || candidate.status === 'ignored') {
+        continue;
+      }
+      if (input.sourceProfileId && candidate.sourceProfileId !== input.sourceProfileId) {
+        continue;
+      }
+      candidate.status = input.status ?? 'ignored';
+      candidate.metadata = { ...candidate.metadata, ...(input.metadata ?? {}) };
+      updated += 1;
+    }
+    return { updated };
   }
 
   async listStoryCandidates() {

--- a/packages/api/src/search/routes.test.ts
+++ b/packages/api/src/search/routes.test.ts
@@ -227,6 +227,32 @@ class FakeSearchStore implements SourceStore, SearchJobStore {
     return candidate;
   }
 
+  async updateStoryCandidateStatus(id: string, input: { status: 'new' | 'shortlisted' | 'ignored' | 'merged'; metadata?: Record<string, unknown> }) {
+    const candidate = this.candidates.find((item) => item.id === id);
+    if (!candidate) {
+      return undefined;
+    }
+    candidate.status = input.status;
+    candidate.metadata = { ...candidate.metadata, ...(input.metadata ?? {}) };
+    return candidate;
+  }
+
+  async clearStoryCandidates(input: { showId: string; sourceProfileId?: string; status?: 'ignored'; metadata?: Record<string, unknown> }) {
+    let updated = 0;
+    for (const candidate of this.candidates) {
+      if (candidate.showId !== input.showId || candidate.status === 'ignored') {
+        continue;
+      }
+      if (input.sourceProfileId && candidate.sourceProfileId !== input.sourceProfileId) {
+        continue;
+      }
+      candidate.status = input.status ?? 'ignored';
+      candidate.metadata = { ...candidate.metadata, ...(input.metadata ?? {}) };
+      updated += 1;
+    }
+    return { updated };
+  }
+
   async listStoryCandidates(filter: StoryCandidateListFilter) {
     const candidates = this.candidates.filter((candidate) => candidate.showId === filter.showId);
     const sorted = filter.sort === 'discovered'

--- a/packages/api/src/search/routes.ts
+++ b/packages/api/src/search/routes.ts
@@ -42,6 +42,20 @@ export interface SearchRoutesOptions {
   sleep?: (ms: number) => Promise<void>;
 }
 
+const candidateStatusSchema = z.enum(['new', 'shortlisted', 'ignored', 'merged']);
+
+const candidateStatusUpdateSchema = z.object({
+  status: candidateStatusSchema,
+  reason: z.string().trim().max(500).optional(),
+});
+
+const clearCandidatesSchema = z.object({
+  showId: z.string().uuid().optional(),
+  showSlug: z.string().min(1).optional(),
+  sourceProfileId: z.string().uuid().optional(),
+  reason: z.string().trim().max(500).optional(),
+});
+
 const manualCandidateSchema = z.object({
   showId: z.string().uuid().optional(),
   showSlug: z.string().trim().min(1).optional(),
@@ -360,21 +374,68 @@ export function registerSearchRoutes(app: FastifyInstance, options: SearchRoutes
     }
   });
 
-  app.get<{ Querystring: { showId?: string; showSlug?: string; limit?: string; sort?: string } }>('/story-candidates', async (request, reply) => {
+  app.get<{ Querystring: { showId?: string; showSlug?: string; limit?: string; sort?: string; includeIgnored?: string } }>('/story-candidates', async (request, reply) => {
     try {
       const store = requireSearchStore(options.getStore());
       const showId = await resolveShowId(store, request.query.showId, request.query.showSlug);
       const parsedLimit = request.query.limit ? Number(request.query.limit) : undefined;
       const limit = parsedLimit && Number.isInteger(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
       const sort = request.query.sort ?? 'score';
+      const includeIgnored = request.query.includeIgnored === 'true';
 
       if (sort !== 'score' && sort !== 'discovered') {
         throw new ApiError(400, 'INVALID_CANDIDATE_SORT', 'Sort must be "score" or "discovered".');
       }
 
-      const candidates = await store.listStoryCandidates({ showId, limit, sort });
+      const candidates = await store.listStoryCandidates({ showId, limit, sort, includeIgnored });
 
       return { ok: true, storyCandidates: candidates };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+
+  app.patch<{ Params: { id: string } }>('/story-candidates/:id', async (request, reply) => {
+    try {
+      const store = requireSearchStore(options.getStore());
+      const body = candidateStatusUpdateSchema.parse(request.body);
+      const updated = await store.updateStoryCandidateStatus(request.params.id, {
+        status: body.status,
+        metadata: body.reason ? {
+          statusReason: body.reason,
+          statusUpdatedAt: new Date().toISOString(),
+        } : {
+          statusUpdatedAt: new Date().toISOString(),
+        },
+      });
+
+      if (!updated) {
+        throw new ApiError(404, 'CANDIDATE_NOT_FOUND', `Story candidate not found: ${request.params.id}`);
+      }
+
+      return { ok: true, candidate: updated };
+    } catch (error) {
+      return sendError(reply, error);
+    }
+  });
+
+  app.post('/story-candidates/clear', async (request, reply) => {
+    try {
+      const store = requireSearchStore(options.getStore());
+      const body = clearCandidatesSchema.parse(request.body);
+      const showId = await resolveShowId(store, body.showId, body.showSlug);
+      const result = await store.clearStoryCandidates({
+        showId,
+        sourceProfileId: body.sourceProfileId,
+        status: 'ignored',
+        metadata: {
+          clearReason: body.reason || 'Cleared from candidate review queue',
+          clearedAt: new Date().toISOString(),
+        },
+      });
+
+      return reply.code(200).send({ ok: true, updated: result.updated });
     } catch (error) {
       return sendError(reply, error);
     }

--- a/packages/api/src/search/store.ts
+++ b/packages/api/src/search/store.ts
@@ -90,6 +90,19 @@ export interface StoryCandidateListFilter {
   showId: string;
   limit?: number;
   sort?: 'score' | 'discovered';
+  includeIgnored?: boolean;
+}
+
+export interface UpdateStoryCandidateStatusInput {
+  status: 'new' | 'shortlisted' | 'ignored' | 'merged';
+  metadata?: Record<string, unknown>;
+}
+
+export interface ClearStoryCandidatesInput {
+  showId: string;
+  sourceProfileId?: string;
+  status?: 'ignored';
+  metadata?: Record<string, unknown>;
 }
 
 export interface UpdateStoryCandidateScoringInput {
@@ -106,5 +119,7 @@ export interface SearchJobStore {
   listStoryCandidateDedupeKeys(showId: string): Promise<CandidateDedupeKey[]>;
   insertStoryCandidate(input: CreateStoryCandidateInput): Promise<StoryCandidateRecord | undefined>;
   updateStoryCandidateScoring(id: string, input: UpdateStoryCandidateScoringInput): Promise<StoryCandidateRecord | undefined>;
+  updateStoryCandidateStatus(id: string, input: UpdateStoryCandidateStatusInput): Promise<StoryCandidateRecord | undefined>;
+  clearStoryCandidates(input: ClearStoryCandidatesInput): Promise<{ updated: number }>;
   listStoryCandidates(filter: StoryCandidateListFilter): Promise<StoryCandidateRecord[]>;
 }

--- a/packages/api/src/sources/db-store.ts
+++ b/packages/api/src/sources/db-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, lte, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, lte, ne, or, sql } from 'drizzle-orm';
 import {
   approvalEvents,
   createDb,
@@ -30,6 +30,8 @@ import type {
   StoryCandidateRecord,
   UpdateJobInput,
   UpdateStoryCandidateScoringInput,
+  UpdateStoryCandidateStatusInput,
+  ClearStoryCandidatesInput,
 } from '../search/store.js';
 import type {
   CreateResearchPacketInput,
@@ -169,7 +171,7 @@ function mapProfile(row: typeof sourceProfiles.$inferSelect): SourceProfileRecor
     showId: row.showId,
     slug: row.slug,
     name: row.name,
-    type: row.type,
+    type: row.type as SourceProfileRecord['type'],
     enabled: row.enabled,
     weight: Number(row.weight),
     freshness: row.freshness,
@@ -958,13 +960,52 @@ export function createDbSourceStore(connectionString = process.env.DATABASE_URL)
       return row ? mapStoryCandidate(row) : undefined;
     },
 
+    async updateStoryCandidateStatus(id: string, input: UpdateStoryCandidateStatusInput) {
+      const current = await this.getStoryCandidate(id);
+      if (!current) {
+        return undefined;
+      }
+
+      const [row] = await db.update(storyCandidates)
+        .set({
+          status: input.status,
+          metadata: { ...current.metadata, ...(input.metadata ?? {}) },
+          updatedAt: new Date(),
+        })
+        .where(eq(storyCandidates.id, id))
+        .returning();
+
+      return row ? mapStoryCandidate(row) : undefined;
+    },
+
+    async clearStoryCandidates(input: ClearStoryCandidatesInput) {
+      const filters = [eq(storyCandidates.showId, input.showId), ne(storyCandidates.status, 'ignored')];
+      if (input.sourceProfileId) {
+        filters.push(eq(storyCandidates.sourceProfileId, input.sourceProfileId));
+      }
+
+      const rows = await db.update(storyCandidates)
+        .set({
+          status: input.status ?? 'ignored',
+          metadata: sql`${storyCandidates.metadata} || ${input.metadata ?? {}}::jsonb`,
+          updatedAt: new Date(),
+        })
+        .where(and(...filters))
+        .returning({ id: storyCandidates.id });
+
+      return { updated: rows.length };
+    },
+
     async listStoryCandidates(filter: StoryCandidateListFilter) {
       const orderBy = filter.sort === 'discovered'
         ? [desc(storyCandidates.discoveredAt)]
         : [sql`${storyCandidates.score} desc nulls last`, desc(storyCandidates.discoveredAt)];
+      const where = filter.includeIgnored
+        ? eq(storyCandidates.showId, filter.showId)
+        : and(eq(storyCandidates.showId, filter.showId), ne(storyCandidates.status, 'ignored'));
       const rows = await db.select()
         .from(storyCandidates)
-        .where(eq(storyCandidates.showId, filter.showId))
+        .where(where)
         .orderBy(...orderBy)
         .limit(filter.limit ?? 50);
 

--- a/packages/api/src/sources/routes.test.ts
+++ b/packages/api/src/sources/routes.test.ts
@@ -551,6 +551,32 @@ class FakeSourceStore implements SourceStore, SearchJobStore, ResearchStore, Mod
     return candidate;
   }
 
+  async updateStoryCandidateStatus(id: string, input: { status: 'new' | 'shortlisted' | 'ignored' | 'merged'; metadata?: Record<string, unknown> }) {
+    const candidate = this.candidates.find((item) => item.id === id);
+    if (!candidate) {
+      return undefined;
+    }
+    candidate.status = input.status;
+    candidate.metadata = { ...candidate.metadata, ...(input.metadata ?? {}) };
+    return candidate;
+  }
+
+  async clearStoryCandidates(input: { showId: string; sourceProfileId?: string; status?: 'ignored'; metadata?: Record<string, unknown> }) {
+    let updated = 0;
+    for (const candidate of this.candidates) {
+      if (candidate.showId !== input.showId || candidate.status === 'ignored') {
+        continue;
+      }
+      if (input.sourceProfileId && candidate.sourceProfileId !== input.sourceProfileId) {
+        continue;
+      }
+      candidate.status = input.status ?? 'ignored';
+      candidate.metadata = { ...candidate.metadata, ...(input.metadata ?? {}) };
+      updated += 1;
+    }
+    return { updated };
+  }
+
   async listStoryCandidates(filter: StoryCandidateListFilter) {
     return this.candidates
       .filter((candidate) => candidate.showId === filter.showId)


### PR DESCRIPTION
Closes #93

## Summary
- add candidate ignore action and clear-all candidates action to the Produce Episode candidate review UI
- add API routes/store methods for ignored candidate updates and scoped candidate clearing
- hide ignored candidates from the normal candidate list by default and cover route/store behavior with tests

## Verification
- npm run check
- git diff --check