### PR TITLE
PFI-04: Redesign candidate review queue

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -493,9 +493,9 @@ Recommended order/status:
 2. #103 — PFI-01 Add Impeccable product/design context for Podcast Forge ✅ merged (#111)
 3. #104 — PFI-02 Produce Episode cockpit header with next action and blockers ✅ merged (#112)
 4. #105 — PFI-03 Distill Produce Episode into focused stage navigation ✅ merged (#113)
-5. #106 — PFI-04 Redesign candidate stories as a ranked editorial review queue 🚧 active agent on `issue-106-pfi-04-candidate-review-queue`
+5. #106 — PFI-04 Redesign candidate stories as a ranked editorial review queue ✅ implemented in PR #115; awaiting independent review
 6. #107 — PFI-05 Make AI, human approval, source evidence, and blockers visually distinct
 7. #108 — PFI-06 Give script and audio review a focused workspace
 8. #109 — PFI-07 Impeccable polish pass for responsive layout, states, and anti-patterns
 
-Current active agent: PFI-04 / issue #106 in worktree `/home/steven/clawd/worktrees/podcast-forge-issue-106`, branch `issue-106-pfi-04-candidate-review-queue`, process `proc_47aa59d8c2c0`, log `/home/steven/clawd/logs/podcast-forge-issue-106-pfi-04-candidate-review-queue.log`, task file `/home/steven/clawd/data/podcast-forge-impeccable-sprint-2026-04-29/PFI-04-codex-task.txt`. Do not launch another UI agent while this branch or PR is active.
+Current active branch/PR: PFI-04 / issue #106 is open as PR #115 from branch `issue-106-pfi-04-candidate-review-queue`. Do not launch another UI agent while this PR is active.

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -1626,21 +1626,80 @@ textarea {
 }
 
 .candidate-row {
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(4.6rem, 0.18fr) minmax(0, 1fr);
 }
 
 .candidate-row .candidate-select {
   align-self: start;
-  grid-row: 1 / 5;
+  grid-row: 1 / 2;
   height: 1.1rem;
-  margin-top: 0.2rem;
+  margin-top: 0.35rem;
   width: 1.1rem;
+}
+
+.candidate-rank {
+  align-self: stretch;
+  background: #eef1f5;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  color: #3f4b5a;
+  display: grid;
+  gap: 0.1rem;
+  justify-items: center;
+  min-width: 4.6rem;
+  padding: 0.45rem 0.35rem;
+  text-align: center;
+}
+
+.candidate-rank.recommended {
+  background: #eef6f2;
+  border-color: #9ac8aa;
+  color: #245b37;
+}
+
+.candidate-rank strong {
+  color: #20242c;
+  font-size: 1rem;
+  line-height: 1.1;
+}
+
+.candidate-rank span {
+  color: inherit;
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1.15;
+  text-transform: uppercase;
 }
 
 .candidate-row .candidate-body {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.5rem;
   min-width: 0;
+}
+
+.candidate-review-header {
+  align-items: start;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.candidate-title-group {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.candidate-title {
+  color: #20242c;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.candidate-source-line {
+  color: #586575;
+  font-size: 0.86rem;
+  line-height: 1.3;
 }
 
 .candidate-facts,
@@ -1675,6 +1734,87 @@ textarea {
   background: #fff1df;
   border-color: #e2c391;
   color: #70440f;
+}
+
+.candidate-chip.article-date {
+  border-style: solid;
+}
+
+.candidate-chip.provider-freshness {
+  background: #eef6ff;
+  border-color: #9ec4ed;
+  color: #1f4d7a;
+}
+
+.candidate-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.candidate-actions button {
+  min-height: 2.15rem;
+}
+
+.candidate-actions .selected-action {
+  border-color: #9ac8aa;
+  color: #245b37;
+}
+
+.candidate-details {
+  background: white;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+}
+
+.candidate-details summary {
+  color: #3f4b5a;
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.candidate-detail-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 0.6rem;
+}
+
+.candidate-detail-block {
+  background: #f8fafc;
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+  padding: 0.55rem 0.65rem;
+}
+
+.candidate-detail-block.ai-analysis {
+  background: #fbfaf1;
+  border-color: #d8cf73;
+}
+
+.candidate-detail-block h4 {
+  color: #27303b;
+  font-size: 0.82rem;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.candidate-detail-block p,
+.candidate-detail-block li {
+  color: #3f4b5a;
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
+.candidate-detail-block ul {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0;
+  padding-left: 1rem;
 }
 
 .record-row > button {
@@ -2015,6 +2155,33 @@ textarea {
 
   .candidate-filter-grid .wide {
     grid-column: auto;
+  }
+
+  .candidate-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .candidate-rank {
+    align-items: center;
+    display: flex;
+    gap: 0.35rem;
+    grid-column: 2;
+    justify-content: flex-start;
+    min-width: 0;
+    text-align: left;
+  }
+
+  .candidate-review-header,
+  .candidate-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .candidate-row .candidate-body {
+    grid-column: 1 / -1;
+  }
+
+  .candidate-actions {
+    justify-content: flex-start;
   }
 
 

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -293,6 +293,52 @@ function candidateScoreText(candidate, index) {
   return `${rank}, score ${candidate.score}`;
 }
 
+function candidateQualityStatus(candidate) {
+  if (candidateHasFallbackScore(candidate)) {
+    return { level: 'warning', label: typeof candidate.score === 'number' ? `fallback score ${candidate.score}` : 'fallback scoring', detail: 'Review scoring before selecting.' };
+  }
+
+  if (candidate.score === null || candidate.score === undefined) {
+    return { level: 'warning', label: 'unscored', detail: 'No quality score recorded.' };
+  }
+
+  if (candidate.score >= 70) {
+    return { level: 'success', label: `high confidence score ${candidate.score}`, detail: 'Scoring recommends review.' };
+  }
+
+  if (candidate.score >= 50) {
+    return { level: '', label: `score ${candidate.score}`, detail: 'Usable, but compare against stronger candidates.' };
+  }
+
+  return { level: 'warning', label: `low score ${candidate.score}`, detail: 'Needs editorial caution.' };
+}
+
+function candidateSourceRiskStatus(candidate) {
+  const sourceQuality = componentScore(candidate, 'sourceQuality');
+
+  if (!candidateUrl(candidate)) {
+    return { level: 'error', label: 'source risk: missing URL' };
+  }
+
+  if (['ignored', 'merged'].includes(candidate.status)) {
+    return { level: 'error', label: `source risk: ${candidate.status} status` };
+  }
+
+  if (typeof sourceQuality === 'number') {
+    if (sourceQuality >= 70) {
+      return { level: 'success', label: `source confidence ${sourceQuality}` };
+    }
+
+    if (sourceQuality < 50) {
+      return { level: 'warning', label: `source risk ${sourceQuality}` };
+    }
+
+    return { level: '', label: `source confidence ${sourceQuality}` };
+  }
+
+  return { level: 'warning', label: 'source confidence unknown' };
+}
+
 function candidateStatusWarnings(candidate) {
   const warnings = [];
   const breakdown = scoreBreakdown(candidate);
@@ -358,16 +404,35 @@ function duplicateValues(values) {
   return [...duplicated];
 }
 
-function candidateFreshnessText(candidate) {
+function candidateFreshnessInfo(candidate) {
   const metadata = asObject(candidate.metadata);
   const freshness = asObject(metadata.freshness);
   const search = asObject(metadata.search);
   const requested = freshnessLabel(freshness.requested || metadata.freshnessRequested || search.freshness || search.recency || search.search_recency_filter || '');
+  const verified = freshness.verified === true;
+  const providerClaimed = freshness.confidence === 'claimed';
+
   if (candidate.publishedAt) {
-    const confidence = freshness.verified === true ? 'verified' : freshness.confidence === 'claimed' ? 'provider-claimed' : 'unverified';
-    return `published ${new Date(candidate.publishedAt).toLocaleString()} (${confidence}${requested ? `, requested ${requested}` : ''})`;
+    const confidence = verified ? 'verified' : providerClaimed ? 'provider-claimed' : 'unverified';
+    return {
+      articleLevel: verified ? 'success' : 'warning',
+      articleLabel: `published date: present | article date ${formatTime(candidate.publishedAt)}`,
+      articleDetail: confidence,
+      requested,
+    };
   }
-  return requested ? `published date unknown (requested ${requested})` : `discovered ${new Date(candidate.discoveredAt).toLocaleString()}`;
+
+  return {
+    articleLevel: 'warning',
+    articleLabel: 'published date: missing',
+    articleDetail: candidate.discoveredAt ? `discovered ${formatTime(candidate.discoveredAt)}` : 'not verified',
+    requested,
+  };
+}
+
+function candidateFreshnessText(candidate) {
+  const info = candidateFreshnessInfo(candidate);
+  return info.requested ? `${info.articleLabel} | provider requested ${info.requested}` : info.articleLabel;
 }
 
 function candidateSourceFilterValue(candidate) {
@@ -448,8 +513,24 @@ function activeCandidateBaseList() {
   return state.storyCandidates.filter((candidate) => state.candidateFilters.status === 'all' || state.candidateFilters.status === 'ignored' || candidate.status !== 'ignored');
 }
 
+function rankedCandidateList(candidates) {
+  const rankTime = (candidate) => {
+    const value = Date.parse(candidate.discoveredAt || candidate.createdAt || '');
+    return Number.isFinite(value) ? value : 0;
+  };
+
+  return [...candidates].sort((left, right) => {
+    const leftScore = typeof left.score === 'number' ? left.score : -1;
+    const rightScore = typeof right.score === 'number' ? right.score : -1;
+    if (rightScore !== leftScore) {
+      return rightScore - leftScore;
+    }
+    return rankTime(right) - rankTime(left);
+  });
+}
+
 function filteredStoryCandidates() {
-  return state.storyCandidates.filter(candidateMatchesFilters);
+  return rankedCandidateList(state.storyCandidates.filter(candidateMatchesFilters));
 }
 
 function candidateFiltersActive() {
@@ -2765,81 +2846,92 @@ function renderStoryCandidates() {
   for (const [index, candidate] of filteredCandidates.entries()) {
     const row = document.createElement('article');
     const selected = state.selectedCandidateIds.includes(candidate.id);
-    row.className = `record-row candidate-row${selected ? ' selected' : ''}`;
+    row.className = `record-row candidate-row editorial-queue-row${selected ? ' selected' : ''}`;
 
     const checkbox = document.createElement('input');
     checkbox.className = 'candidate-select';
     checkbox.type = 'checkbox';
     checkbox.checked = selected;
-    checkbox.setAttribute('aria-label', `Select ${candidate.title}`);
+    checkbox.setAttribute('aria-label', selected ? `Unselect ${candidate.title}` : `Select ${candidate.title}`);
     checkbox.addEventListener('change', () => {
       toggleCandidateSelection(candidate.id);
     });
 
+    const rank = document.createElement('div');
+    rank.className = `candidate-rank${index === 0 ? ' recommended' : ''}`;
+    const rankNumber = document.createElement('strong');
+    rankNumber.textContent = `#${index + 1}`;
+    const rankLabel = document.createElement('span');
+    rankLabel.textContent = index === 0 ? 'Top recommendation' : 'Ranked candidate';
+    rank.append(rankNumber, rankLabel);
+
     const body = document.createElement('div');
     body.className = 'candidate-body';
+
+    const header = document.createElement('div');
+    header.className = 'candidate-review-header';
+
+    const titleGroup = document.createElement('div');
+    titleGroup.className = 'candidate-title-group';
+
     const title = document.createElement('strong');
+    title.className = 'candidate-title';
     title.textContent = candidate.title;
 
-    const meta = document.createElement('span');
     const url = candidateUrl(candidate);
     const domain = hostnameFor(url);
     const sourceProfile = sourceProfileForCandidate(candidate);
-    const published = candidateFreshnessText(candidate);
-    meta.textContent = [
-      candidate.sourceName || domain || 'unknown source',
+    const providerLabel = sourceProfile ? sourceProviderLabel(sourceProfile.type) : 'Manual/imported';
+
+    const sourceLine = document.createElement('span');
+    sourceLine.className = 'candidate-source-line';
+    sourceLine.textContent = [
+      candidate.sourceName || sourceProfile?.name || domain || 'unknown source',
+      providerLabel,
       domain || 'no source URL',
-      candidateScoreText(candidate, index),
-      published,
-      candidate.status,
     ].join(' | ');
+    titleGroup.append(title, sourceLine);
 
     const facts = document.createElement('div');
     facts.className = 'candidate-facts';
-    const origin = document.createElement('span');
-    origin.className = 'candidate-chip';
-    origin.textContent = `origin: ${sourceProfile?.name || 'manual/imported'} | ${sourceQueryText(candidate)}`;
-    facts.append(origin);
 
+    const quality = candidateQualityStatus(candidate);
+    const qualityChip = document.createElement('span');
+    qualityChip.className = `candidate-chip ${quality.level}`;
+    qualityChip.textContent = `quality: ${quality.label}`;
+    facts.append(qualityChip);
+
+    const sourceRisk = candidateSourceRiskStatus(candidate);
+    const sourceRiskChip = document.createElement('span');
+    sourceRiskChip.className = `candidate-chip ${sourceRisk.level}`;
+    sourceRiskChip.textContent = sourceRisk.label;
+    facts.append(sourceRiskChip);
+
+    const published = candidateFreshnessInfo(candidate);
     const dateChip = document.createElement('span');
-    dateChip.className = `candidate-chip ${candidate.publishedAt ? 'success' : 'warning'}`;
-    dateChip.textContent = candidate.publishedAt ? 'published date: present' : 'published date: missing';
+    dateChip.className = `candidate-chip article-date ${published.articleLevel}`;
+    dateChip.textContent = `${published.articleLabel} (${published.articleDetail})`;
     facts.append(dateChip);
 
-    const rationale = scoreBreakdown(candidate).rationale;
-    if (typeof rationale === 'string' && rationale.trim()) {
-      const chip = document.createElement('span');
-      chip.className = 'candidate-chip';
-      chip.textContent = rationale;
-      facts.append(chip);
+    if (published.requested) {
+      const requestedChip = document.createElement('span');
+      requestedChip.className = 'candidate-chip provider-freshness';
+      requestedChip.textContent = `provider freshness requested: ${published.requested}`;
+      facts.append(requestedChip);
     }
 
-    if (scoreBreakdown(candidate).angle) {
-      const chip = document.createElement('span');
-      chip.className = 'candidate-chip';
-      chip.textContent = `suggested angle: ${scoreBreakdown(candidate).angle}`;
-      facts.append(chip);
-    }
-
-    const flags = document.createElement('div');
-    flags.className = 'candidate-flags';
-    for (const warning of candidateStatusWarnings(candidate)) {
-      const chip = document.createElement('span');
-      chip.className = `candidate-chip ${warning.level}`;
-      chip.textContent = warning.text;
-      flags.append(chip);
-    }
-
-    const summary = document.createElement('p');
-    summary.textContent = candidate.summary || candidate.url || 'No summary recorded.';
+    const statusChip = document.createElement('span');
+    statusChip.className = selected ? 'candidate-chip success' : 'candidate-chip';
+    statusChip.textContent = selected ? 'selected for research brief' : `status: ${candidate.status || 'new'}`;
+    facts.append(statusChip);
 
     const actions = document.createElement('div');
-    actions.className = 'actions inline row-actions';
+    actions.className = 'actions inline row-actions candidate-actions';
 
     const select = document.createElement('button');
     select.type = 'button';
-    select.className = 'secondary';
-    select.textContent = selected ? 'Selected for Brief' : 'Select for Brief';
+    select.className = selected ? 'secondary selected-action' : 'secondary';
+    select.textContent = selected ? 'Unselect from Brief' : 'Select for Brief';
     select.addEventListener('click', () => {
       toggleCandidateSelection(candidate.id);
     });
@@ -2862,12 +2954,84 @@ function renderStoryCandidates() {
     });
 
     actions.append(select, createBrief, ignore);
-    body.append(title, meta, facts);
+
+    header.append(titleGroup, actions);
+
+    const flags = document.createElement('div');
+    flags.className = 'candidate-flags';
+    for (const warning of candidateStatusWarnings(candidate)) {
+      const chip = document.createElement('span');
+      chip.className = `candidate-chip ${warning.level}`;
+      chip.textContent = warning.text;
+      flags.append(chip);
+    }
+
+    const details = document.createElement('details');
+    details.className = 'candidate-details';
+    const detailsSummary = document.createElement('summary');
+    detailsSummary.textContent = 'Details and AI analysis';
+
+    const detailGrid = document.createElement('div');
+    detailGrid.className = 'candidate-detail-grid';
+
+    const sourceDetails = document.createElement('div');
+    sourceDetails.className = 'candidate-detail-block';
+    const sourceHeading = document.createElement('h4');
+    sourceHeading.textContent = 'Source trail';
+    const sourceList = document.createElement('ul');
+    for (const warning of candidateStatusWarnings(candidate)) {
+      const item = document.createElement('li');
+      item.textContent = `Warning: ${warning.text}`;
+      sourceList.append(item);
+    }
+    for (const itemText of [
+      `Origin: ${sourceProfile?.name || 'manual/imported'}`,
+      `Search query: ${sourceQueryText(candidate)}`,
+      `URL: ${url || 'missing'}`,
+      `Discovered: ${candidate.discoveredAt ? formatTime(candidate.discoveredAt) : 'not recorded'}`,
+      candidateFreshnessText(candidate),
+    ]) {
+      const item = document.createElement('li');
+      item.textContent = itemText;
+      sourceList.append(item);
+    }
+    sourceDetails.append(sourceHeading, sourceList);
+
+    const aiDetails = document.createElement('div');
+    aiDetails.className = 'candidate-detail-block ai-analysis';
+    const aiHeading = document.createElement('h4');
+    aiHeading.textContent = 'AI analysis';
+    const breakdown = scoreBreakdown(candidate);
+    const rationale = typeof breakdown.rationale === 'string' && breakdown.rationale.trim()
+      ? breakdown.rationale.trim()
+      : 'No AI rationale recorded.';
+    const rationaleText = document.createElement('p');
+    rationaleText.textContent = rationale;
+    aiDetails.append(aiHeading, rationaleText);
+
+    if (breakdown.angle) {
+      const angleText = document.createElement('p');
+      angleText.textContent = `Suggested angle: ${breakdown.angle}`;
+      aiDetails.append(angleText);
+    }
+
+    const summary = document.createElement('p');
+    summary.textContent = candidate.summary || candidate.url || 'No summary recorded.';
+    const summaryBlock = document.createElement('div');
+    summaryBlock.className = 'candidate-detail-block';
+    const summaryHeading = document.createElement('h4');
+    summaryHeading.textContent = 'Candidate summary';
+    summaryBlock.append(summaryHeading, summary);
+
+    detailGrid.append(sourceDetails, aiDetails, summaryBlock);
+    details.append(detailsSummary, detailGrid);
+
+    body.append(header, facts);
     if (flags.children.length > 0) {
       body.append(flags);
     }
-    body.append(summary, actions);
-    row.append(checkbox, body);
+    body.append(details);
+    row.append(checkbox, rank, body);
     els.candidateList.append(row);
   }
 }

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -2899,9 +2899,12 @@ function renderStoryCandidates() {
     const qualityChip = document.createElement('span');
     qualityChip.className = `candidate-chip ${quality.level}`;
     qualityChip.textContent = `quality: ${quality.label}`;
+    qualityChip.title = quality.detail;
+    qualityChip.setAttribute('aria-label', `Quality: ${quality.label}. ${quality.detail}`);
     facts.append(qualityChip);
 
     const sourceRisk = candidateSourceRiskStatus(candidate);
+    const statusWarnings = candidateStatusWarnings(candidate);
     const sourceRiskChip = document.createElement('span');
     sourceRiskChip.className = `candidate-chip ${sourceRisk.level}`;
     sourceRiskChip.textContent = sourceRisk.label;
@@ -2959,7 +2962,7 @@ function renderStoryCandidates() {
 
     const flags = document.createElement('div');
     flags.className = 'candidate-flags';
-    for (const warning of candidateStatusWarnings(candidate)) {
+    for (const warning of statusWarnings) {
       const chip = document.createElement('span');
       chip.className = `candidate-chip ${warning.level}`;
       chip.textContent = warning.text;
@@ -2979,11 +2982,6 @@ function renderStoryCandidates() {
     const sourceHeading = document.createElement('h4');
     sourceHeading.textContent = 'Source trail';
     const sourceList = document.createElement('ul');
-    for (const warning of candidateStatusWarnings(candidate)) {
-      const item = document.createElement('li');
-      item.textContent = `Warning: ${warning.text}`;
-      sourceList.append(item);
-    }
     for (const itemText of [
       `Origin: ${sourceProfile?.name || 'manual/imported'}`,
       `Search query: ${sourceQueryText(candidate)}`,

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -108,6 +108,8 @@ test('candidate list renders as a compact editorial review queue', () => {
     'editorial-queue-row',
     'Top recommendation',
     'quality: ${quality.label}',
+    'qualityChip.title = quality.detail',
+    "qualityChip.setAttribute('aria-label'",
     'source confidence unknown',
     'provider freshness requested:',
     'selected for research brief',
@@ -118,6 +120,8 @@ test('candidate list renders as a compact editorial review queue', () => {
     assertContains(uiJs, expected, `candidate queue renderer ${expected}`);
   }
 
+  assertContains(uiJs, 'const statusWarnings = candidateStatusWarnings(candidate)', 'candidate warnings should be computed once per row');
+  assertContains(uiJs, 'for (const warning of statusWarnings)', 'candidate warning chips should reuse computed warnings');
   assertContains(uiJs, 'function rankedCandidateList(candidates)', 'candidate queue should rank without mutating source rows');
   assertContains(uiJs, 'function candidateFreshnessInfo(candidate)', 'candidate queue should separate date and freshness metadata');
   assertContains(uiJs, 'article date ${formatTime(candidate.publishedAt)}', 'candidate published date should be article-specific');

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -103,6 +103,30 @@ test('candidate list exposes non-mutating filters for date and quality triage', 
   assertContains(stylesCss, '.candidate-filter-grid', 'candidate filter grid styles');
 });
 
+test('candidate list renders as a compact editorial review queue', () => {
+  for (const expected of [
+    'editorial-queue-row',
+    'Top recommendation',
+    'quality: ${quality.label}',
+    'source confidence unknown',
+    'provider freshness requested:',
+    'selected for research brief',
+    'Unselect from Brief',
+    'Details and AI analysis',
+    'AI analysis',
+  ]) {
+    assertContains(uiJs, expected, `candidate queue renderer ${expected}`);
+  }
+
+  assertContains(uiJs, 'function rankedCandidateList(candidates)', 'candidate queue should rank without mutating source rows');
+  assertContains(uiJs, 'function candidateFreshnessInfo(candidate)', 'candidate queue should separate date and freshness metadata');
+  assertContains(uiJs, 'article date ${formatTime(candidate.publishedAt)}', 'candidate published date should be article-specific');
+  assertContains(uiJs, 'provider requested ${info.requested}', 'freshness request should not be merged into the article date chip');
+  assertContains(stylesCss, '.candidate-rank.recommended', 'candidate queue top recommendation styling');
+  assertContains(stylesCss, '.candidate-chip.provider-freshness', 'candidate queue freshness-request chip styling');
+  assertContains(stylesCss, '.candidate-detail-block.ai-analysis', 'candidate AI analysis detail styling');
+});
+
 test('editorial stage definitions remain intact and navigable', () => {
   assertContains(uiJs, 'function buildPipelineStages()', 'pipeline stage builder');
   assertOrdered(


### PR DESCRIPTION
## Summary
- Redesigns candidate stories as a compact ranked editorial review queue with top recommendation cues, source/provider metadata, quality and risk chips, and explicit select/create/ignore actions.
- Separates verified or missing article published date from provider-requested freshness metadata.
- Collapses candidate summary, source trail, warnings, and AI rationale under progressive details labeled as AI analysis.

## Verification
- `node --test scripts/ui-guided-flow-smoke.test.mjs`
- `npm run check`
- `git diff --check`

Closes #106
