### PR TITLE
Add OpenRouter Perplexity/Sonar curated source provider and clearer freshness metadata

### DIFF
--- a/packages/api/public/ui-formatters.js
+++ b/packages/api/public/ui-formatters.js
@@ -25,7 +25,7 @@ export function sourceControlHelp(type) {
   }
 
   if (type === 'openrouter-perplexity') {
-    return 'Freshness/domain filters are requested from OpenRouter Perplexity/Sonar and enforced again after curated results return.';
+    return 'Freshness and excluded domains are requested from OpenRouter Perplexity/Sonar. Include/exclude domain filters are also enforced after curated results return.';
   }
 
   if (type === 'rss') {

--- a/packages/api/src/search/openrouter-perplexity.test.ts
+++ b/packages/api/src/search/openrouter-perplexity.test.ts
@@ -56,8 +56,7 @@ describe('OpenRouter Perplexity source provider', () => {
                       url: 'https://www.anthropic.com/news/claude-opus-4-7',
                       sourceName: 'Anthropic',
                       summary: 'Official announcement with model details.',
-                      publishedAt: '2026-04-28',
-                      freshnessConfidence: 'claimed',
+                      date: '2026-04-28',
                       citations: ['1'],
                     },
                     {
@@ -91,9 +90,33 @@ describe('OpenRouter Perplexity source provider', () => {
     assert.equal((requestBody?.response_format as { type?: string }).type, 'json_schema');
     assert.ok((requestBody?.response_format as { json_schema?: unknown }).json_schema);
     assert.equal(requestBody?.search_recency_filter, 'day');
+    assert.ok((requestBody?.messages as Array<{ content: string }>)[0].content.includes('production approval gates'));
     assert.deepEqual(candidates.map((candidate) => candidate.title), ['Anthropic ships Claude Opus 4.7']);
     assert.equal(candidates[0].publishedAt?.toISOString(), '2026-04-28T00:00:00.000Z');
     assert.deepEqual(candidates[0].metadata.freshness, { requested: 'day', confidence: 'claimed', verified: false });
     assert.deepEqual(candidates[0].metadata.citations, ['https://www.anthropic.com/news/claude-opus-4-7']);
+  });
+
+  it('accepts string search domain filters from config', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const fetchImpl: OpenRouterPerplexityFetch = async (_url, init) => {
+      requestBody = JSON.parse(init.body) as Record<string, unknown>;
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { choices: [{ message: { content: JSON.stringify({ candidates: [] }) } }] };
+        },
+      };
+    };
+
+    await searchOpenRouterPerplexity({
+      apiKey: 'test-key',
+      profile: { ...profile, config: { ...profile.config, search_domain_filter: 'example.com' } },
+      queries: [query],
+      fetchImpl,
+    });
+
+    assert.deepEqual(requestBody?.search_domain_filter, ['-example.com']);
   });
 });

--- a/packages/api/src/search/openrouter-perplexity.ts
+++ b/packages/api/src/search/openrouter-perplexity.ts
@@ -162,6 +162,7 @@ function buildPrompt(query: SourceQueryRecord, profile: SourceProfileRecord, top
     `Search query: ${query.query}`,
     `Source profile: ${profile.name}`,
     'Prefer canonical article or official announcement URLs over homepages, social posts, videos, and aggregator list pages.',
+    'This is source discovery only; do not imply editorial approval, publish readiness, or that production approval gates have been satisfied.',
     'Return JSON only matching the schema. Use null when a publication date is not available. Treat freshness as claimed unless independently verified.'
   ].join('\n');
 }

--- a/packages/api/src/search/openrouter-perplexity.ts
+++ b/packages/api/src/search/openrouter-perplexity.ts
@@ -95,8 +95,16 @@ function normalizeDeniedDomain(domain: string): string | undefined {
   return normalized ? `-${normalized}` : undefined;
 }
 
+function searchDomainFilterFor(query: SourceQueryRecord, profile: SourceProfileRecord): string[] {
+  const configured = option(query, profile, 'search_domain_filter');
+  const configuredArray = asStringArray(configured);
+  if (configuredArray.length > 0) return configuredArray;
+  const configuredString = asString(configured);
+  return configuredString ? [configuredString] : [];
+}
+
 function denyDomainsFor(query: SourceQueryRecord, profile: SourceProfileRecord): string[] {
-  const configured = asStringArray(option(query, profile, 'search_domain_filter'));
+  const configured = searchDomainFilterFor(query, profile);
   const domains = configured.length > 0 ? configured : [...DEFAULT_DENY_DOMAINS, ...profile.excludeDomains, ...query.excludeDomains];
   return [...new Set(domains.map(normalizeDeniedDomain).filter((domain): domain is string => Boolean(domain)))];
 }
@@ -215,19 +223,20 @@ function mapCandidate(item: JsonObject, query: SourceQueryRecord, profile: Sourc
     ...asStringArray(item.evidenceUrls),
     ...(Array.isArray(item.__annotations) ? item.__annotations.map(asObject).map((citation) => asString(citation.url)).filter((value): value is string => Boolean(value)) : []),
   ].filter(isHttpUrl);
+  const publishedAt = parsePublishedAt(item.publishedAt ?? item.date ?? item.publicationDate);
   return {
     title: cleanText(title),
     url,
     canonicalUrl: canonicalizeUrl(url),
     sourceName: asString(item.sourceName) ?? asString(item.source) ?? hostname(url),
     summary: asString(item.summary) ?? asString(item.rationale) ?? null,
-    publishedAt: parsePublishedAt(item.publishedAt ?? item.date ?? item.publicationDate),
+    publishedAt,
     rawPayload: item,
     metadata: {
       provider: 'openrouter-perplexity',
       freshness: {
         requested: search.recency ?? null,
-        confidence: asString(item.freshnessConfidence) ?? (parsePublishedAt(item.publishedAt) ? 'claimed' : 'unknown'),
+        confidence: asString(item.freshnessConfidence) ?? (publishedAt ? 'claimed' : 'unknown'),
         verified: false,
       },
       citations: [...new Set(citations)],


### PR DESCRIPTION
Closes #94

## Summary
- add an OpenRouter-backed Perplexity/Sonar source provider that returns curated, normalized story candidates
- improve freshness labeling so the UI distinguishes requested freshness from verified publication dates
- cover provider normalization and UI freshness behavior with mocked tests only

## Verification
- npm run check
- git diff --check
