### PR TITLE
PFI-02: Add Produce Episode cockpit header

### DIFF
--- a/packages/api/public/index.html
+++ b/packages/api/public/index.html
@@ -46,7 +46,7 @@
       </aside>
 
       <section class="workspace" aria-label="Production workflow and settings panels">
-        <section id="productionCommandBar" class="production-command-bar" data-surface="workflow" aria-label="Production command bar"></section>
+        <section id="productionCommandBar" class="production-command-bar production-cockpit-header" data-surface="workflow" aria-label="Produce Episode cockpit header"></section>
 
         <section id="workflowPanel" class="panel pipeline-panel" data-surface="workflow" aria-labelledby="pipelineTitle">
           <div class="panel-heading">

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -245,6 +245,7 @@ button:disabled {
 
 .command-bar-kicker,
 .command-bar-metric span,
+.command-bar-story-label,
 .command-bar-result span {
   color: #687486;
   font-size: 0.76rem;
@@ -254,6 +255,7 @@ button:disabled {
 
 .command-bar-context h2,
 .command-bar-context p,
+.command-bar-story strong,
 .command-bar-result strong,
 .command-bar-blocker {
   margin: 0;
@@ -267,12 +269,33 @@ button:disabled {
 }
 
 .command-bar-context p,
+.command-bar-story strong,
 .command-bar-result strong,
 .command-bar-blocker {
   color: #3f4b5a;
   font-size: 0.9rem;
   line-height: 1.35;
   overflow-wrap: anywhere;
+}
+
+.command-bar-story {
+  align-items: baseline;
+  display: flex;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.command-bar-story-label {
+  flex: 0 0 auto;
+}
+
+.command-bar-story-title {
+  min-width: 0;
+}
+
+.command-bar-story-detail {
+  color: #687486;
+  font-size: 0.82rem;
 }
 
 .command-bar-metrics {
@@ -2004,16 +2027,35 @@ textarea {
   }
 
   .command-bar-kicker,
-  .command-bar-context p,
+  .command-bar-story-detail,
   .command-bar-result,
   .command-bar-details,
   .command-bar-blocker:not(.visible) {
     display: none;
   }
 
+  .command-bar-story {
+    gap: 0.25rem;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .command-bar-story-label {
+    font-size: 0.58rem;
+  }
+
+  .command-bar-story-title {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .command-bar-context h2 {
     font-size: 0.95rem;
     line-height: 1.15;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .command-bar-metrics {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -935,6 +935,132 @@ function deriveWarningsAndBlockers({
   return { warnings, blockers };
 }
 
+function stageStatusLabel(status) {
+  return {
+    blocked: 'blocked',
+    done: 'complete',
+    'needs-review': 'needs review',
+    ready: 'ready',
+    running: 'running',
+  }[status] || status || 'not started';
+}
+
+function artifactStatusLabel(status) {
+  return {
+    'approved-for-audio': 'approved for audio',
+    'approved-for-publish': 'approved for publishing',
+    'audio-ready': 'audio and cover ready',
+    blocked: 'blocked',
+    draft: 'draft',
+    failed: 'failed',
+    'needs_more_sources': 'needs more sources',
+    published: 'published',
+    ready: 'ready',
+    succeeded: 'complete',
+  }[status] || status || 'not started';
+}
+
+function cockpitEpisodeStory({ activeEpisode, selectedCandidates, activeBrief, activeScript }) {
+  const episode = summarizeEpisode(activeEpisode);
+  if (episode) {
+    return {
+      label: 'Current episode',
+      title: episode.title,
+      detail: episode.status ? `Episode state: ${artifactStatusLabel(episode.status)}` : 'Episode record selected for this production path.',
+      kind: 'episode',
+    };
+  }
+
+  const candidate = summarizeCandidate(selectedCandidates[0]);
+  if (candidate) {
+    return {
+      label: 'Current story',
+      title: candidate.title,
+      detail: firstPresent(candidate.sourceName, candidate.url, 'Candidate story selected for this episode.'),
+      kind: 'story',
+    };
+  }
+
+  const brief = summarizeBrief(activeBrief);
+  if (brief) {
+    return {
+      label: 'Current research brief',
+      title: brief.title,
+      detail: `Research brief state: ${artifactStatusLabel(brief.status)}`,
+      kind: 'brief',
+    };
+  }
+
+  const script = summarizeScript(activeScript);
+  if (script) {
+    return {
+      label: 'Current script',
+      title: script.title,
+      detail: `Script state: ${artifactStatusLabel(script.status)}`,
+      kind: 'script',
+    };
+  }
+
+  return {
+    label: 'Current episode/story',
+    title: 'No active episode or story yet',
+    detail: 'Select a candidate story to define the episode focus.',
+    kind: 'empty',
+  };
+}
+
+function deriveCockpitHeader({
+  selectedShow,
+  selectedCandidates,
+  activeBrief,
+  activeScript,
+  activeEpisode,
+  currentStage,
+  warnings,
+  blockers,
+  primaryNextAction,
+  latestActionResult,
+}) {
+  const result = latestActionResult || {
+    status: 'idle',
+    title: 'Latest result',
+    message: 'No action result recorded yet.',
+    conciseMessage: 'No action result recorded yet.',
+  };
+
+  return {
+    selectedShow: summarizeShow(selectedShow) || {
+      title: 'No show selected',
+    },
+    currentEpisodeStory: cockpitEpisodeStory({
+      activeEpisode,
+      selectedCandidates,
+      activeBrief,
+      activeScript,
+    }),
+    activeStage: {
+      id: currentStage?.id || 'show',
+      label: currentStage?.label || 'Choose show',
+      status: currentStage?.status || 'blocked',
+      statusLabel: stageStatusLabel(currentStage?.status),
+    },
+    blockerCount: blockers.length,
+    warningCount: warnings.length,
+    blockerSummary: blockers[0]?.message || '',
+    latestResult: {
+      id: result.id || 'latest-result',
+      title: result.title || (['error', 'failed'].includes(result.status) ? 'Latest failure' : 'Latest result'),
+      status: result.status || 'idle',
+      message: result.conciseMessage || result.message || 'No action result recorded yet.',
+      nextStep: result.nextStep || '',
+    },
+    primaryNextAction: {
+      ...primaryNextAction,
+      disabledReason: primaryNextAction?.enabled ? '' : primaryNextAction?.blockerReason || blockers[0]?.message || 'The current workflow state blocks this action.',
+    },
+  };
+}
+
 function deriveHistoricalArtifacts({ activeIds, packets, scripts, revisions, assets, episodes }) {
   return {
     briefs: newest(packets).filter((packet) => packet.id !== activeIds.briefId).map((packet) => markArtifact(summarizeBrief(packet), 'archive')),
@@ -1080,6 +1206,18 @@ export function deriveProductionViewModel(input = {}) {
     selectedCandidates,
     inactiveSelectedArtifacts,
   });
+  const cockpitHeader = deriveCockpitHeader({
+    selectedShow,
+    selectedCandidates,
+    activeBrief,
+    activeScript,
+    activeEpisode,
+    currentStage,
+    warnings,
+    blockers,
+    primaryNextAction,
+    latestActionResult: workflowActionFeedback,
+  });
 
   return {
     selectedShowSummary: summarizeShow(selectedShow),
@@ -1099,6 +1237,7 @@ export function deriveProductionViewModel(input = {}) {
     primaryNextAction,
     secondaryActions,
     navigationActions,
+    cockpitHeader,
     latestActionResult: workflowActionFeedback,
     workflowActionFeedback,
     warnings,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1572,23 +1572,30 @@ function renderProductionCommandBar(viewModel, stages) {
     return;
   }
 
-  const action = viewModel.primaryNextAction;
+  const header = viewModel.cockpitHeader || {};
+  const action = header.primaryNextAction || viewModel.primaryNextAction;
   const actionTarget = commandBarActionTarget(action, stages);
   const actionTargetBlocked = Boolean(actionTarget.disabled);
   const actionBlocked = !action.enabled || actionTargetBlocked;
-  const blockerReason = action.blockerReason
+  const blockerReason = action.disabledReason
+    || action.blockerReason
     || (actionTargetBlocked ? actionTarget.actionReason || actionTarget.blockers?.[0] || 'Wait for the current stage action to finish.' : '')
-    || viewModel.blockers[0]?.message
+    || header.blockerSummary
     || '';
   const detailsTarget = commandBarDetailsTarget(viewModel.currentStage.id, stages);
-  const warningCount = viewModel.warnings.length;
-  const blockerCount = viewModel.blockers.length;
-  const result = viewModel.latestActionResult || viewModel.workflowActionFeedback || { status: 'idle', message: 'No action result recorded yet.' };
-  const sourceSummary = viewModel.selectedStorySourceSummary;
-  const showTitle = viewModel.selectedShowSummary?.title || 'No show selected';
-  const episodeTitle = viewModel.activeDraftEpisodeSummary?.title
-    || viewModel.activeArtifacts?.publishing?.title
-    || 'No active episode yet';
+  const warningCount = header.warningCount ?? viewModel.warnings.length;
+  const blockerCount = header.blockerCount ?? viewModel.blockers.length;
+  const result = header.latestResult || viewModel.latestActionResult || viewModel.workflowActionFeedback || { status: 'idle', message: 'No action result recorded yet.' };
+  const showTitle = header.selectedShow?.title || viewModel.selectedShowSummary?.title || 'No show selected';
+  const episodeStory = header.currentEpisodeStory || {
+    label: 'Current episode/story',
+    title: viewModel.activeDraftEpisodeSummary?.title || viewModel.activeArtifacts?.publishing?.title || 'No active episode or story yet',
+    detail: '',
+  };
+  const activeStage = header.activeStage || {
+    label: viewModel.currentStage.label,
+    statusLabel: commandBarStatusLabel(viewModel.currentStage.status),
+  };
   const blockerId = 'production-command-blocker';
   const resultId = 'production-command-result';
 
@@ -1596,19 +1603,28 @@ function renderProductionCommandBar(viewModel, stages) {
   context.className = 'command-bar-context';
   const kicker = document.createElement('span');
   kicker.className = 'command-bar-kicker';
-  kicker.textContent = 'Producing';
+  kicker.textContent = 'Selected show';
   const heading = document.createElement('h2');
   heading.textContent = showTitle;
-  const episode = document.createElement('p');
-  episode.textContent = episodeTitle;
-  context.append(kicker, heading, episode);
+  const story = document.createElement('p');
+  story.className = 'command-bar-story';
+  const storyLabel = document.createElement('span');
+  storyLabel.className = 'command-bar-story-label';
+  storyLabel.textContent = episodeStory.label;
+  const storyTitle = document.createElement('strong');
+  storyTitle.className = 'command-bar-story-title';
+  storyTitle.textContent = episodeStory.title;
+  story.append(storyLabel, storyTitle);
+  const storyDetail = document.createElement('p');
+  storyDetail.className = 'command-bar-story-detail';
+  storyDetail.textContent = episodeStory.detail || '';
+  context.append(kicker, heading, story, storyDetail);
 
   const metrics = document.createElement('div');
   metrics.className = 'command-bar-metrics';
-  appendCommandBarMetric(metrics, 'Stage', `${viewModel.currentStage.label} | ${commandBarStatusLabel(viewModel.currentStage.status)}`);
-  appendCommandBarMetric(metrics, 'Story source', sourceSummary ? `${sourceSummary.providerType} | ${sourceSummary.statusLabel}` : 'Choose source');
-  appendCommandBarMetric(metrics, 'Warnings', String(warningCount), warningCount > 0 ? 'warning' : '');
+  appendCommandBarMetric(metrics, 'Active stage', `${activeStage.label} | ${activeStage.statusLabel}`);
   appendCommandBarMetric(metrics, 'Blockers', String(blockerCount), blockerCount > 0 ? 'blocked' : '');
+  appendCommandBarMetric(metrics, 'Warnings', String(warningCount), warningCount > 0 ? 'warning' : '');
 
   const feedback = document.createElement('div');
   feedback.className = `command-bar-result ${statusClass(result.status || 'idle')}`;
@@ -1617,9 +1633,9 @@ function renderProductionCommandBar(viewModel, stages) {
   feedback.setAttribute('aria-live', 'polite');
   feedback.setAttribute('aria-atomic', 'true');
   const feedbackLabel = document.createElement('span');
-  feedbackLabel.textContent = result.status === 'error' || result.status === 'failed' ? 'Latest failure' : 'Latest result';
+  feedbackLabel.textContent = result.title || (result.status === 'error' || result.status === 'failed' ? 'Latest failure' : 'Latest result');
   const feedbackMessage = document.createElement('strong');
-  feedbackMessage.textContent = result.conciseMessage || result.message || 'No action result recorded yet.';
+  feedbackMessage.textContent = result.message || result.conciseMessage || 'No action result recorded yet.';
   feedback.append(feedbackLabel, feedbackMessage);
 
   const controls = document.createElement('div');
@@ -1630,6 +1646,7 @@ function renderProductionCommandBar(viewModel, stages) {
   primary.dataset.commandControl = 'primary';
   primary.textContent = action.label;
   primary.setAttribute('aria-describedby', actionBlocked ? blockerId : resultId);
+  primary.setAttribute('aria-disabled', actionBlocked ? 'true' : 'false');
   primary.disabled = actionBlocked;
   primary.title = actionBlocked && blockerReason ? blockerReason : '';
   primary.addEventListener('click', () => {
@@ -1655,7 +1672,7 @@ function renderProductionCommandBar(viewModel, stages) {
   blocker.textContent = actionBlocked
     ? `Blocked: ${blockerReason || 'the current workflow state blocks this action.'}`
     : blockerCount > 0
-      ? `Current blocker: ${viewModel.blockers[0].message}`
+      ? `Current blocker: ${header.blockerSummary || viewModel.blockers[0].message}`
       : 'Primary action is available.';
   els.productionCommandBar.append(context, metrics, feedback, controls, blocker);
   if (activeCommandControl) {

--- a/scripts/ui-complexity-smoke.test.mjs
+++ b/scripts/ui-complexity-smoke.test.mjs
@@ -134,17 +134,18 @@ function expandedStageControls(stageId, viewModel) {
 
 function renderNormalProduceSnapshot(viewModel) {
   const currentStageId = trackerStageIdForViewModel(viewModel);
+  const header = viewModel.cockpitHeader;
+  const episodeStory = header.currentEpisodeStory;
   const commandBarControls = [
     viewModel.primaryNextAction.label,
     'Review current stage',
   ];
   const labels = [
-    'Production command bar',
-    'Producing',
-    viewModel.selectedShowSummary?.title || 'No show selected',
-    viewModel.activeArtifacts?.publishing?.title || 'No active episode yet',
-    `Stage ${viewModel.currentStage.label} | ${viewModel.currentStage.status}`,
-    'Story source',
+    'Produce Episode cockpit header',
+    'Selected show',
+    header.selectedShow?.title || 'No show selected',
+    episodeStory.title,
+    `Active stage ${header.activeStage.label} | ${header.activeStage.statusLabel}`,
     'Warnings',
     'Blockers',
     'Latest result',
@@ -152,19 +153,18 @@ function renderNormalProduceSnapshot(viewModel) {
   ];
 
   const commandBarHtml = `
-    <section id="productionCommandBar" class="production-command-bar" aria-label="Production command bar">
+    <section id="productionCommandBar" class="production-command-bar production-cockpit-header" aria-label="Produce Episode cockpit header">
       <div class="command-bar-context">
-        <span>Producing</span>
-        <h2>${escapeHtml(viewModel.selectedShowSummary?.title || 'No show selected')}</h2>
-        <p>${escapeHtml(viewModel.activeArtifacts?.publishing?.title || 'No active episode yet')}</p>
+        <span>Selected show</span>
+        <h2>${escapeHtml(header.selectedShow?.title || 'No show selected')}</h2>
+        <p><span>${escapeHtml(episodeStory.label)}</span><strong>${escapeHtml(episodeStory.title)}</strong></p>
       </div>
       <div class="command-bar-metrics">
-        <div><span>Stage</span><strong>${escapeHtml(viewModel.currentStage.label)} | ${escapeHtml(viewModel.currentStage.status)}</strong></div>
-        <div><span>Story source</span><strong>${escapeHtml(viewModel.selectedStorySourceSummary?.providerType || 'Choose source')}</strong></div>
-        <div><span>Warnings</span><strong>${viewModel.warnings.length}</strong></div>
-        <div><span>Blockers</span><strong>${viewModel.blockers.length}</strong></div>
+        <div><span>Active stage</span><strong>${escapeHtml(header.activeStage.label)} | ${escapeHtml(header.activeStage.statusLabel)}</strong></div>
+        <div><span>Blockers</span><strong>${header.blockerCount}</strong></div>
+        <div><span>Warnings</span><strong>${header.warningCount}</strong></div>
       </div>
-      <div class="command-bar-result" role="status"><span>Latest result</span><strong>${escapeHtml(viewModel.latestActionResult.conciseMessage || viewModel.latestActionResult.message || 'No action result recorded yet.')}</strong></div>
+      <div class="command-bar-result" role="status"><span>${escapeHtml(header.latestResult.title)}</span><strong>${escapeHtml(header.latestResult.message)}</strong></div>
       <div class="command-bar-controls">
         ${commandBarControls.map((label) => `<button type="button">${escapeHtml(label)}</button>`).join('')}
       </div>

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -48,7 +48,7 @@ test('guided workflow shell stays primary on /ui', () => {
   assertContains(indexHtml, 'id="pipelineStages"', 'pipeline stage container');
   assertContains(indexHtml, 'id="workflowContext"', 'workflow context');
   assertContains(indexHtml, 'id="productionCommandBar"', 'production command bar');
-  assertContains(indexHtml, 'Production command bar', 'production command bar label');
+  assertContains(indexHtml, 'Produce Episode cockpit header', 'production cockpit header label');
   assertMatches(indexHtml, /8-stage journey/i, 'workflow should describe the 8-stage journey');
 
   assert.ok(
@@ -156,18 +156,26 @@ test('stage tracker progressively discloses only the current stage by default', 
 });
 
 test('production command bar and concrete blocker copy remain present', () => {
+  assertContains(indexHtml, 'Produce Episode cockpit header', 'cockpit header label');
+  assertContains(indexHtml, 'production-cockpit-header', 'cockpit header class');
   assertContains(uiJs, 'function renderProductionCommandBar(viewModel, stages)', 'production command bar renderer');
+  assertContains(uiJs, 'viewModel.cockpitHeader', 'command bar should render cockpit header view model');
   assertContains(uiJs, 'viewModel.primaryNextAction', 'command bar primary action from view model');
   assertContains(uiJs, 'viewModel.latestActionResult', 'command bar latest result from view model');
   assertContains(uiJs, 'viewModel.workflowActionFeedback', 'command bar workflow feedback from view model');
   assertContains(uiJs, "viewModel.workflowActionFeedback.status !== 'idle'", 'idle workflow feedback should not render as a persistent panel');
   assertContains(uiJs, 'viewModel.warnings.length', 'command bar warning count from view model');
   assertContains(uiJs, 'action: legacyStage?.disabled ? null : legacyStage?.action || null', 'command bar primary action should invoke available stage actions');
-  assertContains(uiJs, 'commandBarStatusLabel(viewModel.currentStage.status)', 'command bar stage status should stay aligned to the view model');
+  assertContains(uiJs, "appendCommandBarMetric(metrics, 'Active stage'", 'cockpit header should show active stage');
+  assertContains(uiJs, "appendCommandBarMetric(metrics, 'Blockers'", 'cockpit header should show blocker count');
+  assertContains(uiJs, "appendCommandBarMetric(metrics, 'Warnings'", 'cockpit header should show warning count');
   assertContains(uiJs, 'openCommandBarPanel', 'command bar details should open hidden panels before scrolling');
   assertContains(uiJs, 'primary.disabled = actionBlocked', 'blocked command bar action disabled state');
+  assertContains(uiJs, "primary.setAttribute('aria-disabled', actionBlocked ? 'true' : 'false')", 'blocked command bar action disabled semantics');
+  assertContains(uiJs, 'action.disabledReason', 'blocked command bar action should explain disabled reason');
   assertContains(uiJs, "viewModel.activeArtifacts?.publishing?.title", 'command bar published episode fallback');
-  assertContains(uiJs, 'No active episode yet', 'command bar active episode fallback');
+  assertContains(uiJs, 'No active episode or story yet', 'command bar active episode/story fallback');
+  assertContains(uiJs, 'command-bar-story', 'cockpit header should show current episode or story');
   assertContains(uiJs, "dataset.commandControl", 'command bar focus restoration control marker');
   assertContains(uiJs, 'Latest failure', 'command bar failure summary label');
   assertContains(uiJs, 'Review current stage', 'command bar stage details button');
@@ -178,6 +186,7 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(stylesCss, '.workflow-feedback-panel.warning', 'workflow feedback warning style');
   assertContains(stylesCss, '.workflow-feedback-panel.blocked', 'workflow feedback blocked style');
   assertContains(stylesCss, '.workflow-feedback-details pre', 'workflow feedback detail style');
+  assertContains(stylesCss, '.command-bar-story-detail', 'cockpit header story detail styles');
   assertContains(uiJs, 'function checklistBlockers(checklist', 'checklist blocker helper');
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
   assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should render in workflow context');

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -291,6 +291,34 @@ test('view model covers candidate selected with no research brief', () => {
   assert.equal(model.primaryNextAction.enabled, true);
 });
 
+test('view model exposes Produce Episode cockpit header context', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [],
+    recentJobs: [{
+      id: 'job-search-ok',
+      type: 'source.search',
+      status: 'succeeded',
+      output: { inserted: 2, skipped: 0 },
+      updatedAt: '2026-04-28T12:00:00.000Z',
+    }],
+    latestActionResult: { status: '', message: '', source: 'test' },
+  }));
+
+  assert.equal(model.cockpitHeader.selectedShow.title, 'Demo Show');
+  assert.equal(model.cockpitHeader.currentEpisodeStory.label, 'Current story');
+  assert.equal(model.cockpitHeader.currentEpisodeStory.title, 'Regulators publish new AI safety guidance');
+  assert.equal(model.cockpitHeader.activeStage.label, 'Build research brief');
+  assert.equal(model.cockpitHeader.activeStage.statusLabel, 'ready');
+  assert.equal(model.cockpitHeader.blockerCount, 0);
+  assert.equal(model.cockpitHeader.warningCount, 0);
+  assert.equal(model.cockpitHeader.latestResult.title, 'Latest result');
+  assert.match(model.cockpitHeader.latestResult.message, /Source search succeeded/);
+  assert.equal(model.cockpitHeader.primaryNextAction.label, 'Build research brief');
+  assert.equal(model.cockpitHeader.primaryNextAction.disabledReason, '');
+});
+
 test('view model blocks drafting while research warnings are unresolved', () => {
   const model = deriveProductionViewModel(baseInput({
     storyCandidates: [candidate],
@@ -659,6 +687,10 @@ test('view model covers publish blocked with concrete blocker reason', () => {
   assert.equal(model.primaryNextAction.label, 'Approve for publishing');
   assert.equal(model.primaryNextAction.enabled, false);
   assert.match(model.primaryNextAction.blockerReason, /Feed metadata configured/);
+  assert.equal(model.cockpitHeader.currentEpisodeStory.label, 'Current episode');
+  assert.equal(model.cockpitHeader.currentEpisodeStory.title, 'AI safety guidance episode');
+  assert.equal(model.cockpitHeader.blockerCount > 0, true);
+  assert.match(model.cockpitHeader.primaryNextAction.disabledReason, /Feed metadata configured/);
   assert.ok(model.blockers.some((blocker) => blocker.stage === 'publishing'));
 });
 


### PR DESCRIPTION
Closes #104

## Summary
- Add a Produce Episode cockpit header view-model slice with selected show, current episode/story, active stage, blocker/warning counts, latest result, and primary next action state.
- Render the existing sticky command surface from that cockpit header with editorial copy and visible disabled-action blocker reasons.
- Keep the mobile header compact with inline story context and chip-style stage/blocker/warning metrics.

## Verification
- npm run check