### PR TITLE
Focus Produce Episode around one current-stage workspace

### DIFF
--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -65,3 +65,8 @@ current stage, and collapsed non-current stages. When a feature intentionally
 adds controls, group or collapse them in the relevant stage first, then update
 the threshold in that test with the reason in the PR. Do not raise the threshold
 to hide unrelated button growth.
+
+Produce context that is not part of the current stage, including story-source
+detail, task-run details, and audit/history counts, should stay behind
+view-model-driven disclosures. Source/search-recipe detail may default open only
+while source discovery is the active workspace.

--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -555,6 +555,56 @@ textarea:focus-visible {
   margin: 0;
 }
 
+.context-disclosure {
+  background: #ffffff;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  grid-column: 1 / -1;
+  padding: 0.65rem 0.75rem;
+}
+
+.context-disclosure.prominent {
+  border-color: #b8c7d9;
+}
+
+.context-disclosure summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+  min-height: 1.8rem;
+}
+
+.context-disclosure summary span {
+  color: #687486;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.context-disclosure summary strong {
+  color: #27303b;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.context-disclosure-body {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.65rem;
+}
+
+.context-disclosure-reason {
+  color: #586575;
+  font-size: 0.86rem;
+  line-height: 1.35;
+  margin: 0;
+}
+
 .audit-history-disclosure {
   background: #f8fafc;
   border: 1px solid #d8dde5;
@@ -1145,6 +1195,10 @@ textarea:focus-visible {
   min-height: 2.4rem;
 }
 
+.pipeline-card .pipeline-primary-action {
+  box-shadow: 0 8px 18px rgba(31, 91, 149, 0.16);
+}
+
 .pipeline-card.collapsed .pipeline-expand {
   align-self: center;
   grid-column: 2;
@@ -1173,6 +1227,34 @@ textarea:focus-visible {
 .pipeline-card .pipeline-action-reason.blocked,
 .panel .action-blocker-note.blocked {
   color: #70440f;
+}
+
+.pipeline-secondary-actions {
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid #d8dde5;
+  border-radius: 6px;
+  justify-self: start;
+  min-width: min(100%, 18rem);
+  padding: 0.45rem 0.55rem;
+}
+
+.pipeline-secondary-actions summary {
+  color: #3f4b5a;
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 700;
+  min-height: 1.65rem;
+}
+
+.pipeline-secondary-actions-body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.45rem;
+}
+
+.pipeline-secondary-actions-body .pipeline-action-reason {
+  flex-basis: 100%;
 }
 
 .pipeline-debug {

--- a/packages/api/public/ui-state.js
+++ b/packages/api/public/ui-state.js
@@ -56,6 +56,7 @@ export const state = {
   activeSettingsTab: 'shows',
   expandedPipelineStageIds: [],
   currentPipelineStageId: '',
+  contextDisclosureOpen: {},
   auditHistoryOpen: false,
   showSetupOpen: false,
   runningActions: {},

--- a/packages/api/public/ui-view-model.js
+++ b/packages/api/public/ui-view-model.js
@@ -1199,6 +1199,43 @@ function deriveCockpitHeader({
   };
 }
 
+function deriveContextDisclosures({
+  currentStage,
+  selectedStorySourceSummary,
+  workflowActionFeedback,
+}) {
+  const sourceDiscoveryIsCurrent = ['source', 'discover'].includes(currentStage?.id);
+  const sourceSummaryText = selectedStorySourceSummary
+    ? `${selectedStorySourceSummary.name} | ${selectedStorySourceSummary.providerType} | ${selectedStorySourceSummary.enabledQueryCount ?? 0} enabled input${selectedStorySourceSummary.enabledQueryCount === 1 ? '' : 's'}`
+    : 'No story source selected';
+  const feedbackIsVisible = Boolean(workflowActionFeedback && workflowActionFeedback.status !== 'idle');
+
+  return {
+    storySource: {
+      key: 'storySource',
+      label: sourceDiscoveryIsCurrent ? 'Source discovery setup' : 'Story-source details',
+      summary: sourceDiscoveryIsCurrent
+        ? (selectedStorySourceSummary?.nextActionDescription || 'Choose or run the current story source.')
+        : sourceSummaryText,
+      defaultOpen: sourceDiscoveryIsCurrent,
+      prominent: sourceDiscoveryIsCurrent,
+      reason: sourceDiscoveryIsCurrent
+        ? 'Source/search-recipe detail is current-stage work.'
+        : 'Source/search-recipe detail is available for audit without competing with the current stage.',
+    },
+    actionResult: {
+      key: 'actionResult',
+      label: 'Latest task result',
+      summary: feedbackIsVisible
+        ? workflowActionFeedback.message || workflowActionFeedback.conciseMessage || 'Task result available.'
+        : 'No task result recorded yet.',
+      defaultOpen: false,
+      visible: feedbackIsVisible,
+      reason: 'Run details stay available without adding another default status surface above the current workspace.',
+    },
+  };
+}
+
 function deriveHistoricalArtifacts({ activeIds, packets, scripts, revisions, assets, episodes }) {
   return {
     briefs: newest(packets).filter((packet) => packet.id !== activeIds.briefId).map((packet) => markArtifact(summarizeBrief(packet), 'archive')),
@@ -1355,6 +1392,12 @@ export function deriveProductionViewModel(input = {}) {
     primaryNextAction,
     latestActionResult: workflowActionFeedback,
   });
+  const selectedStorySourceSummary = summarizeSource(selectedSource, sourceQueries, jobs);
+  const contextDisclosures = deriveContextDisclosures({
+    currentStage,
+    selectedStorySourceSummary,
+    workflowActionFeedback,
+  });
   const scriptReviewWorkspace = summarizeScriptReviewWorkspace(
     activeScript,
     activeRevision,
@@ -1365,7 +1408,7 @@ export function deriveProductionViewModel(input = {}) {
 
   return {
     selectedShowSummary: summarizeShow(selectedShow),
-    selectedStorySourceSummary: summarizeSource(selectedSource, sourceQueries, jobs),
+    selectedStorySourceSummary,
     selectedCandidateStorySummary: summarizeCandidates(selectedCandidates),
     activeDraftEpisodeSummary: activeEpisode && activeEpisode.status !== 'published' ? summarizeEpisode(activeEpisode) : null,
     currentStage: {
@@ -1384,6 +1427,7 @@ export function deriveProductionViewModel(input = {}) {
     secondaryActions,
     navigationActions,
     cockpitHeader,
+    contextDisclosures,
     latestActionResult: workflowActionFeedback,
     workflowActionFeedback,
     warnings,

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -1624,6 +1624,7 @@ function pruneExpandedPipelineStages(stages) {
 function syncCurrentPipelineStage(currentStageId) {
   if (state.currentPipelineStageId && state.currentPipelineStageId !== currentStageId) {
     state.expandedPipelineStageIds = [];
+    state.contextDisclosureOpen = {};
   }
   state.currentPipelineStageId = currentStageId;
 }
@@ -2022,7 +2023,7 @@ function stageCard(stage, currentStageId = '') {
 
   const button = document.createElement('button');
   button.type = 'button';
-  button.className = stage.primary ? '' : 'secondary';
+  button.className = stage.id === currentStageId || stage.primary ? 'pipeline-primary-action' : 'secondary';
   button.textContent = stage.actionLabel;
   button.disabled = stage.disabled;
   button.title = stage.disabled ? (stage.actionReason || stage.next) : '';
@@ -2041,13 +2042,14 @@ function stageCard(stage, currentStageId = '') {
 
   body.append(artifacts, next, button, actionReason);
 
+  const secondaryActions = [];
   if (stage.targetId && panelIsAvailable(stage.targetId)) {
     const panelButton = document.createElement('button');
     panelButton.type = 'button';
     panelButton.className = 'secondary';
     panelButton.textContent = stage.panelActionLabel || `Review ${stage.title}`;
     panelButton.addEventListener('click', () => scrollToPanel(stage.targetId));
-    body.append(panelButton);
+    secondaryActions.push(panelButton);
   }
 
   if (stage.jobTypes?.length) {
@@ -2065,10 +2067,22 @@ function stageCard(stage, currentStageId = '') {
       jobReason.textContent = 'No task run has been recorded for this stage yet.';
       jobButton.title = jobReason.textContent;
       jobButton.setAttribute('aria-describedby', jobReasonId);
-      body.append(jobReason);
+      secondaryActions.push(jobReason);
     }
     jobButton.addEventListener('click', () => viewLatestJob(stage.jobTypes));
-    body.append(jobButton);
+    secondaryActions.push(jobButton);
+  }
+
+  if (secondaryActions.length > 0) {
+    const secondaryDisclosure = document.createElement('details');
+    secondaryDisclosure.className = 'pipeline-secondary-actions';
+    const secondarySummary = document.createElement('summary');
+    secondarySummary.textContent = 'More stage options';
+    const secondaryBody = document.createElement('div');
+    secondaryBody.className = 'pipeline-secondary-actions-body';
+    secondaryBody.append(...secondaryActions);
+    secondaryDisclosure.append(secondarySummary, secondaryBody);
+    body.append(secondaryDisclosure);
   }
 
   if (stage.id !== currentStageId) {
@@ -2180,6 +2194,42 @@ function appendSourceSummaryMetric(container, label, value, className = '') {
   container.append(item);
 }
 
+function contextDisclosureIsOpen(key, defaultOpen = false) {
+  return Object.prototype.hasOwnProperty.call(state.contextDisclosureOpen, key)
+    ? Boolean(state.contextDisclosureOpen[key])
+    : Boolean(defaultOpen);
+}
+
+function renderContextDisclosure(config, renderBody) {
+  const details = document.createElement('details');
+  details.className = `context-disclosure ${config.key || 'context'}${config.prominent ? ' prominent' : ''}`;
+  details.open = contextDisclosureIsOpen(config.key, config.defaultOpen);
+  details.addEventListener('toggle', () => {
+    state.contextDisclosureOpen[config.key] = details.open;
+  });
+
+  const summary = document.createElement('summary');
+  const label = document.createElement('span');
+  label.textContent = config.label || 'Details';
+  const text = document.createElement('strong');
+  text.textContent = config.summary || 'Details available';
+  summary.append(label, text);
+
+  const body = document.createElement('div');
+  body.className = 'context-disclosure-body';
+  const reason = document.createElement('p');
+  reason.className = 'context-disclosure-reason';
+  reason.textContent = config.reason || 'Details are available when needed.';
+  body.append(reason);
+  const renderedBody = renderBody();
+  if (renderedBody) {
+    body.append(renderedBody);
+  }
+
+  details.append(summary, body);
+  return details;
+}
+
 function renderStorySourceSummary(summary) {
   const panel = document.createElement('section');
   panel.className = `story-source-summary${summary?.discoveryReady === false ? ' blocked' : ''}`;
@@ -2227,6 +2277,26 @@ function renderStorySourceSummary(summary) {
 
   panel.append(header, metrics, action);
   return panel;
+}
+
+function renderStorySourceDisclosure(viewModel) {
+  const disclosure = viewModel.contextDisclosures?.storySource || {
+    key: 'storySource',
+    label: 'Story-source details',
+    summary: 'Story source details available.',
+    defaultOpen: false,
+  };
+  return renderContextDisclosure(disclosure, () => renderStorySourceSummary(viewModel.selectedStorySourceSummary));
+}
+
+function renderWorkflowFeedbackDisclosure(viewModel) {
+  const feedback = viewModel.workflowActionFeedback;
+  const disclosure = viewModel.contextDisclosures?.actionResult;
+  if (!feedback || feedback.status === 'idle' || !disclosure?.visible) {
+    return null;
+  }
+
+  return renderContextDisclosure(disclosure, () => renderWorkflowFeedbackPanel(feedback));
 }
 
 function archiveArtifactGroupLabel(key) {
@@ -2626,10 +2696,11 @@ function renderPipeline() {
     els.workflowContext.append(item);
   }
 
-  els.workflowContext.append(renderStorySourceSummary(viewModel.selectedStorySourceSummary));
+  els.workflowContext.append(renderStorySourceDisclosure(viewModel));
 
-  if (viewModel.workflowActionFeedback && viewModel.workflowActionFeedback.status !== 'idle') {
-    els.workflowContext.append(renderWorkflowFeedbackPanel(viewModel.workflowActionFeedback));
+  const feedbackDisclosure = renderWorkflowFeedbackDisclosure(viewModel);
+  if (feedbackDisclosure) {
+    els.workflowContext.append(feedbackDisclosure);
   }
 
   els.workflowContext.append(renderAuditHistoryDisclosure(viewModel));

--- a/scripts/ui-complexity-smoke.test.mjs
+++ b/scripts/ui-complexity-smoke.test.mjs
@@ -19,9 +19,9 @@ const NORMAL_PRODUCE_COMPLEXITY_LIMITS = Object.freeze({
   maxExpandedStageCards: 1,
   maxCollapsedStageCards: 7,
   maxCommandBarControls: 3,
-  maxStageTrackerControls: 12,
-  maxVisibleControls: 15,
-  maxElementNodes: 110,
+  maxStageTrackerControls: 8,
+  maxVisibleControls: 10,
+  maxElementNodes: 115,
 });
 
 const AMBIGUOUS_NORMAL_CONTROL_LABELS = [
@@ -123,12 +123,6 @@ function expandedStageControls(stageId, viewModel) {
     controls.push(`Review ${TRACKER_STAGES.find((stage) => stage.id === stageId)?.label || 'current stage'}`);
   }
 
-  controls.push(stageId === 'discover' ? 'Edit story source settings' : `Review ${TRACKER_STAGES.find((stage) => stage.id === stageId)?.label || 'stage'}`);
-
-  if (['discover', 'brief', 'script', 'production', 'publishing'].includes(stageId)) {
-    controls.push('View Latest Run');
-  }
-
   return controls;
 }
 
@@ -170,10 +164,18 @@ function renderNormalProduceSnapshot(viewModel) {
       </div>
     </section>`;
 
+  const sourceDisclosureOpen = Boolean(viewModel.contextDisclosures?.storySource?.defaultOpen);
+  const sourceDisclosureHtml = `
+    <details class="context-disclosure storySource${sourceDisclosureOpen ? ' prominent' : ''}"${sourceDisclosureOpen ? ' open' : ''}>
+      <summary><span>${escapeHtml(viewModel.contextDisclosures.storySource.label)}</span><strong>${escapeHtml(viewModel.contextDisclosures.storySource.summary)}</strong></summary>
+      <div class="context-disclosure-body">Story-source/search-recipe detail</div>
+    </details>`;
+
   const stageCards = TRACKER_STAGES.map((stage, index) => {
     const expanded = stage.id === currentStageId;
     const controls = expanded ? expandedStageControls(stage.id, viewModel) : ['Expand stage'];
-    labels.push(stage.label, trackerStatus(stage.id, viewModel), ...controls);
+    const secondaryDisclosure = expanded ? ['More stage options'] : [];
+    labels.push(stage.label, trackerStatus(stage.id, viewModel), ...controls, ...secondaryDisclosure);
     return {
       ...stage,
       number: index + 1,
@@ -182,6 +184,7 @@ function renderNormalProduceSnapshot(viewModel) {
       collapsed: !expanded,
       status: trackerStatus(stage.id, viewModel),
       controls,
+      secondaryDisclosure,
     };
   });
 
@@ -191,12 +194,12 @@ function renderNormalProduceSnapshot(viewModel) {
         <article class="pipeline-card ${stage.expanded ? 'expanded current' : 'collapsed'}" data-stage="${stage.number}" data-stage-id="${stage.id}" data-stage-status="${escapeHtml(stage.status)}">
           <div class="pipeline-top"><div><div>Stage ${stage.number}</div><h3>${escapeHtml(stage.label)}</h3></div><span>${escapeHtml(stage.status)}</span>${stage.current ? '<span>current</span>' : ''}</div>
           <div class="pipeline-summary"><p>${escapeHtml(stage.label)}</p><p>${stage.expanded ? 'Next step' : 'Collapsed until current'}</p></div>
-          ${stage.expanded ? `<div class="pipeline-card-body">${stage.controls.map((label) => `<button type="button">${escapeHtml(label)}</button>`).join('')}</div>` : `<button type="button" aria-expanded="false">Expand stage</button>`}
+          ${stage.expanded ? `<div class="pipeline-card-body">${stage.controls.map((label) => `<button type="button">${escapeHtml(label)}</button>`).join('')}<details><summary>More stage options</summary></details></div>` : `<button type="button" aria-expanded="false">Expand stage</button>`}
         </article>
       `).join('')}
     </div>`;
 
-  const html = `${commandBarHtml}${stageHtml}`;
+  const html = `${commandBarHtml}${sourceDisclosureHtml}${stageHtml}`;
   const commandBarControlCount = commandBarControls.length;
   const stageTrackerControlCount = stageCards.reduce((total, stage) => total + stage.controls.length, 0);
   const elementNodes = html.match(/<[a-z][a-z0-9-]*(?:\s|>)/gi)?.length ?? 0;
@@ -206,6 +209,7 @@ function renderNormalProduceSnapshot(viewModel) {
     labels,
     commandBarControls,
     stageCards,
+    sourceDisclosureOpen,
     metrics: {
       commandBarControlCount,
       stageTrackerControlCount,
@@ -229,6 +233,7 @@ test('normal Produce view-model snapshot has command bar and one expanded curren
   assert.match(snapshot.html, /id="pipelineStages"/);
   assert.equal(snapshot.metrics.stageCards, NORMAL_PRODUCE_COMPLEXITY_LIMITS.stageCards);
   assert.equal(snapshot.metrics.expandedStageCards, 1);
+  assert.equal(snapshot.sourceDisclosureOpen, true, 'source/search detail should default open while discovery is current');
   assert.equal(currentStage?.id, 'discover');
   assert.deepEqual(
     snapshot.stageCards.filter((stage) => stage.collapsed).map((stage) => stage.id),
@@ -252,12 +257,50 @@ test('normal Produce workflow controls avoid ambiguous button soup copy', () => 
     snapshot.stageCards.filter((stage) => stage.collapsed).every((stage) => stage.controls.length === 1),
     'collapsed stages should expose one disclosure control each',
   );
+  assert.deepEqual(
+    snapshot.stageCards.find((stage) => stage.current)?.controls,
+    [viewModel.primaryNextAction.label],
+    'current stage card should expose one primary button by default',
+  );
+  assert.deepEqual(
+    snapshot.stageCards.find((stage) => stage.current)?.secondaryDisclosure,
+    ['More stage options'],
+    'current stage secondary controls should be disclosed instead of rendered as peer buttons',
+  );
 
   for (const pattern of AMBIGUOUS_NORMAL_CONTROL_LABELS) {
     for (const label of controlLabels) {
       assert.doesNotMatch(label, pattern, `normal Produce control label should not include ${pattern}`);
     }
   }
+});
+
+test('non-discovery Produce states keep story-source detail collapsed by default', () => {
+  const viewModel = deriveProductionViewModel({
+    ...normalInitialProduceInput(),
+    storyCandidates: [{
+      id: 'candidate-1',
+      title: 'Regulators publish new AI safety guidance',
+      status: 'new',
+      canonicalUrl: 'https://example.com/story',
+    }],
+    selectedCandidateIds: ['candidate-1'],
+    researchPackets: [{
+      id: 'brief-1',
+      title: 'AI safety guidance brief',
+      status: 'ready',
+      warnings: [],
+      citations: [{ url: 'https://example.com/story' }],
+      content: { candidateIds: ['candidate-1'] },
+      updatedAt: '2026-04-28T10:00:00.000Z',
+    }],
+    selectedResearchPacketId: 'brief-1',
+  });
+  const snapshot = renderNormalProduceSnapshot(viewModel);
+
+  assert.equal(viewModel.currentStage.id, 'script');
+  assert.equal(snapshot.sourceDisclosureOpen, false, 'source/search detail should be collapsed after discovery is no longer current');
+  assert.match(snapshot.html, /Story-source details/);
 });
 
 test('normal Produce DOM/control complexity stays below the documented guardrail', () => {

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -228,13 +228,17 @@ test('stage tracker progressively discloses only the current stage by default', 
   assertContains(uiJs, "status.setAttribute('aria-label', `Status: ${statusLabel}`)", 'stage status pills should expose explicit status labels');
   assertContains(uiJs, "card.className = `pipeline-card ${statusClass(statusLabel)}${expanded ? ' expanded' : ' collapsed'}${stage.id === currentStageId ? ' current' : ''}`", 'stage cards should mark collapsed/current state');
   assertContains(uiJs, "button.textContent = stage.actionLabel", 'existing stage action remains available when expanded');
+  assertContains(uiJs, "button.className = stage.id === currentStageId || stage.primary ? 'pipeline-primary-action' : 'secondary'", 'current stage action should be visually primary');
   assertContains(uiJs, 'body.append(artifacts, next, button, actionReason)', 'expanded stage body keeps action context');
+  assertContains(uiJs, "secondarySummary.textContent = 'More stage options'", 'secondary stage controls should be disclosed behind one affordance');
+  assertContains(uiJs, "secondaryDisclosure.className = 'pipeline-secondary-actions'", 'stage secondary actions should use subordinate disclosure styling');
   assertContains(uiJs, 'els.pipelineStages.append(stageCard(stage, currentStageId))', 'render should pass the current stage into each card');
   assertContains(uiJs, "currentBadge.textContent = 'current'", 'current stage should be called out separately from status');
   assertContains(uiJs, "artifactLabel.textContent = 'Active/current artifact'", 'expanded stages should not call archived records latest active artifacts');
   assertContains(uiJs, 'function pruneExpandedPipelineStages(stages)', 'expanded stage state should be pruned during render');
   assertContains(uiJs, 'function syncCurrentPipelineStage(currentStageId)', 'current stage changes should reset manual expansions');
   assertContains(uiJs, 'state.expandedPipelineStageIds = []', 'changing workflow context should reset expanded stage state');
+  assertContains(uiJs, 'state.contextDisclosureOpen = {}', 'changing current stage should restore focused disclosure defaults');
 
   for (const status of ['not started', 'blocked', 'ready', 'complete', 'warning']) {
     assertContains(uiJs, `return '${status}'`, `stage tracker status ${status}`);
@@ -242,6 +246,8 @@ test('stage tracker progressively discloses only the current stage by default', 
 
   assertContains(stylesCss, '.pipeline-card.collapsed .pipeline-expand', 'collapsed tracker styles');
   assertContains(stylesCss, '.pipeline-card-body', 'expanded tracker body styles');
+  assertContains(stylesCss, '.pipeline-secondary-actions', 'secondary stage action disclosure styles');
+  assertContains(stylesCss, '.pipeline-card .pipeline-primary-action', 'current stage primary action style');
   assertContains(stylesCss, '.status-pill.current', 'current status style');
   assertContains(stylesCss, '.status-pill.complete', 'complete status style');
 });
@@ -254,7 +260,7 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'viewModel.primaryNextAction', 'command bar primary action from view model');
   assertContains(uiJs, 'viewModel.latestActionResult', 'command bar latest result from view model');
   assertContains(uiJs, 'viewModel.workflowActionFeedback', 'command bar workflow feedback from view model');
-  assertContains(uiJs, "viewModel.workflowActionFeedback.status !== 'idle'", 'idle workflow feedback should not render as a persistent panel');
+  assertContains(uiJs, "feedback.status === 'idle'", 'idle workflow feedback should not render as a persistent panel');
   assertContains(uiJs, 'viewModel.warnings.length', 'command bar warning count from view model');
   assertContains(uiJs, 'action: legacyStage?.disabled ? null : legacyStage?.action || null', 'command bar primary action should invoke available stage actions');
   assertContains(uiJs, "appendCommandBarMetric(metrics, 'Active stage'", 'cockpit header should show active stage');
@@ -271,6 +277,7 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'Latest failure', 'command bar failure summary label');
   assertContains(uiJs, 'Review current stage', 'command bar stage details button');
   assertContains(uiJs, 'function renderWorkflowFeedbackPanel(feedback', 'workflow feedback panel renderer');
+  assertContains(uiJs, 'function renderWorkflowFeedbackDisclosure(viewModel)', 'workflow feedback should be behind contextual disclosure outside the command bar');
   assertContains(uiJs, 'function attachWorkflowFeedback(stages, viewModel, currentStageId)', 'stage feedback attachment helper');
   assertContains(uiJs, "label.textContent = compact ? 'Current stage result' : 'Action result'", 'current stage result label');
   assertContains(uiJs, 'workflowFeedbackDetailText(feedback)', 'feedback details keep warning/debug data available');
@@ -281,13 +288,20 @@ test('production command bar and concrete blocker copy remain present', () => {
   assertContains(uiJs, 'function checklistBlockers(checklist', 'checklist blocker helper');
   assertContains(uiJs, 'command-bar-blocker', 'command bar blocker summary');
   assertContains(uiJs, 'function renderAuditHistoryDisclosure(viewModel)', 'archive warnings should render behind an audit/history disclosure');
+  assertContains(uiJs, 'function renderStorySourceDisclosure(viewModel)', 'story source detail should render through contextual disclosure');
+  assertContains(uiJs, 'viewModel.contextDisclosures?.storySource', 'story source disclosure should be view-model driven');
   assertContains(uiJs, "summaryLabel.textContent = 'Audit/history'", 'audit/history disclosure should be explicitly labeled');
   assertContains(uiStateJs, 'auditHistoryOpen: false', 'audit/history disclosure state should be tracked across renders');
+  assertContains(uiStateJs, 'contextDisclosureOpen: {}', 'context disclosures should be tracked across renders');
   assertContains(uiJs, 'details.open = Boolean(state.auditHistoryOpen)', 'audit/history disclosure should restore its open state');
   assertContains(uiJs, 'state.auditHistoryOpen = details.open', 'audit/history disclosure should persist user toggles');
+  assertContains(uiViewModelJs, 'function deriveContextDisclosures', 'Produce context disclosure policy should live in the view model');
+  assertContains(uiViewModelJs, "defaultOpen: sourceDiscoveryIsCurrent", 'source/search details should default open only while source discovery is current');
+  assertContains(uiViewModelJs, "defaultOpen: false", 'task result disclosure should stay closed by default');
   assertContains(uiJs, 'artifactScopeWarnings', 'view model archive warnings should stay accessible for audit');
   assertContains(uiJs, 'History/archive records remain available for audit, but production and publishing actions use active/current artifacts only.', 'workflow should explain active versus archive state');
   assertContains(stylesCss, '.audit-history-disclosure', 'audit/history disclosure styles');
+  assertContains(stylesCss, '.context-disclosure', 'contextual disclosure styles');
   assertContains(uiJs, 'const researchPacketId = selectedResearchPacket()?.id', 'script generation should use active/current research packet selection');
   assert.doesNotMatch(uiJs, /const researchPacketId = state\.selectedResearchPacketId/, 'script generation must not post archived saved packet ids');
   assert.doesNotMatch(uiJs, /latestArtifacts\?\.publishing\?\.title/, 'command bar must not present archived/latest episodes as active production context');

--- a/scripts/ui-production-view-model.test.mjs
+++ b/scripts/ui-production-view-model.test.mjs
@@ -255,6 +255,10 @@ test('view model covers source selected with no candidate stories', () => {
   assert.equal(model.currentStage.status, 'ready');
   assert.equal(model.primaryNextAction.label, 'Search Brave');
   assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.contextDisclosures.storySource.defaultOpen, true);
+  assert.equal(model.contextDisclosures.storySource.prominent, true);
+  assert.match(model.contextDisclosures.storySource.reason, /current-stage work/);
+  assert.equal(model.contextDisclosures.actionResult.defaultOpen, false);
 });
 
 test('view model covers candidates loaded but no story selected', () => {
@@ -319,6 +323,9 @@ test('view model exposes Produce Episode cockpit header context', () => {
   assert.match(model.cockpitHeader.latestResult.message, /Source search succeeded/);
   assert.equal(model.cockpitHeader.primaryNextAction.label, 'Build research brief');
   assert.equal(model.cockpitHeader.primaryNextAction.disabledReason, '');
+  assert.equal(model.contextDisclosures.actionResult.visible, true);
+  assert.equal(model.contextDisclosures.actionResult.defaultOpen, false);
+  assert.match(model.contextDisclosures.actionResult.reason, /without adding another default status surface/);
 });
 
 test('view model blocks drafting while research warnings are unresolved', () => {
@@ -367,6 +374,9 @@ test('view model covers research brief ready with no script', () => {
   assert.equal(model.currentStage.status, 'ready');
   assert.equal(model.primaryNextAction.label, 'Generate script draft');
   assert.equal(model.primaryNextAction.enabled, true);
+  assert.equal(model.contextDisclosures.storySource.defaultOpen, false);
+  assert.equal(model.contextDisclosures.storySource.prominent, false);
+  assert.match(model.contextDisclosures.storySource.summary, /Demo Story Sources/);
 });
 
 test('view model recovers downstream workflow when candidate selection is stale', () => {


### PR DESCRIPTION
## Summary
- focuses Produce Episode around view-model-driven current-stage context disclosures
- moves story-source details and action-result details behind contextual disclosures
- groups secondary stage actions behind a More stage options disclosure
- adds/updates UI smoke, complexity, and view-model coverage

Closes #122

## Verification
- npm run check
- git diff --check