### PR TITLE
Fix publish checklist production warning scope

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -499,3 +499,5 @@ Recommended order/status:
 8. #109 — PFI-07 Impeccable polish pass for responsive layout, states, and anti-patterns ✅ merged (#118)
 
 PFI Impeccable UI sprint status: complete. Final issue #109 merged via PR #118 (`3c366af`) after local verification (`npm run check`, `git diff --check`, `npx impeccable --json` returning `[]`, static route smoke) and clean local Gemini review fallback. Sprint state files were updated at `/home/steven/clawd/data/podcast-forge-impeccable-sprint-2026-04-29/sprint-state.json` and `~/clawd/data/podcast-forge-sprint-state.json`.
+
+Follow-up active: #119 — PFI follow-up: scope production warnings in publish checklist. Watchdog found a post-sprint publish-checklist edge case where current production warnings should remain visible review context without blocking approval, while archived/unselected production-job warnings should not count against the active production path. Branch: `issue-119-pfi-followup-production-warning-scope`; verify with `npm run check` and review before merge.

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -735,17 +735,6 @@ function jobMatchesProductionPath(job, episode, assets) {
     return false;
   }
 
-  const jobEpisodeId = firstPresent(
-    job?.episodeId,
-    job?.summary?.episodeId,
-    job?.input?.episodeId,
-    job?.output?.episodeId,
-    job?.metadata?.episodeId,
-  );
-  if (episodeId && jobEpisodeId === episodeId) {
-    return true;
-  }
-
   const jobAssetId = firstPresent(
     job?.assetId,
     job?.summary?.assetId,
@@ -753,7 +742,18 @@ function jobMatchesProductionPath(job, episode, assets) {
     job?.output?.assetId,
     job?.metadata?.assetId,
   );
-  return Boolean(jobAssetId && assetIds.has(jobAssetId));
+  if (jobAssetId && assetIds.size > 0) {
+    return assetIds.has(jobAssetId);
+  }
+
+  const jobEpisodeId = firstPresent(
+    job?.episodeId,
+    job?.summary?.episodeId,
+    job?.input?.episodeId,
+    job?.output?.episodeId,
+    job?.metadata?.episodeId,
+  );
+  return Boolean(episodeId && jobEpisodeId === episodeId);
 }
 
 function productionWarnings(episode, assets, jobs) {

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -728,15 +728,44 @@ function activePathWarning(label, title, hasCandidateSelection) {
   return `${label}${title ? ` "${title}"` : ''} is not part of current production for ${pathDescription}.`;
 }
 
+function jobMatchesProductionPath(job, episode, assets) {
+  const episodeId = episode?.id || null;
+  const assetIds = new Set(asArray(assets).map((asset) => asset?.id).filter(Boolean));
+  if (!episodeId && assetIds.size === 0) {
+    return false;
+  }
+
+  const jobEpisodeId = firstPresent(
+    job?.episodeId,
+    job?.summary?.episodeId,
+    job?.input?.episodeId,
+    job?.output?.episodeId,
+    job?.metadata?.episodeId,
+  );
+  if (episodeId && jobEpisodeId === episodeId) {
+    return true;
+  }
+
+  const jobAssetId = firstPresent(
+    job?.assetId,
+    job?.summary?.assetId,
+    job?.input?.assetId,
+    job?.output?.assetId,
+    job?.metadata?.assetId,
+  );
+  return Boolean(jobAssetId && assetIds.has(jobAssetId));
+}
+
 function productionWarnings(episode, assets, jobs) {
   const audioCoverAssets = asArray(assets).filter(isAudioCoverAsset);
+  const scopedJobs = asArray(jobs).filter((job) => jobMatchesProductionPath(job, episode, audioCoverAssets));
   return [
     ...asArray(episode?.warnings),
     ...audioCoverAssets.flatMap((asset) => [
       ...asArray(asset?.metadata?.warnings),
       ...asArray(asset?.metadata?.validation?.warnings),
     ]),
-    ...asArray(jobs).flatMap((job) => asArray(job?.summary?.warnings)),
+    ...scopedJobs.flatMap((job) => asArray(job?.summary?.warnings)),
   ].filter(Boolean);
 }
 
@@ -823,11 +852,13 @@ function publishChecklist({ packet, script, revision, episode, assets, feed, job
     },
     {
       key: 'warnings',
-      label: 'No blocking warnings remain',
-      passed: researchWarnings.length === 0 && prodWarnings.length === 0,
-      reason: researchWarnings.length + prodWarnings.length === 0
-        ? 'No unresolved research or production warnings are selected.'
-        : `${researchWarnings.length + prodWarnings.length} warning${researchWarnings.length + prodWarnings.length === 1 ? '' : 's'} require review.`,
+      label: 'No review-blocking warnings remain',
+      passed: researchWarnings.length === 0,
+      reason: researchWarnings.length > 0
+        ? `${researchWarnings.length} research warning${researchWarnings.length === 1 ? '' : 's'} need override reasons before publishing.`
+        : prodWarnings.length > 0
+          ? `${prodWarnings.length} production warning${prodWarnings.length === 1 ? '' : 's'} visible for review; publish approval records the review decision.`
+          : 'No unresolved research warnings are selected.',
     },
     {
       key: 'publishApproval',

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -944,11 +944,40 @@ function assetWarningItems(asset) {
   ].filter(Boolean);
 }
 
+function jobMatchesSelectedProductionPath(job) {
+  const episode = selectedEpisode();
+  const episodeId = episode?.id || null;
+  const assetIds = new Set(selectedAssets().map((asset) => asset?.id).filter(Boolean));
+  if (!episodeId && assetIds.size === 0) {
+    return false;
+  }
+
+  const jobEpisodeId = firstPresent(
+    job?.episodeId,
+    job?.summary?.episodeId,
+    job?.input?.episodeId,
+    job?.output?.episodeId,
+    job?.metadata?.episodeId,
+  );
+  if (episodeId && jobEpisodeId === episodeId) {
+    return true;
+  }
+
+  const jobAssetId = firstPresent(
+    job?.assetId,
+    job?.summary?.assetId,
+    job?.input?.assetId,
+    job?.output?.assetId,
+    job?.metadata?.assetId,
+  );
+  return Boolean(jobAssetId && assetIds.has(jobAssetId));
+}
+
 function productionWarningItems() {
   return [
     ...asArray(selectedEpisode()?.warnings),
     ...selectedAssets().flatMap(assetWarningItems),
-    ...state.production.jobs.flatMap((job) => asArray(job.summary?.warnings)),
+    ...state.production.jobs.filter(jobMatchesSelectedProductionPath).flatMap((job) => asArray(job.summary?.warnings)),
   ];
 }
 
@@ -1154,11 +1183,13 @@ function publishChecklistState() {
     },
     {
       key: 'warnings',
-      label: 'No blocking warnings remain',
-      passed: unresolvedWarnings.length === 0 && productionWarnings.length === 0,
-      reason: unresolvedWarnings.length + productionWarnings.length === 0
-        ? 'No unresolved research or production warnings are selected.'
-        : `${unresolvedWarnings.length + productionWarnings.length} warning${unresolvedWarnings.length + productionWarnings.length === 1 ? '' : 's'} require review.`,
+      label: 'No review-blocking warnings remain',
+      passed: unresolvedWarnings.length === 0,
+      reason: unresolvedWarnings.length > 0
+        ? `${unresolvedWarnings.length} research warning${unresolvedWarnings.length === 1 ? '' : 's'} need override reasons before publishing.`
+        : productionWarnings.length > 0
+          ? `${productionWarnings.length} production warning${productionWarnings.length === 1 ? '' : 's'} visible for review; publish approval records the review decision.`
+          : 'No unresolved research warnings are selected.',
     },
     {
       key: 'publishApproval',

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -956,17 +956,6 @@ function jobMatchesSelectedProductionPath(job) {
     return false;
   }
 
-  const jobEpisodeId = firstPresent(
-    job?.episodeId,
-    job?.summary?.episodeId,
-    job?.input?.episodeId,
-    job?.output?.episodeId,
-    job?.metadata?.episodeId,
-  );
-  if (episodeId && jobEpisodeId === episodeId) {
-    return true;
-  }
-
   const jobAssetId = firstPresent(
     job?.assetId,
     job?.summary?.assetId,
@@ -974,7 +963,18 @@ function jobMatchesSelectedProductionPath(job) {
     job?.output?.assetId,
     job?.metadata?.assetId,
   );
-  return Boolean(jobAssetId && assetIds.has(jobAssetId));
+  if (jobAssetId && assetIds.size > 0) {
+    return assetIds.has(jobAssetId);
+  }
+
+  const jobEpisodeId = firstPresent(
+    job?.episodeId,
+    job?.summary?.episodeId,
+    job?.input?.episodeId,
+    job?.output?.episodeId,
+    job?.metadata?.episodeId,
+  );
+  return Boolean(episodeId && jobEpisodeId === episodeId);
 }
 
 function productionWarningItems() {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -60,6 +60,10 @@ function reportError(error, fallback = 'Something went wrong. Open technical det
   return fallback;
 }
 
+function firstPresent(...values) {
+  return values.find((value) => typeof value === 'string' && value.trim())?.trim() || '';
+}
+
 function openConfirmationDialog({
   title,
   description,

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -300,7 +300,7 @@ test('production command bar and concrete blocker copy remain present', () => {
     'Cover art asset exists',
     'Feed metadata configured',
     'RSS/public target configured',
-    'No blocking warnings remain',
+    'No review-blocking warnings remain',
     'Episode approved for publishing',
   ]) {
     assertContains(uiJs, checklistItem, `publish checklist item ${checklistItem}`);

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -692,6 +692,51 @@ test('view model treats publish approval as actionable when prerequisites are re
   assert.ok(model.navigationActions.some((navAction) => navAction.targetStage === 'publishing'));
 });
 
+test('view model keeps publish approval actionable when only scoped production warnings remain', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: {
+      episode,
+      assets: [audioAsset, coverAsset],
+      jobs: [
+        {
+          id: 'active-audio-job',
+          status: 'succeeded',
+          input: { episodeId: 'episode-1', assetId: 'asset-audio-1' },
+          summary: { warnings: [{ code: 'MISSING_SCRIPT_CITATION_MAP', message: 'Editors should verify factual lines.' }] },
+        },
+        {
+          id: 'archive-audio-job',
+          status: 'succeeded',
+          input: { episodeId: 'old-episode', assetId: 'old-asset' },
+          summary: { warnings: [{ code: 'ARCHIVE_WARNING', message: 'Archived production warning.' }] },
+        },
+      ],
+    },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Approve for publishing');
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.cockpitHeader.blockerCount, 0);
+  assert.equal(model.cockpitHeader.warningCount, 1);
+  assert.ok(model.warnings.some((warning) => warning.message.includes('Editors should verify factual lines')));
+  assert.equal(model.warnings.some((warning) => warning.message.includes('Archived production warning')), false);
+  assert.equal(model.blockers.some((blocker) => blocker.message.includes('warning')), false);
+});
+
 test('view model blocks publish approval until episode is audio-ready', () => {
   const draftEpisode = { ...episode, status: 'draft' };
   const model = deriveProductionViewModel(baseInput({
@@ -901,13 +946,13 @@ test('view model deduplicates overlapping recent and production jobs', () => {
     status: 'running',
     createdAt: '2026-04-27T14:20:00.000Z',
     updatedAt: '2026-04-27T14:30:00.000Z',
-    summary: { warnings: [{ message: 'Stale warning.' }] },
+    summary: { episodeId: 'episode-1', warnings: [{ message: 'Stale warning.' }] },
   };
   const duplicateJob = {
     ...recentJob,
     status: 'succeeded',
     updatedAt: '2026-04-27T14:45:00.000Z',
-    summary: { warnings: [{ message: 'Preview asset needs review.' }] },
+    summary: { episodeId: 'episode-1', warnings: [{ message: 'Preview asset needs review.' }] },
   };
 
   const model = deriveProductionViewModel(baseInput({

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -737,6 +737,51 @@ test('view model keeps publish approval actionable when only scoped production w
   assert.equal(model.blockers.some((blocker) => blocker.message.includes('warning')), false);
 });
 
+test('view model excludes same-episode production warnings for unselected historical assetIds', () => {
+  const model = deriveProductionViewModel(baseInput({
+    storyCandidates: [candidate],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [readyBrief],
+    selectedResearchPacketId: 'brief-1',
+    scripts: [approvedScript],
+    selectedScriptId: 'script-1',
+    selectedScript: approvedScript,
+    selectedRevision: passedReviewRevision,
+    selectedRevisions: [passedReviewRevision],
+    production: {
+      episode,
+      assets: [audioAsset, coverAsset],
+      jobs: [
+        {
+          id: 'active-audio-job',
+          status: 'succeeded',
+          input: { episodeId: 'episode-1', assetId: 'asset-audio-1' },
+          summary: { warnings: [{ code: 'MISSING_SCRIPT_CITATION_MAP', message: 'Editors should verify factual lines.' }] },
+        },
+        {
+          id: 'historical-audio-job',
+          status: 'succeeded',
+          input: { episodeId: 'episode-1', assetId: 'archived-asset-audio-1' },
+          summary: { warnings: [{ code: 'ARCHIVED_ASSET_WARNING', message: 'Historical production warning.' }] },
+        },
+      ],
+    },
+    episodes: [episode],
+    selectedEpisodeId: 'episode-1',
+    selectedAssetIds: ['asset-audio-1', 'asset-cover-1'],
+  }));
+
+  assert.equal(model.currentStage.id, 'publishing');
+  assert.equal(model.currentStage.status, 'ready');
+  assert.equal(model.primaryNextAction.label, 'Approve for publishing');
+  assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.cockpitHeader.blockerCount, 0);
+  assert.equal(model.cockpitHeader.warningCount, 1);
+  assert.ok(model.warnings.some((warning) => warning.message.includes('Editors should verify factual lines')));
+  assert.equal(model.warnings.some((warning) => warning.message.includes('Historical production warning')), false);
+  assert.equal(model.blockers.some((blocker) => blocker.message.includes('Historical production warning')), false);
+});
+
 test('view model blocks publish approval until episode is audio-ready', () => {
   const draftEpisode = { ...episode, status: 'draft' };
   const model = deriveProductionViewModel(baseInput({


### PR DESCRIPTION
Closes #119

## Summary
- scopes production job warnings to the selected/current episode or selected production assets
- keeps current production warnings visible as review context without blocking publish approval by themselves
- updates static UI smoke and view-model tests for the publish checklist wording and warning-scope behavior
- updates HANDOFF.md with the follow-up orchestration state

## Verification
- `npm run check`
- `git diff --check`

## Notes
Static frontend only; no React/Next/Vite/Vue/Svelte or build-pipeline changes.