### PR TITLE
Compact AI admin surfaces and readability

### DIFF
--- a/packages/api/public/styles.css
+++ b/packages/api/public/styles.css
@@ -29,6 +29,8 @@
 
 body {
   background: #f5f6f8;
+  color: #20242c;
+  line-height: 1.5;
   margin: 0;
   overflow-x: clip;
 }
@@ -158,9 +160,10 @@ textarea:focus-visible {
 
 .help,
 .field small {
-  color: #687486;
+  color: #586575;
   font-size: 0.85rem;
-  line-height: 1.35;
+  line-height: 1.5;
+  max-width: 72ch;
 }
 
 .field small {
@@ -170,6 +173,7 @@ textarea:focus-visible {
 .debug-details {
   color: #3f4b5a;
   font-size: 0.85rem;
+  line-height: 1.5;
   margin-top: 0.45rem;
   max-width: min(720px, 100%);
 }
@@ -2584,7 +2588,7 @@ textarea {
   border: 1px solid #9ec4ed;
   border-radius: 8px;
   color: #1f4d7a;
-  padding: 0.85rem 0.95rem;
+  padding: 0.95rem 1.05rem;
 }
 
 .settings-overview h3,
@@ -2593,7 +2597,9 @@ textarea {
 }
 
 .settings-overview p {
+  line-height: 1.5;
   margin-top: 0.25rem;
+  max-width: 76ch;
 }
 
 .settings-card {
@@ -2601,8 +2607,8 @@ textarea {
   border: 1px solid #d8dde5;
   border-radius: 8px;
   display: grid;
-  gap: 0.85rem;
-  padding: 0.9rem;
+  gap: 0.95rem;
+  padding: 1rem;
 }
 
 .settings-card-heading {
@@ -2614,12 +2620,15 @@ textarea {
 
 .settings-card-heading h3,
 .settings-subhead h3 {
+  line-height: 1.25;
   margin: 0;
 }
 
 .settings-card-heading p,
 .settings-subhead p {
+  line-height: 1.5;
   margin: 0.25rem 0 0;
+  max-width: 72ch;
 }
 
 .settings-form .grid {
@@ -2646,6 +2655,7 @@ textarea {
   background: #ffffff;
   border: 1px solid #d8dde5;
   border-radius: 6px;
+  line-height: 1.5;
   padding: 0.65rem 0.75rem;
 }
 
@@ -2672,6 +2682,8 @@ textarea {
   border: 1px solid #9ec4ed;
   border-radius: 6px;
   color: #1f4d7a;
+  line-height: 1.5;
+  max-width: 76ch;
   padding: 0.65rem 0.75rem;
 }
 
@@ -2681,12 +2693,17 @@ textarea {
   gap: 0.45rem;
 }
 
+.settings-summary-kv {
+  gap: 0.5rem;
+}
+
 .settings-kv span {
   background: white;
   border: 1px solid #d8dde5;
   border-radius: 999px;
   color: #3f4b5a;
   font-size: 0.85rem;
+  line-height: 1.35;
   padding: 0.2rem 0.5rem;
 }
 
@@ -2698,6 +2715,7 @@ textarea {
 .prompt-card textarea[readonly] {
   background: white;
   color: #27303b;
+  line-height: 1.5;
 }
 
 @media (max-width: 820px) {

--- a/packages/api/public/ui.js
+++ b/packages/api/public/ui.js
@@ -3323,6 +3323,45 @@ function appendSettingsChip(container, label, value) {
   container.append(item);
 }
 
+function countLabel(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function modelRoleSummary(profile, params = asObject(profile.config?.params)) {
+  return [
+    ['Role key', formatRole(profile.role)],
+    ['Agent instructions', profile.promptTemplateKey ? 'custom prompt selected' : 'default prompt'],
+    ['Fallbacks', countLabel(asArray(profile.fallbacks).length, 'fallback')],
+    ['Budget guard', profile.budgetUsd === null || profile.budgetUsd === undefined ? 'not configured' : 'configured'],
+    ['Reasoning', typeof params.reasoningEffort === 'string' ? 'configured' : 'default'],
+  ];
+}
+
+function promptTemplateSummary(template) {
+  const body = String(template.body || '');
+  return [
+    ['Role', formatRole(template.role)],
+    ['Key', template.key],
+    ['Version', template.version],
+    ['Output format', template.outputFormat],
+    ['Schema', template.outputSchemaName || 'none'],
+    ['Body length', countLabel(body.length, 'character')],
+    ['Variables', countLabel(asArray(template.inputVariables).length, 'variable')],
+  ];
+}
+
+function failedRunForPipeline(pipeline) {
+  return state.failedScheduledRuns.find((job) => {
+    const input = asObject(job.input);
+    return input.scheduledPipelineSlug === pipeline.slug
+      || input.scheduledPipelineId === pipeline.id;
+  }) || null;
+}
+
+function scheduleFailureSummary(job) {
+  return job ? `failed ${formatTime(job.updatedAt)}` : 'none recorded';
+}
+
 function setActiveSettingsTab(tab) {
   if (!SETTINGS_TAB_PANELS[tab]) {
     return;
@@ -3776,8 +3815,9 @@ function renderSettingsModels() {
           <h3></h3>
           <p class="help"></p>
         </div>
+        <span class="status-pill neutral">advanced edit closed</span>
       </div>
-      <div class="settings-kv"></div>
+      <div class="settings-kv settings-summary-kv"></div>
       <details class="settings-advanced">
         <summary>Advanced model/provider routing</summary>
         <div class="grid">
@@ -3796,8 +3836,9 @@ function renderSettingsModels() {
     form.querySelector('h3').textContent = info.title;
     form.querySelector('.help').textContent = info.description;
     const kv = form.querySelector('.settings-kv');
-    appendSettingsChip(kv, 'Role key', formatRole(profile.role));
-    appendSettingsChip(kv, 'Routing', 'collapsed in Advanced model/provider routing');
+    for (const [label, value] of modelRoleSummary(profile, params)) {
+      appendSettingsChip(kv, label, value);
+    }
     form.elements.provider.value = profile.provider;
     form.elements.model.value = profile.model;
     form.elements.promptTemplateKey.value = profile.promptTemplateKey || '';
@@ -3848,8 +3889,9 @@ function renderSettingsPrompts() {
         </div>
         <span class="status-pill ready"></span>
       </div>
+      <div class="settings-kv settings-summary-kv"></div>
       <details class="settings-advanced">
-        <summary>Prompt internals and output schema</summary>
+        <summary>Advanced prompt body and output schema</summary>
         <div class="settings-kv"></div>
         <label class="field"><span>Agent instructions</span><textarea rows="8" readonly></textarea></label>
         <details class="debug-details"><summary>Output schema summary</summary><pre></pre></details>
@@ -3858,7 +3900,11 @@ function renderSettingsPrompts() {
     card.querySelector('h3').textContent = template.title || template.key;
     card.querySelector('.help').textContent = template.description || 'No description recorded.';
     card.querySelector('.status-pill').textContent = template.showId ? 'show override' : 'global default';
-    const kv = card.querySelector('.settings-kv');
+    const summaryKv = card.querySelector('.settings-summary-kv');
+    for (const [label, value] of promptTemplateSummary(template)) {
+      appendSettingsChip(summaryKv, label, value);
+    }
+    const advancedKv = card.querySelector('.settings-advanced .settings-kv');
     for (const [label, value] of [
       ['Role', formatRole(template.role)],
       ['Key', template.key],
@@ -3866,9 +3912,7 @@ function renderSettingsPrompts() {
       ['Output format', template.outputFormat],
       ['Schema', template.outputSchemaName || 'none'],
     ]) {
-      const item = document.createElement('span');
-      item.textContent = `${label}: ${value}`;
-      kv.append(item);
+      appendSettingsChip(advancedKv, label, value);
     }
     card.querySelector('textarea').value = template.body || '';
     card.querySelector('pre').textContent = JSON.stringify(sanitizedDebug({
@@ -3979,7 +4023,7 @@ function renderSettingsSchedules() {
 
   els.settingsSchedules.append(settingsOverview(
     'Automation',
-    'Review whether scheduled work is enabled and whether publishing is allowed unattended. Cron, workflow, and manual run controls are collapsed by default.',
+    'Review whether scheduled work is enabled, when it runs next, and whether it failed recently. Cron, workflow, and autopublish controls are collapsed by default.',
   ));
 
   if (state.scheduledPipelines.length === 0) {
@@ -3987,37 +4031,44 @@ function renderSettingsSchedules() {
   }
 
   for (const pipeline of state.scheduledPipelines) {
+    const nextRun = pipeline.nextRunAt ? formatTime(pipeline.nextRunAt) : 'not scheduled';
+    const failedRun = failedRunForPipeline(pipeline);
     const form = document.createElement('form');
     form.className = 'settings-card settings-form';
     form.innerHTML = `
       <div class="settings-card-heading">
         <div>
           <h3></h3>
-          <p class="help">Routine automation review shows whether the run is enabled. Cron, workflow, manual run, and autopublish controls are advanced.</p>
+          <p class="help">Run status is visible first. Cron, workflow, and autopublish controls stay in advanced editing.</p>
         </div>
-        <button type="submit">Save Schedule</button>
+        <button class="secondary" name="run" type="button">Run Now</button>
       </div>
-      <div class="grid">
-        <label class="field"><span>Name</span><input name="name" type="text" required></label>
-        <label class="toggle admin-toggle"><input name="enabled" type="checkbox"><span>Enabled</span></label>
-      </div>
+      <div class="settings-kv settings-summary-kv"></div>
       <details class="settings-advanced">
         <summary>Advanced schedule workflow and publish controls</summary>
         <div class="grid">
+          <label class="field"><span>Name</span><input name="name" type="text" required></label>
           <label class="field"><span>Slug</span><input name="slug" type="text" required></label>
           <label class="field"><span>Cron</span><input name="cron" type="text" required></label>
           <label class="field"><span>Timezone</span><input name="timezone" type="text" required></label>
           <label class="field"><span>Workflow</span><input name="workflow" type="text" required></label>
+          <label class="toggle admin-toggle"><input name="enabled" type="checkbox"><span>Enabled</span></label>
           <label class="toggle admin-toggle"><input name="autopublish" type="checkbox"><span>Autopublish</span></label>
         </div>
         <p class="settings-note">Autopublish should stay off unless the show is explicitly approved for unattended publishing.</p>
-        <div class="actions inline">
-          <button class="secondary" name="run" type="button">Run Now</button>
-        </div>
+        <div class="actions inline"><button type="submit">Save Schedule</button></div>
       </details>
     `;
-    const nextRun = pipeline.nextRunAt ? new Date(pipeline.nextRunAt).toLocaleString() : 'not scheduled';
-    form.querySelector('h3').textContent = `${pipeline.name} | next ${nextRun}`;
+    form.querySelector('h3').textContent = pipeline.name;
+    const summaryKv = form.querySelector('.settings-summary-kv');
+    for (const [label, value] of [
+      ['Status', pipeline.enabled ? 'enabled' : 'disabled'],
+      ['Next run', nextRun],
+      ['Last failure', scheduleFailureSummary(failedRun)],
+      ['Publishing', pipeline.autopublish ? 'autopublish configured' : 'approval required'],
+    ]) {
+      appendSettingsChip(summaryKv, label, value);
+    }
     form.elements.name.value = pipeline.name;
     form.elements.slug.value = pipeline.slug;
     form.elements.cron.value = pipeline.cron;

--- a/scripts/ui-guided-flow-smoke.test.mjs
+++ b/scripts/ui-guided-flow-smoke.test.mjs
@@ -773,7 +773,7 @@ test('settings admin defaults to basic overview with advanced details collapsed'
     'Advanced source scoring and internal ID',
     'Search query management',
     'Advanced model/provider routing',
-    'Prompt internals and output schema',
+    'Advanced prompt body and output schema',
     'Advanced publishing paths and storage labels',
     'Advanced schedule workflow and publish controls',
     'Sanitized feed metadata',
@@ -812,7 +812,71 @@ test('settings admin defaults to basic overview with advanced details collapsed'
 
   assertContains(stylesCss, '.settings-overview', 'basic settings overview style');
   assertContains(stylesCss, '.settings-advanced', 'advanced settings disclosure style');
+  assertContains(stylesCss, '.settings-summary-kv', 'compact settings summary style');
   assertContains(stylesCss, '.settings-section[hidden]', 'inactive settings panels hidden style');
+});
+
+test('ai role prompt and schedule admin surfaces render summaries before advanced internals', () => {
+  for (const expected of [
+    'function modelRoleSummary(profile',
+    'function promptTemplateSummary(template)',
+    'function failedRunForPipeline(pipeline)',
+    'function scheduleFailureSummary(job)',
+    'settings-summary-kv',
+    'advanced edit closed',
+    'Body length',
+    'Last failure',
+    'Run Now',
+  ]) {
+    assertContains(uiJs, expected, `compact AI/admin marker ${expected}`);
+  }
+
+  assertOrdered(
+    uiJs,
+    [
+      /function renderSettingsModels\(\)/,
+      /<div class="settings-kv settings-summary-kv"><\/div>/,
+      /<details class="settings-advanced">/,
+      /<summary>Advanced model\/provider routing<\/summary>/,
+      /<label class="field"><span>Provider<\/span><input name="provider" type="text" required><\/label>/,
+      /<label class="field"><span>Model<\/span><input name="model" type="text" required><\/label>/,
+      /<div class="actions"><button type="submit">Save Model Role<\/button><\/div>/,
+    ],
+    'AI role settings should show compact role summaries before collapsed provider/model edit fields',
+  );
+
+  assertOrdered(
+    uiJs,
+    [
+      /function renderSettingsPrompts\(\)/,
+      /<div class="settings-kv settings-summary-kv"><\/div>/,
+      /<details class="settings-advanced">/,
+      /<summary>Advanced prompt body and output schema<\/summary>/,
+      /<label class="field"><span>Agent instructions<\/span><textarea rows="8" readonly><\/textarea><\/label>/,
+      /<details class="debug-details"><summary>Output schema summary<\/summary><pre><\/pre><\/details>/,
+    ],
+    'Prompt templates should summarize metadata before collapsed body and schema debug data',
+  );
+
+  assertOrdered(
+    uiJs,
+    [
+      /function renderSettingsSchedules\(\)/,
+      /<button class="secondary" name="run" type="button">Run Now<\/button>/,
+      /<div class="settings-kv settings-summary-kv"><\/div>/,
+      /<details class="settings-advanced">/,
+      /<summary>Advanced schedule workflow and publish controls<\/summary>/,
+      /<label class="field"><span>Cron<\/span><input name="cron" type="text" required><\/label>/,
+      /<label class="field"><span>Workflow<\/span><input name="workflow" type="text" required><\/label>/,
+      /<label class="toggle admin-toggle"><input name="autopublish" type="checkbox"><span>Autopublish<\/span><\/label>/,
+      /<div class="actions inline"><button type="submit">Save Schedule<\/button><\/div>/,
+    ],
+    'Scheduled pipelines should show run/status summaries before collapsed cron workflow and autopublish controls',
+  );
+
+  assert.doesNotMatch(uiJs, /<details[^>]*class="[^"]*settings-advanced[^"]*"[^>]*\sopen\b/, 'AI/admin advanced internals should not render expanded by default');
+  assertContains(stylesCss, 'max-width: 72ch', 'long help text should have a readable max width');
+  assertContains(stylesCss, 'line-height: 1.5', 'readability line-height adjustments');
 });
 
 test('story source search queries use compact single-editor management', () => {


### PR DESCRIPTION
Closes #125

## Summary
- Compacts AI model role cards into summary chips with provider/model/budget/reasoning/fallback internals collapsed behind Advanced model/provider routing.
- Compacts prompt template cards into summary metadata while keeping long prompt bodies and output schema JSON collapsed by default.
- Compacts scheduled pipeline cards around enabled state, next run, last failure, publishing mode, and Run Now, with cron/workflow/autopublish controls in Advanced schedule workflow and publish controls.
- Improves Settings/Admin readability with stronger base text color, roomier line-height, max-width for prose/help text, and slightly less cramped card padding.

## Verification
- `npm run check`
- `git diff --check`

## Notes
- No backend model, prompt, scheduler, publishing, approval, or source APIs changed.
- Tests remain network-free and assert that AI role/prompt/schedule internals are collapsed by default while advanced controls remain reachable.
