### PR TITLE
PFI-03: Distill Produce Episode stage navigation

### DIFF
--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -456,15 +456,39 @@ button:disabled {
   overflow-wrap: anywhere;
 }
 
+.artifact-scope-panel summary {
+  cursor: pointer;
+  display: grid;
+  gap: 0.2rem;
+}
+
 .artifact-scope-panel p {
   color: #586575;
   font-size: 0.86rem;
   margin: 0;
 }
 
+.audit-history-disclosure p {
+  margin-top: 0.45rem;
+}
+
+.audit-history-list {
+  color: #3f4b5a;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.9rem;
+  margin: 0.45rem 0 0;
+  padding-left: 1rem;
+}
+
+.audit-history-list li {
+  font-size: 0.86rem;
+}
+
 .artifact-scope-warning-list {
   display: grid;
   gap: 0.25rem;
+  margin-top: 0.45rem;
 }
 
 .artifact-scope-warning-list p {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -885,7 +885,6 @@ function deriveWarningsAndBlockers({
   jobs,
   checklist,
   selectedCandidates,
-  inactiveSelectedArtifacts = [],
 }) {
   const warnings = [];
   const blockers = [];
@@ -921,15 +920,6 @@ function deriveWarningsAndBlockers({
       const target = checklistStage(item.key);
       blockers.push(warningItem(target, `${item.label}: ${item.reason}`, item, 'error'));
     }
-  }
-
-  for (const item of inactiveSelectedArtifacts) {
-    warnings.push(warningItem(
-      item.stage || 'production',
-      item.message || 'Loaded artifact is not part of current production.',
-      item.source || null,
-      'warning',
-    ));
   }
 
   return { warnings, blockers };
@@ -1071,6 +1061,41 @@ function deriveHistoricalArtifacts({ activeIds, packets, scripts, revisions, ass
   };
 }
 
+function deriveAuditHistory({ historicalArtifacts, inactiveSelectedArtifacts }) {
+  const sections = [
+    ['Research briefs', 'briefs'],
+    ['Scripts', 'scripts'],
+    ['Integrity reviews', 'reviews'],
+    ['Audio/cover assets', 'audioCover'],
+    ['Publishing records', 'publishing'],
+  ].map(([label, key]) => ({
+    key,
+    label,
+    count: asArray(historicalArtifacts[key]).length,
+  })).filter((section) => section.count > 0);
+  const warnings = asArray(inactiveSelectedArtifacts).map((item) => warningItem(
+    item.stage || 'production',
+    item.message || 'Loaded artifact is not part of current production.',
+    item.source || null,
+    'warning',
+  ));
+  const archiveCount = sections.reduce((total, section) => total + section.count, 0);
+  const warningCount = warnings.length;
+
+  return {
+    archiveCount,
+    warningCount,
+    sections,
+    warnings,
+    summary: warningCount > 0
+      ? `${warningCount} archive/history warning${warningCount === 1 ? '' : 's'} kept in audit disclosure.`
+      : archiveCount > 0
+        ? `${archiveCount} history/archive artifact${archiveCount === 1 ? '' : 's'} kept out of active state.`
+        : 'Only active/current artifacts are shown as production state.',
+    detail: 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.',
+  };
+}
+
 export function deriveProductionViewModel(input = {}) {
   const shows = asArray(input.shows);
   const feeds = asArray(input.feeds);
@@ -1196,6 +1221,10 @@ export function deriveProductionViewModel(input = {}) {
     assets: productionAssets,
     episodes,
   });
+  const auditHistory = deriveAuditHistory({
+    historicalArtifacts,
+    inactiveSelectedArtifacts,
+  });
   const { warnings, blockers } = deriveWarningsAndBlockers({
     activeBrief,
     activeRevision,
@@ -1233,6 +1262,7 @@ export function deriveProductionViewModel(input = {}) {
     activeArtifacts,
     latestArtifacts,
     historicalArtifacts,
+    auditHistory,
     artifactScopeWarnings: inactiveSelectedArtifacts,
     primaryNextAction,
     secondaryActions,
@@ -1249,7 +1279,7 @@ export function deriveProductionViewModel(input = {}) {
       advanced: Boolean(input.activeSurface === 'settings' || input.activeSurface === 'debug'),
       groups: {
         activeWorkflow: true,
-        history: Object.values(historicalArtifacts).some((items) => items.length > 0),
+        history: auditHistory.archiveCount > 0 || auditHistory.warningCount > 0,
         admin: input.activeSurface === 'settings',
         debug: input.activeSurface === 'debug',
       },

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1756,11 +1756,19 @@ function renderWorkflowFeedbackPanel(feedback, { compact = false } = {}) {
 function stageCard(stage, currentStageId = '') {
   const statusLabel = stageStatusLabel(stage);
   const expanded = pipelineStageIsExpanded(stage, currentStageId);
+  const headingId = `pipeline-stage-heading-${stage.id}`;
+  const summaryId = `pipeline-stage-summary-${stage.id}`;
+  const bodyId = `pipeline-stage-body-${stage.id}`;
   const card = document.createElement('article');
   card.className = `pipeline-card ${statusClass(statusLabel)}${expanded ? ' expanded' : ' collapsed'}${stage.id === currentStageId ? ' current' : ''}`;
   card.dataset.stage = String(stage.number);
   card.dataset.stageId = stage.id;
   card.dataset.stageStatus = statusLabel;
+  card.setAttribute('aria-labelledby', headingId);
+  card.setAttribute('aria-describedby', summaryId);
+  if (stage.id === currentStageId) {
+    card.setAttribute('aria-current', 'step');
+  }
 
   const top = document.createElement('div');
   top.className = 'pipeline-top';
@@ -1769,6 +1777,7 @@ function stageCard(stage, currentStageId = '') {
   step.className = 'pipeline-step';
   step.textContent = `Stage ${stage.number}`;
   const title = document.createElement('h3');
+  title.id = headingId;
   title.textContent = stage.title;
   heading.append(step, title);
   const status = document.createElement('span');
@@ -1784,6 +1793,7 @@ function stageCard(stage, currentStageId = '') {
 
   const summary = document.createElement('div');
   summary.className = 'pipeline-summary';
+  summary.id = summaryId;
   const summaryText = document.createElement('p');
   summaryText.textContent = stage.artifact;
   const summaryNext = document.createElement('p');
@@ -1799,6 +1809,7 @@ function stageCard(stage, currentStageId = '') {
     expandButton.className = 'secondary pipeline-expand';
     expandButton.textContent = 'Expand stage';
     expandButton.setAttribute('aria-expanded', 'false');
+    expandButton.setAttribute('aria-controls', bodyId);
     expandButton.setAttribute('aria-label', `Expand ${stage.title}`);
     expandButton.addEventListener('click', () => setPipelineStageExpanded(stage.id, true));
     card.append(expandButton);
@@ -1807,6 +1818,7 @@ function stageCard(stage, currentStageId = '') {
 
   const body = document.createElement('div');
   body.className = 'pipeline-card-body';
+  body.id = bodyId;
 
   const artifacts = document.createElement('div');
   artifacts.className = 'pipeline-artifacts';
@@ -1898,6 +1910,7 @@ function stageCard(stage, currentStageId = '') {
     collapseButton.className = 'secondary pipeline-expand';
     collapseButton.textContent = 'Collapse stage';
     collapseButton.setAttribute('aria-expanded', 'true');
+    collapseButton.setAttribute('aria-controls', bodyId);
     collapseButton.setAttribute('aria-label', `Collapse ${stage.title}`);
     collapseButton.addEventListener('click', () => setPipelineStageExpanded(stage.id, false));
     body.append(collapseButton);
@@ -2354,6 +2367,50 @@ function buildPipelineStages() {
   ];
 }
 
+function renderAuditHistoryDisclosure(viewModel) {
+  const auditHistory = viewModel.auditHistory || {};
+  const details = document.createElement('details');
+  details.className = `artifact-scope-panel audit-history-disclosure${auditHistory.warningCount > 0 ? ' warning' : ''}`;
+
+  const summary = document.createElement('summary');
+  const label = document.createElement('span');
+  label.textContent = auditHistory.warningCount > 0 ? 'Audit/history warnings' : 'Audit/history';
+  const summaryText = document.createElement('strong');
+  summaryText.textContent = auditHistory.summary || 'Only active/current artifacts are shown as production state.';
+  summary.append(label, summaryText);
+  details.append(summary);
+
+  const detail = document.createElement('p');
+  detail.textContent = auditHistory.detail || 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.';
+  details.append(detail);
+
+  const sections = asArray(auditHistory.sections);
+  if (sections.length > 0) {
+    const list = document.createElement('ul');
+    list.className = 'audit-history-list';
+    sections.forEach((section) => {
+      const item = document.createElement('li');
+      item.textContent = `${section.label}: ${section.count}`;
+      list.append(item);
+    });
+    details.append(list);
+  }
+
+  const auditWarnings = asArray(auditHistory.warnings);
+  if (auditWarnings.length > 0) {
+    const warningList = document.createElement('div');
+    warningList.className = 'artifact-scope-warning-list';
+    auditWarnings.forEach((warning) => {
+      const warningItem = document.createElement('p');
+      warningItem.textContent = warning.message;
+      warningList.append(warningItem);
+    });
+    details.append(warningList);
+  }
+
+  return details;
+}
+
 function renderPipeline() {
   const viewModel = state.productionViewModel || deriveProductionViewModel(state);
   const show = selectedShow();
@@ -2387,32 +2444,7 @@ function renderPipeline() {
     els.workflowContext.append(renderWorkflowFeedbackPanel(viewModel.workflowActionFeedback));
   }
 
-  const scopeWarnings = asArray(viewModel.artifactScopeWarnings);
-  const archiveCounts = viewModel.historicalArtifacts || {};
-  const archiveCount = Object.values(archiveCounts).reduce((total, items) => total + asArray(items).length, 0);
-  const scopePanel = document.createElement('div');
-  scopePanel.className = `artifact-scope-panel${scopeWarnings.length > 0 ? ' warning' : ''}`;
-  const scopeLabel = document.createElement('span');
-  scopeLabel.textContent = scopeWarnings.length > 0 ? 'Current production warning' : 'Artifact scope';
-  const scopeText = document.createElement('strong');
-  scopeText.textContent = scopeWarnings.length > 0
-    ? `${scopeWarnings.length} artifact${scopeWarnings.length === 1 ? '' : 's'} not part of current production.`
-    : archiveCount > 0 ? `${archiveCount} history/archive artifact${archiveCount === 1 ? '' : 's'} kept out of active state.` : 'Only active/current artifacts are shown as production state.';
-  const scopeDetail = document.createElement('p');
-  scopeDetail.textContent = 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.';
-  scopePanel.append(scopeLabel, scopeText);
-  if (scopeWarnings.length > 0) {
-    const warningList = document.createElement('div');
-    warningList.className = 'artifact-scope-warning-list';
-    scopeWarnings.forEach((warning) => {
-      const warningItem = document.createElement('p');
-      warningItem.textContent = warning.message;
-      warningList.append(warningItem);
-    });
-    scopePanel.append(warningList);
-  }
-  scopePanel.append(scopeDetail);
-  els.workflowContext.append(scopePanel);
+  els.workflowContext.append(renderAuditHistoryDisclosure(viewModel));
 
   const stages = buildPipelineStages();
   pruneExpandedPipelineStages(stages);

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -144,6 +144,10 @@ test('stage tracker progressively discloses only the current stage by default', 
   assertContains(uiJs, "artifactLabel.textContent = 'Active/current artifact'", 'expanded stages should not call archived records latest active artifacts');
   assertContains(uiJs, 'function pruneExpandedPipelineStages(stages)', 'expanded stage state should be pruned during render');
   assertContains(uiJs, 'state.expandedPipelineStageIds = []', 'changing workflow context should reset expanded stage state');
+  assertContains(uiJs, "card.setAttribute('aria-current', 'step')", 'current stage should expose aria-current step semantics');
+  assertContains(uiJs, "card.setAttribute('aria-labelledby', headingId)", 'stage cards should be labelled by their heading');
+  assertContains(uiJs, "expandButton.setAttribute('aria-controls', bodyId)", 'collapsed stage controls should point to expanded body');
+  assertContains(uiJs, "collapseButton.setAttribute('aria-controls', bodyId)", 'collapse controls should point to expanded body');
 
   for (const status of ['not started', 'blocked', 'ready', 'complete', 'warning']) {
     assertContains(uiJs, `return '${status}'`, `stage tracker status ${status}`);
@@ -189,8 +193,12 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(stylesCss, '.command-bar-story-detail', 'cockpit header story detail styles');
   assertContains(uiJs, 'function checklistBlockers(checklist', 'checklist blocker helper');
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
-  assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should render in workflow context');
+  assertContains(uiJs, 'function renderAuditHistoryDisclosure(viewModel)', 'audit/history disclosure renderer');
+  assertContains(uiJs, 'viewModel.auditHistory', 'view model archive warnings should render in audit history disclosure');
+  assertContains(uiJs, "label.textContent = auditHistory.warningCount > 0 ? 'Audit/history warnings' : 'Audit/history'", 'archive warnings should be labelled as audit/history');
   assertContains(uiJs, 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.', 'workflow should explain active versus archive state');
+  assertContains(stylesCss, '.audit-history-disclosure p', 'audit history disclosure detail styles');
+  assertContains(stylesCss, '.audit-history-list', 'audit history count list styles');
   assertContains(uiJs, 'const researchPacketId = selectedResearchPacket()?.id', 'script generation should use active/current research packet selection');
   assert.doesNotMatch(uiJs, /const researchPacketId = state\.selectedResearchPacketId/, 'script generation must not post archived saved packet ids');
   assert.doesNotMatch(uiJs, /latestArtifacts\?\.publishing\?\.title/, 'command bar must not present archived/latest episodes as active production context');

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -519,6 +519,8 @@ test('view model keeps unlinked production assets archived instead of active', (
   assert.equal(model.activeArtifacts.audioCover, null);
   assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-unlinked-audio' && item.stateLabel === 'History/archive'));
   assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+  assert.ok(model.auditHistory.warnings.some((warning) => warning.message.includes('not part of current production')));
+  assert.ok(!model.warnings.some((warning) => warning.message.includes('not part of current production')));
 });
 
 test('view model archives production artifacts that do not match the selected candidate path', () => {
@@ -566,7 +568,8 @@ test('view model archives production artifacts that do not match the selected ca
   assert.ok(model.historicalArtifacts.scripts.some((item) => item.id === 'script-1' && item.stateLabel === 'History/archive'));
   assert.ok(model.historicalArtifacts.audioCover.some((item) => item.id === 'asset-old-audio' && item.stateLabel === 'History/archive'));
   assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
-  assert.ok(model.warnings.some((warning) => warning.message.includes('not part of current production')));
+  assert.ok(model.auditHistory.warnings.some((warning) => warning.message.includes('not part of current production')));
+  assert.ok(!model.warnings.some((warning) => warning.message.includes('not part of current production')));
   assert.equal(model.primaryNextAction.label, 'Generate script draft');
 });
 
@@ -589,6 +592,7 @@ test('view model does not promote unlinked legacy packets as current for a selec
   assert.equal(model.activeArtifacts.brief, null);
   assert.ok(model.historicalArtifacts.briefs.some((item) => item.id === 'brief-legacy' && item.stateLabel === 'History/archive'));
   assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+  assert.ok(model.auditHistory.warnings.some((warning) => warning.message.includes('not part of current production')));
   assert.equal(model.primaryNextAction.label, 'Build research brief');
 });
 
@@ -613,6 +617,7 @@ test('view model does not promote multi-candidate packets for a narrower selecte
   assert.equal(model.activeArtifacts.brief, null);
   assert.ok(model.historicalArtifacts.briefs.some((item) => item.id === 'brief-multi' && item.stateLabel === 'History/archive'));
   assert.ok(model.artifactScopeWarnings.some((item) => item.message.includes('not part of current production')));
+  assert.ok(model.auditHistory.warnings.some((warning) => warning.message.includes('not part of current production')));
   assert.equal(model.primaryNextAction.label, 'Build research brief');
 });
 
@@ -977,7 +982,14 @@ test('view model separates active artifacts from historical artifacts', () => {
     assert.equal(model.historicalArtifacts.audioCover[0].stage, 'production');
     assert.equal(model.historicalArtifacts.audioCover[0].productionKind, 'audio');
     assert.ok(!model.warnings.some((warning) => warning.message.includes('non-production')));
+    assert.ok(!model.warnings.some((warning) => warning.message.includes('not part of current production')));
     assert.deepEqual(model.historicalArtifacts.publishing.map((item) => item.id), ['episode-old']);
+    assert.equal(model.auditHistory.archiveCount, 5);
     assert.equal(model.visibility.groups.history, true);
   }
+
+  assert.equal(selectedModel.auditHistory.warningCount, 0);
+  assert.equal(defaultModel.auditHistory.warningCount, 1);
+  assert.match(defaultModel.auditHistory.warnings[0].message, /not part of current production/);
+  assert.equal(defaultModel.cockpitHeader.warningCount, defaultModel.warnings.length);
 });


### PR DESCRIPTION
Closes #105

## Summary
- Move non-blocking archive/history production warnings out of the main warning stream and into an explicit Audit/history disclosure.
- Preserve active/current warning and blocker visibility for the production path while keeping historical artifacts auditable.
- Add clearer stage card accessibility semantics for current step, headings, summaries, and expand/collapse controls.
- Update UI smoke and view-model regression tests for focused stage navigation and audit disclosure behavior.

## Verification
- npm run check
- git diff --check