### PR TITLE
PFI-03: Focus Produce Episode stage navigation

### DIFF
--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -462,6 +462,48 @@ button:disabled {
   margin: 0;
 }
 
+.audit-history-disclosure {
+  background: #f8fafc;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  grid-column: 1 / -1;
+  padding: 0.65rem 0.75rem;
+}
+
+.audit-history-disclosure.has-history-warnings {
+  background: #fbfaf1;
+  border-color: #d8cf73;
+}
+
+.audit-history-disclosure summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.audit-history-disclosure summary span {
+  color: #687486;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.audit-history-disclosure summary strong {
+  color: #27303b;
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+.audit-history-disclosure p {
+  color: #3f4b5a;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  margin: 0.55rem 0 0;
+}
+
 .artifact-scope-warning-list {
   display: grid;
   gap: 0.25rem;
@@ -478,6 +520,24 @@ button:disabled {
   font-size: 0.95rem;
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.audit-history-counts {
+  display: grid;
+  gap: 0.25rem 0.75rem;
+  grid-template-columns: minmax(8rem, max-content) minmax(0, 1fr);
+  margin: 0.55rem 0 0;
+}
+
+.audit-history-counts dt,
+.audit-history-counts dd {
+  color: #3f4b5a;
+  font-size: 0.86rem;
+  margin: 0;
+}
+
+.audit-history-counts dt {
+  font-weight: 700;
 }
 
 .workflow-feedback-panel {

--- a/packages/api/public/ui-state.js
+++ b/packages/api/public/ui-state.js
@@ -55,6 +55,7 @@ export const state = {
   activeSurface: 'workflow',
   activeSettingsTab: 'shows',
   expandedPipelineStageIds: [],
+  currentPipelineStageId: '',
   showSetupOpen: false,
   runningActions: {},
 };

--- a/packages/api/public/ui-state.js
+++ b/packages/api/public/ui-state.js
@@ -56,6 +56,7 @@ export const state = {
   activeSettingsTab: 'shows',
   expandedPipelineStageIds: [],
   currentPipelineStageId: '',
+  auditHistoryOpen: false,
   showSetupOpen: false,
   runningActions: {},
 };

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -885,7 +885,6 @@ function deriveWarningsAndBlockers({
   jobs,
   checklist,
   selectedCandidates,
-  inactiveSelectedArtifacts = [],
 }) {
   const warnings = [];
   const blockers = [];
@@ -921,15 +920,6 @@ function deriveWarningsAndBlockers({
       const target = checklistStage(item.key);
       blockers.push(warningItem(target, `${item.label}: ${item.reason}`, item, 'error'));
     }
-  }
-
-  for (const item of inactiveSelectedArtifacts) {
-    warnings.push(warningItem(
-      item.stage || 'production',
-      item.message || 'Loaded artifact is not part of current production.',
-      item.source || null,
-      'warning',
-    ));
   }
 
   return { warnings, blockers };

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -1194,7 +1194,6 @@ export function deriveProductionViewModel(input = {}) {
     jobs,
     checklist,
     selectedCandidates,
-    inactiveSelectedArtifacts,
   });
   const cockpitHeader = deriveCockpitHeader({
     selectedShow,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -2087,6 +2087,10 @@ function renderAuditHistoryDisclosure(viewModel) {
   const archiveCount = archiveEntries.reduce((total, [, items]) => total + items.length, 0);
   const details = document.createElement('details');
   details.className = `audit-history-disclosure${scopeWarnings.length > 0 ? ' has-history-warnings' : ''}`;
+  details.open = Boolean(state.auditHistoryOpen);
+  details.addEventListener('toggle', () => {
+    state.auditHistoryOpen = details.open;
+  });
 
   const summary = document.createElement('summary');
   const summaryLabel = document.createElement('span');

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1460,6 +1460,13 @@ function pruneExpandedPipelineStages(stages) {
   state.expandedPipelineStageIds = state.expandedPipelineStageIds.filter((stageId) => stageIds.has(stageId));
 }
 
+function syncCurrentPipelineStage(currentStageId) {
+  if (state.currentPipelineStageId && state.currentPipelineStageId !== currentStageId) {
+    state.expandedPipelineStageIds = [];
+  }
+  state.currentPipelineStageId = currentStageId;
+}
+
 function setPipelineStageExpanded(stageId, expanded) {
   const expandedIds = new Set(state.expandedPipelineStageIds);
   if (expanded) {
@@ -1756,11 +1763,14 @@ function renderWorkflowFeedbackPanel(feedback, { compact = false } = {}) {
 function stageCard(stage, currentStageId = '') {
   const statusLabel = stageStatusLabel(stage);
   const expanded = pipelineStageIsExpanded(stage, currentStageId);
+  const titleId = `pipeline-stage-title-${stage.id}`;
+  const bodyId = `pipeline-stage-body-${stage.id}`;
   const card = document.createElement('article');
   card.className = `pipeline-card ${statusClass(statusLabel)}${expanded ? ' expanded' : ' collapsed'}${stage.id === currentStageId ? ' current' : ''}`;
   card.dataset.stage = String(stage.number);
   card.dataset.stageId = stage.id;
   card.dataset.stageStatus = statusLabel;
+  card.setAttribute('aria-labelledby', titleId);
 
   const top = document.createElement('div');
   top.className = 'pipeline-top';
@@ -1769,10 +1779,12 @@ function stageCard(stage, currentStageId = '') {
   step.className = 'pipeline-step';
   step.textContent = `Stage ${stage.number}`;
   const title = document.createElement('h3');
+  title.id = titleId;
   title.textContent = stage.title;
   heading.append(step, title);
   const status = document.createElement('span');
   status.className = `status-pill ${statusClass(statusLabel)}`;
+  status.setAttribute('aria-label', `Status: ${statusLabel}`);
   status.textContent = statusLabel;
   top.append(heading, status);
   if (stage.id === currentStageId) {
@@ -1799,14 +1811,20 @@ function stageCard(stage, currentStageId = '') {
     expandButton.className = 'secondary pipeline-expand';
     expandButton.textContent = 'Expand stage';
     expandButton.setAttribute('aria-expanded', 'false');
+    expandButton.setAttribute('aria-controls', bodyId);
     expandButton.setAttribute('aria-label', `Expand ${stage.title}`);
     expandButton.addEventListener('click', () => setPipelineStageExpanded(stage.id, true));
-    card.append(expandButton);
+    const collapsedBody = document.createElement('div');
+    collapsedBody.className = 'pipeline-card-body';
+    collapsedBody.id = bodyId;
+    collapsedBody.hidden = true;
+    card.append(expandButton, collapsedBody);
     return card;
   }
 
   const body = document.createElement('div');
   body.className = 'pipeline-card-body';
+  body.id = bodyId;
 
   const artifacts = document.createElement('div');
   artifacts.className = 'pipeline-artifacts';
@@ -1898,6 +1916,7 @@ function stageCard(stage, currentStageId = '') {
     collapseButton.className = 'secondary pipeline-expand';
     collapseButton.textContent = 'Collapse stage';
     collapseButton.setAttribute('aria-expanded', 'true');
+    collapseButton.setAttribute('aria-controls', bodyId);
     collapseButton.setAttribute('aria-label', `Collapse ${stage.title}`);
     collapseButton.addEventListener('click', () => setPipelineStageExpanded(stage.id, false));
     body.append(collapseButton);
@@ -2047,6 +2066,67 @@ function renderStorySourceSummary(summary) {
 
   panel.append(header, metrics, action);
   return panel;
+}
+
+function archiveArtifactGroupLabel(key) {
+  return {
+    briefs: 'Research briefs',
+    scripts: 'Script drafts',
+    reviews: 'Integrity reviews',
+    audioCover: 'Audio and cover assets',
+    publishing: 'Publishing records',
+  }[key] || key;
+}
+
+function renderAuditHistoryDisclosure(viewModel) {
+  const scopeWarnings = asArray(viewModel.artifactScopeWarnings);
+  const archiveCounts = viewModel.historicalArtifacts || {};
+  const archiveEntries = Object.entries(archiveCounts)
+    .map(([key, items]) => [key, asArray(items)])
+    .filter(([, items]) => items.length > 0);
+  const archiveCount = archiveEntries.reduce((total, [, items]) => total + items.length, 0);
+  const details = document.createElement('details');
+  details.className = `audit-history-disclosure${scopeWarnings.length > 0 ? ' has-history-warnings' : ''}`;
+
+  const summary = document.createElement('summary');
+  const summaryLabel = document.createElement('span');
+  summaryLabel.textContent = 'Audit/history';
+  const summaryText = document.createElement('strong');
+  summaryText.textContent = scopeWarnings.length > 0
+    ? `${scopeWarnings.length} archive notice${scopeWarnings.length === 1 ? '' : 's'}, ${archiveCount} history artifact${archiveCount === 1 ? '' : 's'}`
+    : archiveCount > 0 ? `${archiveCount} history/archive artifact${archiveCount === 1 ? '' : 's'} kept out of active state` : 'No history/archive artifacts on this path';
+  summary.append(summaryLabel, summaryText);
+
+  const detail = document.createElement('p');
+  detail.textContent = 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.';
+  details.append(summary, detail);
+
+  if (scopeWarnings.length > 0) {
+    const warningList = document.createElement('div');
+    warningList.className = 'artifact-scope-warning-list';
+    warningList.setAttribute('aria-label', 'Archive notices');
+    scopeWarnings.forEach((warning) => {
+      const warningItem = document.createElement('p');
+      warningItem.textContent = warning.message;
+      warningList.append(warningItem);
+    });
+    details.append(warningList);
+  }
+
+  if (archiveEntries.length > 0) {
+    const groups = document.createElement('dl');
+    groups.className = 'audit-history-counts';
+    for (const [key, items] of archiveEntries) {
+      const term = document.createElement('dt');
+      term.textContent = archiveArtifactGroupLabel(key);
+      const description = document.createElement('dd');
+      description.textContent = `${items.length} record${items.length === 1 ? '' : 's'}`;
+      groups.append(term, description);
+    }
+    details.append(groups);
+  }
+
+  return details;
 }
 
 function buildPipelineStages() {
@@ -2387,36 +2467,12 @@ function renderPipeline() {
     els.workflowContext.append(renderWorkflowFeedbackPanel(viewModel.workflowActionFeedback));
   }
 
-  const scopeWarnings = asArray(viewModel.artifactScopeWarnings);
-  const archiveCounts = viewModel.historicalArtifacts || {};
-  const archiveCount = Object.values(archiveCounts).reduce((total, items) => total + asArray(items).length, 0);
-  const scopePanel = document.createElement('div');
-  scopePanel.className = `artifact-scope-panel${scopeWarnings.length > 0 ? ' warning' : ''}`;
-  const scopeLabel = document.createElement('span');
-  scopeLabel.textContent = scopeWarnings.length > 0 ? 'Current production warning' : 'Artifact scope';
-  const scopeText = document.createElement('strong');
-  scopeText.textContent = scopeWarnings.length > 0
-    ? `${scopeWarnings.length} artifact${scopeWarnings.length === 1 ? '' : 's'} not part of current production.`
-    : archiveCount > 0 ? `${archiveCount} history/archive artifact${archiveCount === 1 ? '' : 's'} kept out of active state.` : 'Only active/current artifacts are shown as production state.';
-  const scopeDetail = document.createElement('p');
-  scopeDetail.textContent = 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.';
-  scopePanel.append(scopeLabel, scopeText);
-  if (scopeWarnings.length > 0) {
-    const warningList = document.createElement('div');
-    warningList.className = 'artifact-scope-warning-list';
-    scopeWarnings.forEach((warning) => {
-      const warningItem = document.createElement('p');
-      warningItem.textContent = warning.message;
-      warningList.append(warningItem);
-    });
-    scopePanel.append(warningList);
-  }
-  scopePanel.append(scopeDetail);
-  els.workflowContext.append(scopePanel);
+  els.workflowContext.append(renderAuditHistoryDisclosure(viewModel));
 
   const stages = buildPipelineStages();
   pruneExpandedPipelineStages(stages);
   const currentStageId = currentPipelineStageId(viewModel, stages);
+  syncCurrentPipelineStage(currentStageId);
   attachWorkflowFeedback(stages, viewModel, currentStageId);
   renderProductionCommandBar(viewModel, stages);
   els.pipelineStages.innerHTML = '';

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -196,6 +196,9 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
   assertContains(uiJs, 'function renderAuditHistoryDisclosure(viewModel)', 'archive warnings should render behind an audit/history disclosure');
   assertContains(uiJs, "summaryLabel.textContent = 'Audit/history'", 'audit/history disclosure should be explicitly labeled');
+  assertContains(uiStateJs, 'auditHistoryOpen: false', 'audit/history disclosure state should be tracked across renders');
+  assertContains(uiJs, 'details.open = Boolean(state.auditHistoryOpen)', 'audit/history disclosure should restore its open state');
+  assertContains(uiJs, 'state.auditHistoryOpen = details.open', 'audit/history disclosure should persist user toggles');
   assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should stay accessible for audit');
   assertContains(uiJs, 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.', 'workflow should explain active versus archive state');
   assertContains(stylesCss, '.audit-history-disclosure', 'audit/history disclosure styles');

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -126,6 +126,7 @@ test('editorial stage definitions remain intact and navigable', () => {
   assertContains(uiJs, 'scrollToPanel(stage.targetId)', 'stage card panel navigation');
   assertContains(uiJs, 'function scrollToPanel(id)', 'panel scroll helper');
   assertContains(uiJs, "card.dataset.stage", 'stage cards should expose stage numbers');
+  assertContains(uiJs, "card.setAttribute('aria-labelledby', titleId)", 'stage cards should connect article labels to headings');
 });
 
 test('stage tracker progressively discloses only the current stage by default', () => {
@@ -135,7 +136,10 @@ test('stage tracker progressively discloses only the current stage by default', 
   assertContains(uiJs, 'stage.id === currentStageId || state.expandedPipelineStageIds.includes(stage.id)', 'current stage should be expanded by default');
   assertContains(uiJs, 'if (!expanded)', 'collapsed stage branch');
   assertContains(uiJs, "expandButton.textContent = 'Expand stage'", 'collapsed stages should expose an expand control');
+  assertContains(uiJs, "expandButton.setAttribute('aria-controls', bodyId)", 'collapsed stage disclosure should name the controlled region');
   assertContains(uiJs, "collapseButton.textContent = 'Collapse stage'", 'expanded non-current stages should expose a collapse control');
+  assertContains(uiJs, "collapseButton.setAttribute('aria-controls', bodyId)", 'expanded stage disclosure should name the controlled region');
+  assertContains(uiJs, "status.setAttribute('aria-label', `Status: ${statusLabel}`)", 'stage status pills should expose explicit status labels');
   assertContains(uiJs, "card.className = `pipeline-card ${statusClass(statusLabel)}${expanded ? ' expanded' : ' collapsed'}${stage.id === currentStageId ? ' current' : ''}`", 'stage cards should mark collapsed/current state');
   assertContains(uiJs, "button.textContent = stage.actionLabel", 'existing stage action remains available when expanded');
   assertContains(uiJs, 'body.append(artifacts, next, button, actionReason)', 'expanded stage body keeps action context');
@@ -143,6 +147,7 @@ test('stage tracker progressively discloses only the current stage by default', 
   assertContains(uiJs, "currentBadge.textContent = 'current'", 'current stage should be called out separately from status');
   assertContains(uiJs, "artifactLabel.textContent = 'Active/current artifact'", 'expanded stages should not call archived records latest active artifacts');
   assertContains(uiJs, 'function pruneExpandedPipelineStages(stages)', 'expanded stage state should be pruned during render');
+  assertContains(uiJs, 'function syncCurrentPipelineStage(currentStageId)', 'current stage changes should reset manual expansions');
   assertContains(uiJs, 'state.expandedPipelineStageIds = []', 'changing workflow context should reset expanded stage state');
 
   for (const status of ['not started', 'blocked', 'ready', 'complete', 'warning']) {
@@ -189,8 +194,11 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(stylesCss, '.command-bar-story-detail', 'cockpit header story detail styles');
   assertContains(uiJs, 'function checklistBlockers(checklist', 'checklist blocker helper');
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
-  assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should render in workflow context');
+  assertContains(uiJs, 'function renderAuditHistoryDisclosure(viewModel)', 'archive warnings should render behind an audit/history disclosure');
+  assertContains(uiJs, "summaryLabel.textContent = 'Audit/history'", 'audit/history disclosure should be explicitly labeled');
+  assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should stay accessible for audit');
   assertContains(uiJs, 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.', 'workflow should explain active versus archive state');
+  assertContains(stylesCss, '.audit-history-disclosure', 'audit/history disclosure styles');
   assertContains(uiJs, 'const researchPacketId = selectedResearchPacket()?.id', 'script generation should use active/current research packet selection');
   assert.doesNotMatch(uiJs, /const researchPacketId = state\.selectedResearchPacketId/, 'script generation must not post archived saved packet ids');
   assert.doesNotMatch(uiJs, /latestArtifacts\?\.publishing\?\.title/, 'command bar must not present archived/latest episodes as active production context');

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -287,6 +287,8 @@ test('view model covers candidate selected with no research brief', () => {
   assert.equal(model.activeArtifacts.audioCover, null);
   assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-audio-1'));
   assert.ok(model.artifactScopeWarnings.some((item) => item.stage === 'publishing'));
+  assert.equal(model.warnings.some((warning) => warning.message.includes('not part of current production')), false);
+  assert.equal(model.cockpitHeader.warningCount, 0);
   assert.equal(model.primaryNextAction.label, 'Build research brief');
   assert.equal(model.primaryNextAction.enabled, true);
 });
@@ -519,6 +521,7 @@ test('view model keeps unlinked production assets archived instead of active', (
   assert.equal(model.activeArtifacts.audioCover, null);
   assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-unlinked-audio' && item.stateLabel === 'History/archive'));
   assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+  assert.equal(model.warnings.some((warning) => warning.message.includes('not part of current production')), false);
 });
 
 test('view model archives production artifacts that do not match the selected candidate path', () => {
@@ -566,7 +569,8 @@ test('view model archives production artifacts that do not match the selected ca
   assert.ok(model.historicalArtifacts.scripts.some((item) => item.id === 'script-1' && item.stateLabel === 'History/archive'));
   assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-old-audio' && item.stateLabel === 'History/archive'));
   assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
-  assert.ok(model.warnings.some((warning) => warning.message.includes('not part of current production')));
+  assert.equal(model.warnings.some((warning) => warning.message.includes('not part of current production')), false);
+  assert.equal(model.cockpitHeader.warningCount, 0);
   assert.equal(model.primaryNextAction.label, 'Generate script draft');
 });
 


### PR DESCRIPTION
Closes #105

## Summary
- Focused the Produce Episode stage tracker so stale expanded stages reset when the current stage changes.
- Added accessible stage disclosure semantics with explicit status labels and controlled expanded/collapsed regions.
- Moved archive/history artifact notices into an audit/history disclosure while keeping active blockers and warnings on the main workflow path.

## Verification
- `node scripts/ui-guided-flow-smoke.test.mjs`
- `node scripts/ui-production-view-model.test.mjs`
- `node scripts/ui-complexity-smoke.test.mjs`
- `npm run check`
